### PR TITLE
fix: clean up stale dtach sockets on startup

### DIFF
--- a/src/terminal/pty_manager.rs
+++ b/src/terminal/pty_manager.rs
@@ -98,6 +98,17 @@ impl PtyManager {
             log::info!("Session persistence enabled with {:?}", session_backend);
         }
 
+        // Clean up stale dtach sockets from previous crashes
+        #[cfg(unix)]
+        if matches!(session_backend, ResolvedBackend::Dtach) {
+            std::thread::Builder::new()
+                .name("dtach-socket-gc".into())
+                .spawn(|| {
+                    crate::terminal::session_backend::cleanup_stale_dtach_sockets();
+                })
+                .ok();
+        }
+
         (
             Self {
                 terminals: Arc::new(Mutex::new(HashMap::new())),

--- a/src/terminal/session_backend.rs
+++ b/src/terminal/session_backend.rs
@@ -314,6 +314,46 @@ impl ResolvedBackend {
     }
 }
 
+/// Remove dtach socket files whose dtach process is no longer running.
+/// Called once at startup to clean up after crashes or ungraceful exits.
+#[cfg(unix)]
+pub fn cleanup_stale_dtach_sockets() {
+    let dir = get_dtach_socket_dir();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return, // dir doesn't exist yet — nothing to clean
+    };
+
+    let mut removed = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("sock") {
+            continue;
+        }
+
+        // Check if any process still has this socket open
+        let has_listener = Command::new("lsof")
+            .arg("-t")
+            .arg(&path)
+            .output()
+            .map(|o| !o.stdout.is_empty())
+            .unwrap_or(false);
+
+        if !has_listener {
+            let _ = std::fs::remove_file(&path);
+            removed += 1;
+        }
+    }
+
+    if removed > 0 {
+        log::info!(
+            "Cleaned up {} stale dtach socket(s) from {:?}",
+            removed,
+            dir
+        );
+    }
+}
+
 /// Resolve a session backend for a specific WSL distro.
 /// Runs `wsl.exe -d <distro> -- sh -c "command -v <tool>"` to check availability.
 /// Results are cached per (distro, preference) pair so detection runs at most once.


### PR DESCRIPTION
## Summary
- Add `cleanup_stale_dtach_sockets()` that scans `/tmp/okena-<uid>/` for orphaned `.sock` files on startup
- Uses `lsof` to check if any process still holds each socket; removes dead ones
- Runs in a background thread from `PtyManager::new()` to avoid blocking the UI

## Context
After a crash or SIGKILL, dtach socket files were never cleaned up, accumulating indefinitely. On a real machine this resulted in 163+ orphaned sockets over 5 days.

## Test plan
- [ ] Launch Okena with dtach backend, verify startup logs show cleanup count (if stale sockets exist)
- [ ] Kill Okena with `kill -9`, relaunch, confirm orphaned sockets are removed
- [ ] Verify active sessions are not affected by the cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)