### PR TITLE
fix: memory leaks in remote client mode on reconnect

### DIFF
--- a/src/remote/routes/stream.rs
+++ b/src/remote/routes/stream.rs
@@ -130,6 +130,9 @@ async fn handle_ws(mut socket: WebSocket, state: AppState, query_token: Option<S
                             Ok(WsInbound::Unsubscribe { terminal_ids }) => {
                                 for id in &terminal_ids {
                                     subscribed_ids.remove(id);
+                                    if let Some(sid) = stream_id_map.remove(id) {
+                                        reverse_stream_map.remove(&sid);
+                                    }
                                 }
                             }
                             Ok(WsInbound::SendText { terminal_id, text }) => {


### PR DESCRIPTION
Make create_terminal idempotent — skip creating a new Terminal/TerminalHolder when one already exists for the same prefixed_id. On reconnect the server re-sends CreateTerminal for every live terminal, which was duplicating objects while GPUI views held Arc references to the old ones (~19-48 MB per terminal).

Also clean up server-side stream maps (stream_id_map, reverse_stream_map) on Unsubscribe to prevent unbounded growth, and prune empty IP entries from the rate limiter's per_ip HashMap.