### PR TITLE
feat: add remote project creation from client

### DIFF
--- a/crates/okena-core/src/api.rs
+++ b/crates/okena-core/src/api.rs
@@ -178,6 +178,10 @@ pub enum ActionRequest {
         #[serde(default)]
         mode: DiffMode,
     },
+    AddProject {
+        name: String,
+        path: String,
+    },
 }
 
 /// POST /v1/pair request
@@ -384,6 +388,10 @@ mod tests {
                 project_id: "p1".into(),
                 file_path: "src/main.rs".into(),
                 mode: DiffMode::Staged,
+            },
+            ActionRequest::AddProject {
+                name: "My Project".into(),
+                path: "/home/user/projects/my-project".into(),
             },
         ];
         for action in actions {

--- a/src/action_dispatch.rs
+++ b/src/action_dispatch.rs
@@ -341,5 +341,6 @@ fn strip_remote_ids(action: ActionRequest, connection_id: &str) -> ActionRequest
             file_path,
             mode,
         },
+        ActionRequest::AddProject { name, path } => ActionRequest::AddProject { name, path },
     }
 }

--- a/src/views/overlay_manager.rs
+++ b/src/views/overlay_manager.rs
@@ -396,12 +396,16 @@ impl OverlayManager {
     // ========================================================================
 
     /// Toggle add project dialog overlay.
-    pub fn toggle_add_project_dialog(&mut self, cx: &mut Context<Self>) {
+    pub fn toggle_add_project_dialog(
+        &mut self,
+        remote_manager: Option<Entity<RemoteConnectionManager>>,
+        cx: &mut Context<Self>,
+    ) {
         if self.is_modal::<AddProjectDialog>() {
             self.close_modal(cx);
         } else {
             let workspace = self.workspace.clone();
-            let entity = cx.new(|cx| AddProjectDialog::new(workspace, cx));
+            let entity = cx.new(|cx| AddProjectDialog::new(workspace, remote_manager, cx));
             cx.subscribe(&entity, |this, _, event: &AddProjectDialogEvent, cx| {
                 if event.is_close() {
                     this.close_modal(cx);

--- a/src/views/root/handlers.rs
+++ b/src/views/root/handlers.rs
@@ -314,8 +314,9 @@ impl RootView {
                     });
                 }
                 OverlayRequest::AddProjectDialog => {
+                    let rm = self.remote_manager.clone();
                     self.overlay_manager.update(cx, |om, cx| {
-                        om.toggle_add_project_dialog(cx);
+                        om.toggle_add_project_dialog(rm, cx);
                     });
                 }
                 OverlayRequest::DiffViewer { path, file } => {

--- a/src/views/root/render.rs
+++ b/src/views/root/render.rs
@@ -436,8 +436,9 @@ impl Render for RootView {
             // Handle new project action
             .on_action(cx.listener({
                 let overlay_manager = overlay_manager.clone();
-                move |_this, _: &NewProject, _window, cx| {
-                    overlay_manager.update(cx, |om, cx| om.toggle_add_project_dialog(cx));
+                move |this, _: &NewProject, _window, cx| {
+                    let rm = this.remote_manager.clone();
+                    overlay_manager.update(cx, |om, cx| om.toggle_add_project_dialog(rm, cx));
                 }
             }))
             // Handle open settings file action

--- a/src/workspace/actions/execute.rs
+++ b/src/workspace/actions/execute.rs
@@ -304,6 +304,10 @@ pub fn execute_action(
                 None => ActionResult::Err(format!("project not found: {}", project_id)),
             }
         }
+        ActionRequest::AddProject { name, path } => {
+            ws.add_project(name, path, true, cx);
+            ActionResult::Ok(None)
+        }
         ActionRequest::ReadContent { terminal_id } => {
             match ensure_terminal(&terminal_id, terminals, backend, ws) {
                 Some(term) => {


### PR DESCRIPTION
## Summary
- Allow adding projects on remote servers via the Add Project dialog
- When remote connections exist, a target selector (Local / remote name) appears
- For remote targets, the path is typed manually (no browse/autocomplete) and dispatched as an AddProject action to the server

## Changed files
- `crates/okena-core/src/api.rs` — new AddProject API type
- `src/views/overlays/add_project_dialog.rs` — target selector UI and remote dispatch
- `src/workspace/actions/execute.rs` — handle AddProject action on server side

🤖 Generated with [Claude Code](https://claude.com/claude-code)