### PR TITLE
feat(terminal): AI agent session detection and auto-recovery

### DIFF
--- a/assets/icons/agent.svg
+++ b/assets/icons/agent.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="3"/><line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/><path d="M9 20h6"/></svg>

--- a/src/terminal/agents.rs
+++ b/src/terminal/agents.rs
@@ -1,0 +1,123 @@
+//! AI agent process detection and session ID resolution.
+//!
+//! Detects AI coding agents (Claude Code, Copilot CLI) running inside terminal
+//! processes and reads their session IDs from agent-specific storage locations:
+//! - Claude: `~/.claude/sessions/<pid>.json`
+//! - Copilot: `~/.copilot/session-state/<uuid>/inuse.<pid>.lock`
+
+use crate::workspace::state::AgentType;
+
+/// Detected agent info including the agent's PID (for session file lookup).
+pub struct DetectedAgent {
+    pub agent_type: AgentType,
+    pub pid: u32,
+}
+
+/// Detect AI coding agent among all descendant processes of the given PID.
+/// Returns the AgentType and PID if a known agent is found.
+#[cfg(unix)]
+pub fn detect_agent_process(shell_pid: u32) -> Option<DetectedAgent> {
+    let descendants = collect_descendant_pids(shell_pid);
+
+    descendants.iter()
+        .filter_map(|&pid| {
+            let cmdline = std::fs::read(format!("/proc/{}/cmdline", pid)).ok()?;
+            let exe = cmdline.split(|&b| b == 0).next()?;
+            let basename = String::from_utf8_lossy(exe);
+            let basename = basename.rsplit('/').next()?;
+            match basename {
+                "claude" => Some(DetectedAgent { agent_type: AgentType::Claude, pid }),
+                "copilot" => Some(DetectedAgent { agent_type: AgentType::Copilot, pid }),
+                _ => None,
+            }
+        })
+        .next()
+}
+
+#[cfg(not(unix))]
+pub fn detect_agent_process(_shell_pid: u32) -> Option<DetectedAgent> {
+    None
+}
+
+/// Read the agent session ID using the appropriate method for the agent type.
+#[cfg(unix)]
+pub fn read_agent_session_id(agent: &DetectedAgent) -> Option<String> {
+    match agent.agent_type {
+        AgentType::Claude => read_claude_session_id(agent.pid),
+        AgentType::Copilot => read_copilot_session_id(agent.pid),
+    }
+}
+
+#[cfg(not(unix))]
+pub fn read_agent_session_id(_agent: &DetectedAgent) -> Option<String> {
+    None
+}
+
+/// Read a Claude Code session ID from `~/.claude/sessions/<pid>.json`.
+#[cfg(unix)]
+fn read_claude_session_id(pid: u32) -> Option<String> {
+    let path = dirs::home_dir()?.join(format!(".claude/sessions/{}.json", pid));
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str::<serde_json::Value>(&content)
+        .ok()?
+        .get("sessionId")?
+        .as_str()
+        .map(str::to_string)
+}
+
+/// Read a Copilot CLI session ID from `~/.copilot/session-state/`.
+/// Copilot creates `inuse.<child_pid>.lock` files inside session directories.
+/// We search for lock files matching the copilot PID or any of its children.
+#[cfg(unix)]
+fn read_copilot_session_id(pid: u32) -> Option<String> {
+    let session_dir = dirs::home_dir()?.join(".copilot/session-state");
+    if !session_dir.is_dir() {
+        return None;
+    }
+
+    // Collect the copilot PID + its direct children (copilot spawns a backend process)
+    let mut pids_to_match: Vec<u32> = vec![pid];
+    if let Ok(output) = std::process::Command::new("pgrep")
+        .args(["-P", &pid.to_string()])
+        .output()
+    {
+        pids_to_match.extend(
+            String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .filter_map(|l| l.trim().parse::<u32>().ok()),
+        );
+    }
+
+    // Search session directories for inuse.<pid>.lock files
+    std::fs::read_dir(&session_dir).ok()?.find_map(|entry| {
+        let entry = entry.ok()?;
+        let session_id = entry.file_name().to_str()?.to_string();
+        let has_lock = pids_to_match.iter().any(|p| {
+            entry.path().join(format!("inuse.{}.lock", p)).exists()
+        });
+        has_lock.then_some(session_id)
+    })
+}
+
+/// Recursively collect all descendant PIDs of a given process.
+#[cfg(unix)]
+fn collect_descendant_pids(root_pid: u32) -> Vec<u32> {
+    let mut all = Vec::new();
+    let mut queue = vec![root_pid];
+
+    while let Some(pid) = queue.pop() {
+        let output = std::process::Command::new("pgrep")
+            .args(["-P", &pid.to_string()])
+            .output();
+
+        if let Ok(output) = output {
+            let children: Vec<u32> = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .filter_map(|line| line.trim().parse::<u32>().ok())
+                .collect();
+            all.extend(&children);
+            queue.extend(children);
+        }
+    }
+    all
+}

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1,3 +1,4 @@
+pub mod agents;
 pub mod backend;
 pub mod input;
 pub mod pty_manager;

--- a/src/views/chrome/header_buttons.rs
+++ b/src/views/chrome/header_buttons.rs
@@ -14,6 +14,7 @@ pub enum HeaderAction {
     SplitVertical,
     SplitHorizontal,
     AddTab,
+    AgentInfo,
     Minimize,
     ExportBuffer,
     Fullscreen,
@@ -31,6 +32,7 @@ impl HeaderAction {
             HeaderAction::SplitVertical => "icons/split-vertical.svg",
             HeaderAction::SplitHorizontal => "icons/split-horizontal.svg",
             HeaderAction::AddTab => "icons/tabs.svg",
+            HeaderAction::AgentInfo => "icons/agent.svg",
             HeaderAction::Minimize => "icons/minimize.svg",
             HeaderAction::ExportBuffer => "icons/copy.svg",
             HeaderAction::Fullscreen => "icons/fullscreen.svg",
@@ -48,6 +50,7 @@ impl HeaderAction {
             HeaderAction::SplitVertical => "Split Vertical",
             HeaderAction::SplitHorizontal => "Split Horizontal",
             HeaderAction::AddTab => "Add Tab",
+            HeaderAction::AgentInfo => "Agent Session Info",
             HeaderAction::Minimize => "Minimize",
             HeaderAction::ExportBuffer => "Export Buffer to File",
             HeaderAction::Fullscreen => "Fullscreen",
@@ -68,7 +71,7 @@ impl HeaderAction {
             HeaderAction::Minimize => Some(Box::new(keybindings::MinimizeTerminal)),
             HeaderAction::Fullscreen => Some(Box::new(keybindings::ToggleFullscreen)),
             HeaderAction::Close => Some(Box::new(keybindings::CloseTerminal)),
-            HeaderAction::ExportBuffer | HeaderAction::Detach
+            HeaderAction::AgentInfo | HeaderAction::ExportBuffer | HeaderAction::Detach
             | HeaderAction::ZoomPrev | HeaderAction::ZoomNext | HeaderAction::ExitZoom => None,
         }
     }
@@ -84,6 +87,7 @@ impl HeaderAction {
             HeaderAction::SplitVertical => "split-vertical-btn",
             HeaderAction::SplitHorizontal => "split-horizontal-btn",
             HeaderAction::AddTab => "add-tab-btn",
+            HeaderAction::AgentInfo => "agent-info-btn",
             HeaderAction::Minimize => "minimize-btn",
             HeaderAction::ExportBuffer => "export-buffer-btn",
             HeaderAction::Fullscreen => "fullscreen-btn",

--- a/src/views/layout/tabs/mod.rs
+++ b/src/views/layout/tabs/mod.rs
@@ -18,6 +18,7 @@ use crate::views::layout::pane_drag::{PaneDrag, PaneDragView};
 use crate::workspace::state::{LayoutNode, SplitDirection};
 use gpui::*;
 use gpui_component::{h_flex, v_flex};
+use gpui_component::tooltip::Tooltip;
 use gpui::prelude::*;
 use std::collections::HashSet;
 
@@ -98,10 +99,17 @@ impl LayoutContainer {
         let terminal_id_for_close = terminal_id.clone();
         let terminal_id_for_fullscreen = terminal_id.clone();
 
+        // Check if active terminal has an agent session
+        let has_agent = terminal_id.as_ref().map_or(false, |tid| {
+            ctx.workspace.read(cx).project(&ctx.project_id)
+                .map_or(false, |p| p.agent_sessions.contains_key(tid))
+        });
+
         // Clone context for each action - much cleaner than individual clones
         let ctx_split_v = ctx.clone();
         let ctx_split_h = ctx.clone();
         let ctx_add_tab = ctx.clone();
+        let ctx_agent = ctx.clone();
         let ctx_minimize = ctx.clone();
         let ctx_fullscreen = ctx.clone();
         let ctx_detach = ctx.clone();
@@ -169,6 +177,27 @@ impl LayoutContainer {
                         }
                     }),
             )
+            // Agent Info (conditional: only shown for agent terminals)
+            .when(has_agent, |el| {
+                let terminal_id_for_agent = terminal_id.clone();
+                let request_broker = self.request_broker.clone();
+                el.child(
+                    header_button_base(HeaderAction::AgentInfo, &id_suffix, ButtonSize::COMPACT, &t, None)
+                        .on_click(move |_, _window, cx| {
+                            if let Some(ref tid) = terminal_id_for_agent {
+                                request_broker.update(cx, |broker, cx| {
+                                    broker.push_overlay_request(
+                                        crate::workspace::requests::OverlayRequest::AgentSessionInfo {
+                                            project_id: ctx_agent.project_id.clone(),
+                                            terminal_id: tid.clone(),
+                                        },
+                                        cx,
+                                    );
+                                });
+                            }
+                        }),
+                )
+            })
             // Minimize
             .child(
                 header_button_base(HeaderAction::Minimize, &id_suffix, ButtonSize::COMPACT, &t, None)
@@ -426,6 +455,12 @@ impl LayoutContainer {
                 project_for_names.as_ref().map_or(false, |p| p.hook_terminals.contains_key(tid))
             });
 
+            // Check if this terminal has an agent session (and grab tooltip info)
+            let agent_session = terminal_id.as_ref().and_then(|tid| {
+                project_for_names.as_ref()?.agent_sessions.get(tid).cloned()
+            });
+            let has_agent = agent_session.is_some();
+
             // Get tab label: user-set custom name > non-prompt OSC title > "Tab N"
             let tab_label = if let Some(ref tid) = terminal_id {
                 if let Some(ref p) = project_for_names {
@@ -515,10 +550,29 @@ impl LayoutContainer {
                             }))
                             .into_any_element()
                     } else {
-                        let icon_color = if is_hook { rgb(t.term_yellow) } else if is_waiting { rgb(t.border_idle) } else if is_active { rgb(t.success) } else { rgb(t.text_muted) };
+                        let icon_color = if is_hook { rgb(t.term_yellow) } else if has_agent { rgb(t.term_cyan) } else if is_waiting { rgb(t.border_idle) } else if is_active { rgb(t.success) } else { rgb(t.text_muted) };
+                        let icon_path = if has_agent { "icons/agent.svg" } else { "icons/terminal.svg" };
+
+                        // Build agent tooltip text
+                        let agent_tooltip = agent_session.as_ref().map(|s| {
+                            match &s.session_id {
+                                Some(sid) => format!("{} ({})", s.agent_type.display_name(), sid),
+                                None => format!("{} (detecting session...)", s.agent_type.display_name()),
+                            }
+                        });
+
+                        let icon = svg().path(icon_path).size(px(12.0)).text_color(icon_color);
                         h_flex()
                             .gap(px(6.0))
-                            .child(svg().path("icons/terminal.svg").size(px(12.0)).text_color(icon_color))
+                            .child(if let Some(tip) = agent_tooltip {
+                                div()
+                                    .id(format!("agent-tip-{}-{}", i, terminal_id.as_deref().unwrap_or("?")))
+                                    .child(icon)
+                                    .tooltip(move |_window, cx| Tooltip::new(tip.clone()).build(_window, cx))
+                                    .into_any_element()
+                            } else {
+                                icon.into_any_element()
+                            })
                             .child(tab_label.clone())
                             .children(idle_label.as_ref().map(|d| {
                                 div().text_size(px(10.0)).text_color(rgb(t.border_idle)).child(d.clone())

--- a/src/views/layout/terminal_pane/mod.rs
+++ b/src/views/layout/terminal_pane/mod.rs
@@ -149,6 +149,7 @@ impl TerminalPane {
         pane.start_dirty_check_loop(cx);
         pane.start_cursor_blink_loop(cx);
         pane.start_idle_check_loop(cx);
+        pane.start_agent_detection_loop(cx);
 
         pane
     }
@@ -353,6 +354,113 @@ impl TerminalPane {
         .detach();
     }
 
+    /// Start agent detection loop — periodically checks if an AI agent is running
+    /// in this terminal and captures its session ID for recovery on restart.
+    fn start_agent_detection_loop(&self, cx: &mut Context<Self>) {
+        cx.spawn(async move |this: WeakEntity<TerminalPane>, cx| {
+            // Wait a bit for the terminal to initialize before first check
+            smol::Timer::after(Duration::from_secs(5)).await;
+
+            let detect_interval = Duration::from_secs(5);
+            let scan_interval = Duration::from_secs(10);
+            let mut agent_detected = false;
+            let mut session_id_captured = false;
+
+            loop {
+                let interval = if !agent_detected { detect_interval } else { scan_interval };
+                smol::Timer::after(interval).await;
+
+                if session_id_captured {
+                    // Nothing more to do — session ID is persisted
+                    // But keep checking in case the agent restarts with a new session
+                    smol::Timer::after(Duration::from_secs(30)).await;
+                    session_id_captured = false;
+                    agent_detected = false;
+                }
+
+                // Step 1: gather terminal info
+                // Use get_service_pids() which resolves through tmux/screen/dtach
+                // to find the actual shell PID (not the session client PID).
+                let info = this.update(cx, |pane, _cx| {
+                    let terminal = pane.terminal.as_ref()?;
+                    let tid = pane.terminal_id.clone()?;
+                    let service_pids = pane.backend.get_service_pids(&tid);
+                    log::debug!(
+                        "Agent detection: terminal {} service_pids={:?}",
+                        tid, service_pids
+                    );
+                    if service_pids.is_empty() {
+                        return None;
+                    }
+                    Some((terminal.clone(), service_pids, tid, pane.project_id.clone(), pane.layout_path.clone()))
+                });
+
+                let (terminal, service_pids, terminal_id, project_id, layout_path) = match info {
+                    Ok(Some(data)) => data,
+                    Ok(None) => {
+                        log::debug!("Agent detection: no terminal info available, skipping");
+                        continue;
+                    }
+                    Err(_) => break,
+                };
+
+                // Step 2: detect agent process + read session ID (off main thread)
+                // Search descendants of ALL service PIDs (covers tmux pane PIDs, dtach daemons, etc.)
+                if !agent_detected {
+                    let detected = smol::unblock(move || {
+                        service_pids.iter()
+                            .find_map(|&pid| crate::terminal::agents::detect_agent_process(pid))
+                    }).await;
+
+                    if let Some(agent) = detected {
+                        agent_detected = true;
+                        let at = agent.agent_type.clone();
+                        // Read session ID immediately from agent's session file
+                        let session_id = smol::unblock(move || {
+                            crate::terminal::agents::read_agent_session_id(&agent)
+                        }).await;
+                        let tid = terminal_id.clone();
+                        let pid2 = project_id.clone();
+                        let lp = layout_path.clone();
+                        let sid = session_id.clone();
+                        log::info!(
+                            "Agent detected: {:?} in terminal {} session_id={:?}",
+                            at, tid, sid
+                        );
+
+                        // Record detection + session ID in workspace
+                        let _ = this.update(cx, |pane, cx| {
+                            pane.workspace.update(cx, |ws, cx| {
+                                if let Some(project) = ws.project_mut(&pid2) {
+                                    project.agent_sessions.insert(tid, crate::workspace::state::AgentSession {
+                                        agent_type: at,
+                                        session_id: sid.clone(),
+                                        detected_at: std::time::SystemTime::now()
+                                            .duration_since(std::time::UNIX_EPOCH)
+                                            .unwrap_or_default()
+                                            .as_secs(),
+                                        layout_path: lp,
+                                    });
+                                    ws.notify_data(cx);
+                                }
+                            });
+                        });
+                        session_id_captured = sid.is_some();
+                    }
+                    continue;
+                }
+
+                // Step 3: if session ID wasn't captured yet, reset detection
+                // to re-detect on the next cycle (agent might not have written
+                // its session file yet).
+                if !session_id_captured {
+                    agent_detected = false;
+                }
+            }
+        })
+        .detach();
+    }
+
     // === Terminal creation ===
 
     /// Create terminal for existing PTY.
@@ -437,8 +545,31 @@ impl TerminalPane {
         {
             Ok(terminal_id) => {
                 self.terminal_id = Some(terminal_id.clone());
+
+                // Check for a saved agent session to restore (matched by layout path)
+                let agent_resume = {
+                    let ws = self.workspace.read(cx);
+                    ws.project(&self.project_id).and_then(|project| {
+                        project.agent_sessions.values()
+                            .find(|s| s.layout_path == self.layout_path && s.session_id.is_some())
+                            .map(|s| s.agent_type.resume_command(s.session_id.as_ref().unwrap()))
+                    })
+                };
+
                 self.workspace.update(cx, |ws, cx| {
                     ws.set_terminal_id(&self.project_id, &self.layout_path, terminal_id.clone(), cx);
+
+                    // Migrate agent session from old terminal_id to new one
+                    if let Some(project) = ws.project_mut(&self.project_id) {
+                        let existing: Option<crate::workspace::state::AgentSession> = project.agent_sessions.values()
+                            .find(|s| s.layout_path == self.layout_path)
+                            .cloned();
+                        if let Some(session) = existing {
+                            // Remove old entry (keyed by old terminal_id) and insert with new key
+                            project.agent_sessions.retain(|_, s| s.layout_path != self.layout_path);
+                            project.agent_sessions.insert(terminal_id.clone(), session);
+                        }
+                    }
                 });
 
                 let size = TerminalSize::default();
@@ -451,7 +582,18 @@ impl TerminalPane {
                 self.terminal = Some(terminal.clone());
 
                 // Update child entities
-                self.update_child_terminals(terminal, cx);
+                self.update_child_terminals(terminal.clone(), cx);
+
+                // Auto-resume agent session if one was saved
+                if let Some(resume_cmd) = agent_resume {
+                    let term = terminal.clone();
+                    cx.spawn(async move |_this: WeakEntity<TerminalPane>, _cx| {
+                        // Wait for shell prompt to be ready
+                        smol::Timer::after(Duration::from_millis(1500)).await;
+                        term.send_input(&format!("{}\r", resume_cmd));
+                        log::info!("Auto-resumed agent session: {}", resume_cmd);
+                    }).detach();
+                }
 
                 self.pending_focus = true;
                 cx.notify();

--- a/src/views/panels/sidebar/project_list.rs
+++ b/src/views/panels/sidebar/project_list.rs
@@ -448,6 +448,13 @@ impl Sidebar {
 
         // Priority: user-set custom name > non-prompt OSC title > directory fallback
         // Also check for bell notification and cached idle/waiting state
+        let agent_session = {
+            let ws = self.workspace.read(cx);
+            ws.project(&project_id)
+                .and_then(|p| p.agent_sessions.get(&terminal_id).cloned())
+        };
+        let has_agent = agent_session.is_some();
+
         let (terminal_name, has_bell, is_waiting, idle_label) = {
             let ws = self.workspace.read(cx);
             let project = ws.project(&project_id);
@@ -516,38 +523,55 @@ impl Sidebar {
                     });
                 }
             }))
-            .child(
-                // Terminal icon - different for minimized and bell state
-                div()
+            .child({
+                // Terminal icon - different for minimized, bell, and agent state
+                let agent_tooltip = agent_session.as_ref().map(|s| {
+                    match &s.session_id {
+                        Some(sid) => format!("{} ({})", s.agent_type.display_name(), sid),
+                        None => format!("{} (detecting session...)", s.agent_type.display_name()),
+                    }
+                });
+                let icon = svg()
+                    .path(if has_bell {
+                        "icons/bell.svg"
+                    } else if has_agent {
+                        "icons/agent.svg"
+                    } else if is_minimized {
+                        "icons/terminal-minimized.svg"
+                    } else {
+                        "icons/terminal.svg"
+                    })
+                    .size(px(12.0))
+                    .text_color(if has_bell {
+                        rgb(t.border_bell)
+                    } else if has_agent {
+                        rgb(t.term_cyan)
+                    } else if is_waiting {
+                        rgb(t.border_idle)
+                    } else if is_minimized {
+                        rgb(t.text_muted)
+                    } else if is_inactive_tab {
+                        rgb(t.text_muted)
+                    } else {
+                        rgb(t.success)
+                    });
+                let icon_container = div()
                     .flex_shrink_0()
                     .w(px(14.0))
                     .h(px(14.0))
                     .flex()
                     .items_center()
                     .justify_center()
-                    .child(
-                        svg()
-                            .path(if has_bell {
-                                "icons/bell.svg"
-                            } else if is_minimized {
-                                "icons/terminal-minimized.svg"
-                            } else {
-                                "icons/terminal.svg"
-                            })
-                            .size(px(12.0))
-                            .text_color(if has_bell {
-                                rgb(t.border_bell)
-                            } else if is_waiting {
-                                rgb(t.border_idle)
-                            } else if is_minimized {
-                                rgb(t.text_muted)
-                            } else if is_inactive_tab {
-                                rgb(t.text_muted)
-                            } else {
-                                rgb(t.success)
-                            })
-                    ),
-            )
+                    .child(icon);
+                if let Some(tip) = agent_tooltip {
+                    icon_container
+                        .id(format!("{}agent-tip-{}", id_prefix, terminal_id))
+                        .tooltip(move |_window, cx| Tooltip::new(tip.clone()).build(_window, cx))
+                        .into_any_element()
+                } else {
+                    icon_container.into_any_element()
+                }
+            })
             .child(
                 // Terminal name (or input if renaming)
                 if is_renaming {

--- a/src/views/root/handlers.rs
+++ b/src/views/root/handlers.rs
@@ -413,6 +413,23 @@ impl RootView {
                 OverlayRequest::ShowServiceLog { project_id, service_name } => {
                     self.handle_show_service_log(project_id, service_name, cx);
                 }
+                OverlayRequest::AgentSessionInfo { project_id, terminal_id } => {
+                    let info = self.workspace.read(cx).project(&project_id)
+                        .and_then(|p| p.agent_sessions.get(&terminal_id).cloned());
+                    if let Some(session) = info {
+                        let msg = match &session.session_id {
+                            Some(sid) => format!(
+                                "{} — Session: {}",
+                                session.agent_type.display_name(), sid
+                            ),
+                            None => format!(
+                                "{} — Session ID not yet captured",
+                                session.agent_type.display_name()
+                            ),
+                        };
+                        crate::views::panels::toast::ToastManager::info(msg, cx);
+                    }
+                }
             }
         }
     }

--- a/src/views/root/mod.rs
+++ b/src/views/root/mod.rs
@@ -364,6 +364,7 @@ impl RootView {
                                 remote_git_status: api_project.git_status.clone(),
                                 default_shell: None,
                                 hook_terminals: std::collections::HashMap::new(),
+                                agent_sessions: std::collections::HashMap::new(),
                             });
                         }
                     });

--- a/src/workspace/actions/folder.rs
+++ b/src/workspace/actions/folder.rs
@@ -166,6 +166,7 @@ mod tests {
             remote_git_status: None,
             default_shell: None,
             hook_terminals: HashMap::new(),
+            agent_sessions: HashMap::new(),
         }
     }
 
@@ -280,6 +281,7 @@ mod gpui_tests {
             remote_git_status: None,
             default_shell: None,
             hook_terminals: HashMap::new(),
+            agent_sessions: HashMap::new(),
         }
     }
 

--- a/src/workspace/actions/layout.rs
+++ b/src/workspace/actions/layout.rs
@@ -1280,6 +1280,7 @@ mod gpui_tests {
             remote_git_status: None,
             default_shell: None,
             hook_terminals: HashMap::new(),
+            agent_sessions: HashMap::new(),
         }
     }
 
@@ -1523,6 +1524,7 @@ mod gpui_tests {
             remote_git_status: None,
             default_shell: None,
             hook_terminals: HashMap::new(),
+            agent_sessions: HashMap::new(),
         }
     }
 

--- a/src/workspace/actions/project.rs
+++ b/src/workspace/actions/project.rs
@@ -76,6 +76,7 @@ impl Workspace {
             remote_git_status: None,
             default_shell,
             hook_terminals: HashMap::new(),
+            agent_sessions: HashMap::new(),
         };
         let project_hooks = project.hooks.clone();
         self.data.projects.push(project);
@@ -415,6 +416,7 @@ impl Workspace {
             remote_git_status: None,
             default_shell: None,
             hook_terminals: HashMap::new(),
+            agent_sessions: HashMap::new(),
         };
 
         let new_project_hooks = project.hooks.clone();
@@ -526,6 +528,7 @@ impl Workspace {
             remote_host: None,
             remote_git_status: None,
             hook_terminals: HashMap::new(),
+            agent_sessions: HashMap::new(),
         };
 
         // Insert after parent in project_order
@@ -721,6 +724,7 @@ mod tests {
             remote_git_status: None,
             default_shell: None,
             hook_terminals: HashMap::new(),
+            agent_sessions: HashMap::new(),
         }
     }
 
@@ -851,6 +855,7 @@ mod gpui_tests {
             remote_git_status: None,
             default_shell: None,
             hook_terminals: HashMap::new(),
+            agent_sessions: HashMap::new(),
         }
     }
 

--- a/src/workspace/persistence.rs
+++ b/src/workspace/persistence.rs
@@ -158,6 +158,11 @@ pub(crate) fn validate_workspace_data(
             }
             project.service_terminals.clear();
 
+            // Agent sessions: terminal IDs are about to become invalid, but the
+            // layout_path field lets us match them to new terminals after restart.
+            // Keep only sessions that have a captured session_id (worth restoring).
+            project.agent_sessions.retain(|_, s| s.session_id.is_some());
+
             // Reset Running hooks to Succeeded (the process is dead after restart)
             for entry in project.hook_terminals.values_mut() {
                 if entry.status == HookTerminalStatus::Running {
@@ -182,6 +187,7 @@ pub(crate) fn validate_workspace_data(
             .unwrap_or_default();
         project.terminal_names.retain(|id, _| layout_ids.contains(id));
         project.hidden_terminals.retain(|id, _| layout_ids.contains(id));
+        project.agent_sessions.retain(|id, _| layout_ids.contains(id));
     }
 
     // Populate worktree_ids from worktree_info back-references (migration for old data)
@@ -502,6 +508,7 @@ pub(crate) fn sync_worktrees(data: &mut WorkspaceData, path_template: &str) {
                 remote_host: None,
                 remote_git_status: None,
                 hook_terminals: HashMap::new(),
+                agent_sessions: HashMap::new(),
             };
 
             // Insert after parent in project_order
@@ -559,6 +566,7 @@ pub fn default_workspace() -> WorkspaceData {
             remote_git_status: None,
             default_shell: None,
             hook_terminals: HashMap::new(),
+            agent_sessions: HashMap::new(),
         }],
         project_order: vec![project_id],
         project_widths: HashMap::new(),
@@ -593,6 +601,7 @@ mod tests {
             remote_git_status: None,
             default_shell: None,
             hook_terminals: HashMap::new(),
+            agent_sessions: HashMap::new(),
         }
     }
 

--- a/src/workspace/requests.rs
+++ b/src/workspace/requests.rs
@@ -53,6 +53,10 @@ pub enum OverlayRequest {
         position: gpui::Point<gpui::Pixels>,
     },
     ShowServiceLog { project_id: String, service_name: String },
+    AgentSessionInfo {
+        project_id: String,
+        terminal_id: String,
+    },
 }
 
 /// Requests consumed by Sidebar::render()

--- a/src/workspace/state.rs
+++ b/src/workspace/state.rs
@@ -95,6 +95,45 @@ impl WorktreeMetadata {
     }
 }
 
+/// Type of AI coding agent detected in a terminal.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AgentType {
+    Claude,
+    Copilot,
+}
+
+impl AgentType {
+    /// Build the CLI command to resume a specific session.
+    pub fn resume_command(&self, session_id: &str) -> String {
+        match self {
+            AgentType::Claude => format!("claude --resume {}", session_id),
+            AgentType::Copilot => format!("copilot --resume {}", session_id),
+        }
+    }
+
+    /// Display name for UI.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            AgentType::Claude => "Claude Code",
+            AgentType::Copilot => "Copilot CLI",
+        }
+    }
+}
+
+/// Persisted agent session info for a terminal.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AgentSession {
+    pub agent_type: AgentType,
+    /// Session ID captured from terminal output (None until captured).
+    #[serde(default)]
+    pub session_id: Option<String>,
+    /// Unix timestamp (seconds) when the agent was first detected.
+    pub detected_at: u64,
+    /// Layout path when detected (stable across restarts even when terminal IDs change).
+    #[serde(default)]
+    pub layout_path: Vec<usize>,
+}
+
 /// Status of a hook terminal in the service panel.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum HookTerminalStatus {
@@ -177,6 +216,10 @@ pub struct ProjectData {
     /// Hook terminals displayed in the service panel (persisted across restarts)
     #[serde(default)]
     pub hook_terminals: HashMap<String, HookTerminalEntry>,
+    /// Detected AI agent sessions (terminal_id -> session info).
+    /// Persisted across restarts to enable automatic session recovery.
+    #[serde(default)]
+    pub agent_sessions: HashMap<String, AgentSession>,
 }
 
 impl ProjectData {
@@ -1648,6 +1691,7 @@ mod tests {
             remote_git_status: None,
             default_shell: None,
             hook_terminals: HashMap::new(),
+            agent_sessions: HashMap::new(),
         }
     }
 
@@ -2537,6 +2581,7 @@ mod workspace_tests {
             remote_git_status: None,
             default_shell: None,
             hook_terminals: HashMap::new(),
+            agent_sessions: HashMap::new(),
         }
     }
 
@@ -3306,6 +3351,7 @@ mod gpui_tests {
             remote_git_status: None,
             default_shell: None,
             hook_terminals: HashMap::new(),
+            agent_sessions: HashMap::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

- Automatically detect AI coding agents (Claude Code, Copilot CLI) running in terminal panes
- Capture session IDs by reading agent-specific storage files
- Auto-resume agent sessions on app restart (`claude --resume <id>`, `copilot --resume <id>`)
- Show visual indicators (cyan robot icon + tooltip) in tab bar and sidebar
- Add "Agent Session Info" button in terminal action bar

## How it works

1. **Detection**: A background loop per terminal calls `get_service_pids()` (resolves through tmux/screen/dtach), then walks the descendant process tree via `/proc/<pid>/cmdline` to find `claude` or `copilot`
2. **Session ID capture**: Reads `~/.claude/sessions/<pid>.json` for Claude, scans `~/.copilot/session-state/` for Copilot lock files
3. **Persistence**: Agent sessions stored in `workspace.json` under `project.agent_sessions` (backward-compatible via `#[serde(default)]`)
4. **Auto-resume**: On restart, if a terminal had an agent session with a captured ID, the resume command is sent to the shell after a 1.5s init delay
5. **UI**: Cyan agent icon replaces terminal icon, tooltip shows agent type + session UUID, action button opens session info toast

## Files changed

| File | Purpose |
|------|---------|
| `src/terminal/agents.rs` | **New** — agent process detection, session ID reading |
| `src/workspace/state.rs` | `AgentType`, `AgentSession` structs, `agent_sessions` field on `ProjectData` |
| `src/workspace/persistence.rs` | Cleanup orphaned sessions, retain sessions with IDs across restarts |
| `src/views/layout/terminal_pane/mod.rs` | Agent detection loop, auto-resume on terminal creation |
| `src/views/layout/tabs/mod.rs` | Agent icon, tooltip, and info button in tab bar |
| `src/views/panels/sidebar/project_list.rs` | Agent icon + tooltip in sidebar |
| `src/views/chrome/header_buttons.rs` | `AgentInfo` header action variant |
| `src/workspace/requests.rs` | `AgentSessionInfo` overlay request |
| `src/views/root/handlers.rs` | Handle agent info request (toast) |
| `assets/icons/agent.svg` | Robot icon for agent terminals |

## Test plan

- [x] `cargo check --release` passes
- [x] `cargo test` — all 398 tests pass
- [x] `cargo clippy` — no new warnings
- [x] Open terminal with `claude` running → agent icon appears within ~10s
- [x] Open terminal with `copilot` running → agent icon appears within ~10s
- [x] Hover agent icon → tooltip shows "Claude Code (<session-uuid>)"
- [x] Click agent info button → toast shows session details
- [x] Close and reopen app → agent session auto-resumes with `claude --resume <id>`
- [x] Workspace.json contains `agent_sessions` entries after detection


🤖 Generated with [Claude Code](https://claude.com/claude-code)