### PR TITLE
feat: sync project order and colors between remote client and server

### DIFF
--- a/src/action_dispatch.rs
+++ b/src/action_dispatch.rs
@@ -352,5 +352,26 @@ fn strip_remote_ids(action: ActionRequest, connection_id: &str) -> ActionRequest
             mode,
         },
         ActionRequest::AddProject { name, path } => ActionRequest::AddProject { name, path },
+        ActionRequest::ReorderProjectInFolder {
+            folder_id,
+            project_id,
+            new_index,
+        } => ActionRequest::ReorderProjectInFolder {
+            folder_id: s(&folder_id),
+            project_id: s(&project_id),
+            new_index,
+        },
+        ActionRequest::SetProjectColor { project_id, color } => {
+            ActionRequest::SetProjectColor {
+                project_id: s(&project_id),
+                color,
+            }
+        }
+        ActionRequest::SetFolderColor { folder_id, color } => {
+            ActionRequest::SetFolderColor {
+                folder_id: s(&folder_id),
+                color,
+            }
+        }
     }
 }

--- a/src/app/remote_commands.rs
+++ b/src/app/remote_commands.rs
@@ -1,8 +1,9 @@
 use crate::remote::bridge::{BridgeMessage, BridgeReceiver, CommandResult, RemoteCommand};
-use crate::remote::types::{ApiFullscreen, ApiProject, StateResponse};
+use crate::remote::types::{ApiFolder, ApiFullscreen, ApiProject, StateResponse};
 use crate::terminal::backend::TerminalBackend;
 use crate::workspace::actions::execute::{ensure_terminal, execute_action};
 use gpui::*;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use super::Okena;
@@ -42,7 +43,17 @@ impl Okena {
                             let ws = workspace.read(cx);
                             let sv = *state_version.borrow();
                             let git_statuses = git_status_tx.borrow().clone();
-                            let projects: Vec<ApiProject> = ws.data().projects.iter().map(|p| {
+                            let data = ws.data();
+
+                            // Build a lookup map for projects
+                            let project_map: std::collections::HashMap<&str, &crate::workspace::state::ProjectData> =
+                                data.projects.iter().map(|p| (p.id.as_str(), p)).collect();
+
+                            // Build ordered projects following project_order + folder expansion
+                            let mut projects: Vec<ApiProject> = Vec::new();
+                            let mut seen: HashSet<String> = HashSet::new();
+
+                            let build_api_project = |p: &crate::workspace::state::ProjectData| -> ApiProject {
                                 let git_status = git_statuses.get(&p.id).cloned();
                                 ApiProject {
                                     id: p.id.clone(),
@@ -52,6 +63,40 @@ impl Okena {
                                     layout: p.layout.as_ref().map(|l| l.to_api()),
                                     terminal_names: p.terminal_names.clone(),
                                     git_status,
+                                    folder_color: p.folder_color,
+                                }
+                            };
+
+                            for id in &data.project_order {
+                                if let Some(folder) = data.folders.iter().find(|f| &f.id == id) {
+                                    for pid in &folder.project_ids {
+                                        if seen.insert(pid.clone()) {
+                                            if let Some(p) = project_map.get(pid.as_str()) {
+                                                projects.push(build_api_project(p));
+                                            }
+                                        }
+                                    }
+                                } else if seen.insert(id.clone()) {
+                                    if let Some(p) = project_map.get(id.as_str()) {
+                                        projects.push(build_api_project(p));
+                                    }
+                                }
+                            }
+
+                            // Append orphan projects not in any order
+                            for p in &data.projects {
+                                if seen.insert(p.id.clone()) {
+                                    projects.push(build_api_project(p));
+                                }
+                            }
+
+                            // Build folders for response
+                            let folders: Vec<ApiFolder> = data.folders.iter().map(|f| {
+                                ApiFolder {
+                                    id: f.id.clone(),
+                                    name: f.name.clone(),
+                                    project_ids: f.project_ids.clone(),
+                                    folder_color: f.folder_color,
                                 }
                             }).collect();
 
@@ -67,6 +112,8 @@ impl Okena {
                                 projects,
                                 focused_project_id: ws.focused_project_id().cloned(),
                                 fullscreen_terminal: fullscreen,
+                                project_order: data.project_order.clone(),
+                                folders,
                             };
 
                             CommandResult::Ok(Some(serde_json::to_value(resp).expect("BUG: StateResponse must serialize")))

--- a/src/remote/types.rs
+++ b/src/remote/types.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 pub use okena_core::api::{
-    ActionRequest, ApiFullscreen, ApiGitStatus, ApiLayoutNode, ApiProject, ErrorResponse,
+    ActionRequest, ApiFolder, ApiFullscreen, ApiGitStatus, ApiLayoutNode, ApiProject, ErrorResponse,
     HealthResponse, PairRequest, PairResponse, StateResponse,
 };
 #[allow(unused_imports)]

--- a/src/workspace/actions/execute.rs
+++ b/src/workspace/actions/execute.rs
@@ -308,6 +308,22 @@ pub fn execute_action(
             ws.add_project(name, path, true, cx);
             ActionResult::Ok(None)
         }
+        ActionRequest::ReorderProjectInFolder {
+            folder_id,
+            project_id,
+            new_index,
+        } => {
+            ws.reorder_project_in_folder(&folder_id, &project_id, new_index, cx);
+            ActionResult::Ok(None)
+        }
+        ActionRequest::SetProjectColor { project_id, color } => {
+            ws.set_folder_color(&project_id, color, cx);
+            ActionResult::Ok(None)
+        }
+        ActionRequest::SetFolderColor { folder_id, color } => {
+            ws.set_folder_item_color(&folder_id, color, cx);
+            ActionResult::Ok(None)
+        }
         ActionRequest::ReadContent { terminal_id } => {
             match ensure_terminal(&terminal_id, terminals, backend, ws) {
                 Some(term) => {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -13,6 +13,8 @@ export interface StateResponse {
   projects: ApiProject[];
   focused_project_id: string | null;
   fullscreen_terminal: ApiFullscreen | null;
+  project_order?: string[];
+  folders?: ApiFolder[];
 }
 
 export interface ApiProject {
@@ -23,6 +25,14 @@ export interface ApiProject {
   layout: ApiLayoutNode | null;
   terminal_names: Record<string, string>;
   git_status?: ApiGitStatus | null;
+  folder_color?: string;
+}
+
+export interface ApiFolder {
+  id: string;
+  name: string;
+  project_ids: string[];
+  folder_color?: string;
 }
 
 export interface ApiGitStatus {
@@ -63,7 +73,10 @@ export type ActionRequest =
   | { action: "git_diff_summary"; project_id: string }
   | { action: "git_diff"; project_id: string; mode?: DiffMode; ignore_whitespace?: boolean }
   | { action: "git_branches"; project_id: string }
-  | { action: "git_file_contents"; project_id: string; file_path: string; mode?: DiffMode };
+  | { action: "git_file_contents"; project_id: string; file_path: string; mode?: DiffMode }
+  | { action: "reorder_project_in_folder"; folder_id: string; project_id: string; new_index: number }
+  | { action: "set_project_color"; project_id: string; color: string }
+  | { action: "set_folder_color"; folder_id: string; color: string };
 
 export interface PairRequest {
   code: string;


### PR DESCRIPTION
## Summary
- Server now sends project_order, folders, and folder_color in the API response so remote clients display projects in the correct order with correct colors
- Adds ActionRequest variants (ReorderProjectInFolder, SetProjectColor, SetFolderColor) so client changes propagate back to the server instead of reverting on next sync

## Changed files
- `crates/okena-core/src/api.rs` — new API types for order/color sync
- `src/app/headless.rs` — server-side handling of new actions
- `src/app/remote_commands.rs` — include order/color data in API response
- `src/views/panels/sidebar/` — dispatch color/reorder actions to remote
- `src/views/root/mod.rs` — apply remote order/colors on sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)