### PR TITLE
fix: persist sidebar settings and show worktree terminals on focus

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -118,6 +118,25 @@ impl SettingsState {
 
     setting_setter!(set_claude_code_integration, claude_code_integration, bool);
 
+    /// Set sidebar open state
+    pub fn set_sidebar_open(&mut self, value: bool, cx: &mut Context<Self>) {
+        self.settings.sidebar.is_open = value;
+        self.save_and_notify(cx);
+    }
+
+    /// Set sidebar auto-hide mode
+    pub fn set_sidebar_auto_hide(&mut self, value: bool, cx: &mut Context<Self>) {
+        self.settings.sidebar.auto_hide = value;
+        self.save_and_notify(cx);
+    }
+
+    /// Set sidebar width (clamped to min/max bounds)
+    pub fn set_sidebar_width(&mut self, value: f32, cx: &mut Context<Self>) {
+        use crate::workspace::persistence::{MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH};
+        self.settings.sidebar.width = value.clamp(MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH);
+        self.save_and_notify(cx);
+    }
+
     /// Set the theme mode
     pub fn set_theme_mode(&mut self, value: ThemeMode, cx: &mut Context<Self>) {
         self.settings.theme_mode = value;

--- a/src/views/root/mod.rs
+++ b/src/views/root/mod.rs
@@ -18,7 +18,7 @@ use crate::views::layout::split_pane::{new_active_drag, ActiveDrag};
 use crate::views::panels::status_bar::StatusBar;
 use crate::views::panels::toast::ToastOverlay;
 use crate::views::chrome::title_bar::TitleBar;
-use crate::workspace::persistence::{load_settings, AppSettings};
+use crate::settings::settings;
 use crate::workspace::request_broker::RequestBroker;
 use crate::workspace::state::Workspace;
 use gpui::*;
@@ -40,8 +40,6 @@ pub struct RootView {
     sidebar: Entity<Sidebar>,
     /// Sidebar state controller
     sidebar_ctrl: SidebarController,
-    /// App settings for persistence
-    app_settings: AppSettings,
     /// Stored project column entities (created once, not during render)
     project_columns: HashMap<String, Entity<ProjectColumn>>,
     /// Title bar entity
@@ -84,8 +82,8 @@ impl RootView {
     ) -> Self {
         let terminals: TerminalsRegistry = Arc::new(Mutex::new(HashMap::new()));
 
-        // Load app settings and create sidebar controller
-        let app_settings = load_settings();
+        // Create sidebar controller from current global settings
+        let app_settings = settings(cx);
         let sidebar_ctrl = SidebarController::new(&app_settings);
 
         // Create sidebar entity once to preserve state
@@ -141,7 +139,6 @@ impl RootView {
             terminals,
             sidebar,
             sidebar_ctrl,
-            app_settings,
             project_columns: HashMap::new(),
             title_bar,
             status_bar,

--- a/src/views/root/render.rs
+++ b/src/views/root/render.rs
@@ -322,7 +322,10 @@ impl Render for RootView {
                             DragState::Sidebar => {
                                 // Handle sidebar resize
                                 let new_width = f32::from(event.position.x);
-                                this.sidebar_ctrl.set_width(new_width, &mut this.app_settings);
+                                this.sidebar_ctrl.set_width(new_width);
+                                // Persist through global SettingsState (debounced)
+                                let width = this.sidebar_ctrl.width();
+                                settings_entity(cx).update(cx, |s, cx| s.set_sidebar_width(width, cx));
                                 cx.notify();
                             }
                             DragState::ServicePanel { project_id, initial_mouse_y, initial_height } => {

--- a/src/views/root/sidebar.rs
+++ b/src/views/root/sidebar.rs
@@ -1,3 +1,4 @@
+use crate::settings::settings_entity;
 use crate::views::sidebar_controller::{AnimationTarget, SidebarController, FRAME_TIME_MS};
 use gpui::*;
 
@@ -6,7 +7,10 @@ use super::RootView;
 impl RootView {
     /// Toggle sidebar visibility with animation
     pub(super) fn toggle_sidebar(&mut self, cx: &mut Context<Self>) {
-        let target = self.sidebar_ctrl.toggle(&mut self.app_settings);
+        let target = self.sidebar_ctrl.toggle();
+        // Persist through global SettingsState (avoids stale settings overwrite)
+        let open = self.sidebar_ctrl.is_open();
+        settings_entity(cx).update(cx, |s, cx| s.set_sidebar_open(open, cx));
         self.sync_status_bar_sidebar_state(cx);
         self.animate_sidebar_to(target, cx);
     }
@@ -24,7 +28,14 @@ impl RootView {
 
     /// Toggle auto-hide mode
     pub(super) fn toggle_sidebar_auto_hide(&mut self, cx: &mut Context<Self>) {
-        let target = self.sidebar_ctrl.toggle_auto_hide(&mut self.app_settings);
+        let target = self.sidebar_ctrl.toggle_auto_hide();
+        // Persist through global SettingsState
+        let open = self.sidebar_ctrl.is_open();
+        let auto_hide = self.sidebar_ctrl.is_auto_hide();
+        settings_entity(cx).update(cx, |s, cx| {
+            s.set_sidebar_auto_hide(auto_hide, cx);
+            s.set_sidebar_open(open, cx);
+        });
         self.animate_sidebar_to(target, cx);
         cx.notify();
     }

--- a/src/views/sidebar_controller.rs
+++ b/src/views/sidebar_controller.rs
@@ -3,7 +3,7 @@
 //! Manages sidebar visibility, auto-hide behavior, and animation state.
 //! The actual animation spawning is handled by the parent view.
 
-use crate::workspace::persistence::{save_settings, AppSettings, MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH};
+use crate::workspace::persistence::{AppSettings, MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH};
 
 /// Animation duration in milliseconds.
 pub const ANIMATION_DURATION_MS: u64 = 150;
@@ -78,10 +78,10 @@ impl SidebarController {
     }
 
     /// Set the sidebar width (clamped to min/max bounds).
-    pub fn set_width(&mut self, width: f32, settings: &mut AppSettings) {
+    ///
+    /// Note: Caller is responsible for persisting via SettingsState.
+    pub fn set_width(&mut self, width: f32) {
         self.width = width.clamp(MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH);
-        settings.sidebar.width = self.width;
-        let _ = save_settings(settings);
     }
 
     /// Check if sidebar is logically open.
@@ -121,14 +121,10 @@ impl SidebarController {
 
     /// Toggle sidebar visibility.
     ///
-    /// Returns the animation target and updates settings.
-    pub fn toggle(&mut self, settings: &mut AppSettings) -> AnimationTarget {
+    /// Returns the animation target. Caller is responsible for persisting via SettingsState.
+    pub fn toggle(&mut self) -> AnimationTarget {
         self.open = !self.open;
         self.hover_shown = false;
-
-        // Persist state
-        settings.sidebar.is_open = self.open;
-        let _ = save_settings(settings);
 
         if self.open {
             AnimationTarget::Open
@@ -140,8 +136,8 @@ impl SidebarController {
     /// Toggle auto-hide mode.
     ///
     /// If auto-hide is enabled and sidebar is open, it will close.
-    /// Returns the animation target and updates settings.
-    pub fn toggle_auto_hide(&mut self, settings: &mut AppSettings) -> AnimationTarget {
+    /// Returns the animation target. Caller is responsible for persisting via SettingsState.
+    pub fn toggle_auto_hide(&mut self) -> AnimationTarget {
         self.auto_hide = !self.auto_hide;
 
         let target = if self.auto_hide && self.open {
@@ -151,11 +147,6 @@ impl SidebarController {
         } else {
             AnimationTarget::None
         };
-
-        // Persist state
-        settings.sidebar.auto_hide = self.auto_hide;
-        settings.sidebar.is_open = self.open;
-        let _ = save_settings(settings);
 
         target
     }
@@ -209,16 +200,16 @@ mod tests {
 
     #[test]
     fn test_toggle() {
-        let mut settings = test_settings();
+        let settings = test_settings();
         let mut ctrl = SidebarController::new(&settings);
 
         assert!(!ctrl.is_open());
 
-        let target = ctrl.toggle(&mut settings);
+        let target = ctrl.toggle();
         assert!(ctrl.is_open());
         assert_eq!(target, AnimationTarget::Open);
 
-        let target = ctrl.toggle(&mut settings);
+        let target = ctrl.toggle();
         assert!(!ctrl.is_open());
         assert_eq!(target, AnimationTarget::Close);
     }
@@ -231,7 +222,7 @@ mod tests {
         ctrl.animation = 1.0;
 
         // Enable auto-hide while open should close
-        let target = ctrl.toggle_auto_hide(&mut settings);
+        let target = ctrl.toggle_auto_hide();
         assert!(ctrl.is_auto_hide());
         assert!(!ctrl.is_open());
         assert_eq!(target, AnimationTarget::Close);
@@ -254,16 +245,16 @@ mod tests {
 
     #[test]
     fn test_width_clamping() {
-        let mut settings = test_settings();
+        let settings = test_settings();
         let mut ctrl = SidebarController::new(&settings);
 
-        ctrl.set_width(10.0, &mut settings); // below MIN
+        ctrl.set_width(10.0); // below MIN
         assert_eq!(ctrl.width(), MIN_SIDEBAR_WIDTH);
 
-        ctrl.set_width(9999.0, &mut settings); // above MAX
+        ctrl.set_width(9999.0); // above MAX
         assert_eq!(ctrl.width(), MAX_SIDEBAR_WIDTH);
 
-        ctrl.set_width(300.0, &mut settings); // within range
+        ctrl.set_width(300.0); // within range
         assert_eq!(ctrl.width(), 300.0);
     }
 

--- a/src/workspace/state.rs
+++ b/src/workspace/state.rs
@@ -527,17 +527,26 @@ impl Workspace {
     pub fn visible_projects(&self) -> Vec<&ProjectData> {
         let focused = self.focused_project_id();
         let folder_filter = self.active_folder_filter.as_ref();
+
+        // When a project is focused, also show its worktree children
+        let is_focused = |p: &ProjectData, fid: &String| -> bool {
+            &p.id == fid
+                || p.worktree_info
+                    .as_ref()
+                    .map_or(false, |wi| &wi.parent_project_id == fid)
+        };
+
         let mut result = Vec::new();
         for id in &self.data.project_order {
             if let Some(folder) = self.data.folders.iter().find(|f| f.id == *id) {
                 // When folder filter is active, skip folders that don't match
                 if let Some(filter_id) = folder_filter {
                     if &folder.id != filter_id {
-                        // Still allow the focused project through even if in wrong folder
+                        // Still allow the focused project (and its worktrees) through even if in wrong folder
                         if let Some(fid) = focused {
                             for pid in &folder.project_ids {
-                                if pid == fid {
-                                    if let Some(p) = self.data.projects.iter().find(|p| &p.id == pid) {
+                                if let Some(p) = self.data.projects.iter().find(|p| &p.id == pid) {
+                                    if is_focused(p, fid) {
                                         result.push(p);
                                     }
                                 }
@@ -549,7 +558,7 @@ impl Workspace {
                 // Folder: include its projects
                 for pid in &folder.project_ids {
                     if let Some(p) = self.data.projects.iter().find(|p| p.id == *pid) {
-                        if focused.map_or(p.is_visible, |fid| &p.id == fid) {
+                        if focused.map_or(p.is_visible, |fid| is_focused(p, fid)) {
                             result.push(p);
                         }
                     }
@@ -557,13 +566,13 @@ impl Workspace {
             } else if let Some(p) = self.data.projects.iter().find(|p| p.id == *id) {
                 // Top-level project: hide when folder filter is active
                 if folder_filter.is_some() {
-                    // Still allow the focused project through
-                    if focused.map_or(false, |fid| &p.id == fid) {
+                    // Still allow the focused project (and its worktrees) through
+                    if focused.map_or(false, |fid| is_focused(p, fid)) {
                         result.push(p);
                     }
                     continue;
                 }
-                if focused.map_or(p.is_visible, |fid| &p.id == fid) {
+                if focused.map_or(p.is_visible, |fid| is_focused(p, fid)) {
                     result.push(p);
                 }
             }


### PR DESCRIPTION
## Summary
- **Worktree visibility fix**: Focusing a project now also shows its worktree children — `visible_projects()` was only matching by exact project ID, excluding worktrees whose `parent_project_id` pointed to the focused project.
- **Sidebar settings persistence**: Sidebar open/auto-hide/width state is now persisted through the global `SettingsState` entity (debounced auto-save) instead of direct `save_settings()` calls from `SidebarController`, preventing stale settings overwrites.

## Test plan
- [ ] Focus a project that has worktrees — verify worktree columns appear alongside the parent
- [ ] Unfocus — verify all visible projects return to normal
- [ ] Toggle sidebar open/closed, resize sidebar, toggle auto-hide — verify settings persist across restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)