### PR TITLE
perf: skip view caching on macOS, keep it on Linux/Windows

### DIFF
--- a/crates/okena-ui/src/lib.rs
+++ b/crates/okena-ui/src/lib.rs
@@ -2,6 +2,22 @@
 //!
 //! Reusable UI components, design tokens, and theme helpers for the Okena terminal.
 
+use gpui::{AnyView, StyleRefinement, Styled};
+
+/// Wrap a view with `cached(size_full())` on platforms where it helps.
+///
+/// On macOS, GPUI calls `window.refresh()` frequently (hover tracking, input
+/// modality switches), which forces all cached views to miss. The miss path
+/// uses `layout_as_root()` — an independent taffy tree that doubles layout
+/// cost. On Linux/Windows, refreshes are rare so caches hit most frames.
+pub fn cached_on_non_macos(view: AnyView) -> AnyView {
+    if cfg!(target_os = "macos") {
+        view
+    } else {
+        view.cached(StyleRefinement::default().size_full())
+    }
+}
+
 pub mod badge;
 pub mod button;
 pub mod chip;

--- a/crates/okena-views-terminal/src/layout/layout_container.rs
+++ b/crates/okena-views-terminal/src/layout/layout_container.rs
@@ -246,9 +246,7 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                     .flex_1()
                     .min_h_0()
                     .relative()
-                    .child(AnyView::from(self.terminal_pane.clone().unwrap()).cached(
-                        StyleRefinement::default().size_full()
-                    ))
+                    .child(okena_ui::cached_on_non_macos(self.terminal_pane.clone().unwrap().into()))
                     .child(self.render_drop_zones(terminal_id, cx, &self.active_drag.clone())),
             )
     }
@@ -397,9 +395,7 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                 .size_full()
                 .min_h_0()
                 .min_w_0()
-                .child(AnyView::from(container).cached(
-                    StyleRefinement::default().size_full()
-                ));
+                .child(okena_ui::cached_on_non_macos(container.into()));
         }
 
         let is_horizontal = direction == SplitDirection::Horizontal;
@@ -478,9 +474,7 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                 .flex_basis(relative(size_percent / 100.0))
                 .min_w_0()
                 .min_h_0()
-                .child(AnyView::from(container).cached(
-                    StyleRefinement::default().size_full()
-                ))
+                .child(okena_ui::cached_on_non_macos(container.into()))
                 .into_any_element();
 
             elements.push(child_element);

--- a/crates/okena-views-terminal/src/layout/tabs/mod.rs
+++ b/crates/okena-views-terminal/src/layout/tabs/mod.rs
@@ -251,9 +251,7 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
 
             return v_flex()
                 .size_full()
-                .child(AnyView::from(container).cached(
-                    StyleRefinement::default().size_full()
-                ));
+                .child(okena_ui::cached_on_non_macos(container.into()));
         }
 
         let num_children = children.len();
@@ -305,7 +303,7 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                         })
                         .clone();
 
-                    AnyView::from(container).cached(StyleRefinement::default().size_full())
+                    okena_ui::cached_on_non_macos(container.into())
                 }),
             )
     }

--- a/crates/okena-views-terminal/src/layout/terminal_pane/render.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/render.rs
@@ -189,9 +189,7 @@ impl<D: ActionDispatch + Send + Sync> Render for TerminalPane<D> {
                         .min_w_0()
                         .overflow_hidden()
                         .relative()
-                        .child(AnyView::from(self.content.clone()).cached(
-                            StyleRefinement::default().size_full()
-                        ))
+                        .child(okena_ui::cached_on_non_macos(self.content.clone().into()))
                         .when(show_border, |el| {
                             el.child(div().absolute().inset_0().border_1().border_color(border_color))
                         }),

--- a/crates/okena-views-terminal/src/overlays/detached_terminal.rs
+++ b/crates/okena-views-terminal/src/overlays/detached_terminal.rs
@@ -314,9 +314,7 @@ impl Render for DetachedTerminalView {
                 div()
                     .flex_1()
                     .min_h_0()
-                    .child(AnyView::from(self.content.clone()).cached(
-                        StyleRefinement::default().size_full()
-                    )),
+                    .child(okena_ui::cached_on_non_macos(self.content.clone().into())),
             )
             .id("detached-terminal-main")
             .on_click(cx.listener(|this, _, window, cx| {

--- a/src/simple_root.rs
+++ b/src/simple_root.rs
@@ -4,7 +4,7 @@
 use gpui::{
     AnyView, Bounds, Context, CursorStyle, Decorations, DispatchPhase, Hitbox, HitboxBehavior,
     InteractiveElement, IntoElement, MouseButton, MouseDownEvent, ParentElement, Pixels, Point,
-    Render, ResizeEdge, Size, StyleRefinement, Styled, Window, canvas, div, point, prelude::FluentBuilder, px,
+    Render, ResizeEdge, Size, Styled, Window, canvas, div, point, prelude::FluentBuilder, px,
 };
 
 /// Edge detection zone size (pixels) for CSD resize handles.
@@ -94,7 +94,7 @@ impl Render for SimpleRoot {
                     .absolute(),
                 )
             })
-            .child(self.view.clone().cached(StyleRefinement::default().size_full()))
+            .child(okena_ui::cached_on_non_macos(self.view.clone()))
     }
 }
 

--- a/src/views/panels/project_column.rs
+++ b/src/views/panels/project_column.rs
@@ -704,9 +704,7 @@ impl Render for ProjectColumn {
                         .flex_1()
                         .min_h_0()
                         .overflow_hidden()
-                        .child(AnyView::from(self.layout_container.clone().unwrap()).cached(
-                            StyleRefinement::default().size_full()
-                        ))
+                        .child(okena_ui::cached_on_non_macos(self.layout_container.clone().unwrap().into()))
                         .into_any_element()
                 } else if is_creating {
                     self.render_creating_state(cx).into_any_element()

--- a/src/views/root/render.rs
+++ b/src/views/root/render.rs
@@ -181,9 +181,7 @@ impl RootView {
                     .w(px(pixel_width))
                     .flex_shrink_0()
                     .h_full()
-                    .child(AnyView::from(col).cached(
-                        StyleRefinement::default().size_full()
-                    ))
+                    .child(okena_ui::cached_on_non_macos(col.into()))
                     .into_any_element();
 
                 elements.push(col_element);


### PR DESCRIPTION
## Summary
Makes the `cached()` view optimization platform-conditional: enabled on Linux/Windows where it helps, disabled on macOS where it hurts.

## Problem
GPUI's `cached()` skips layout recomputation for non-dirty views. On **Linux/Windows** this works well — `window.refresh()` is rare, so caches hit most frames. On **macOS**, GPUI calls `window.refresh()` frequently (hover tracking, input modality switches), causing constant cache misses. The miss path uses `layout_as_root()` — an independent taffy tree that **doubles layout cost** vs the normal integrated path.

## Solution
- Add `cached_on_non_macos()` helper in `okena-ui` that applies `cached(size_full())` only on non-macOS
- Replace all `AnyView::from(view).cached(...)` calls with `cached_on_non_macos(view.into())`
- Sidebar stays always-cached on all platforms (its cache actually hits since it's never in the terminal's dirty path)

## Test plan
- [ ] **macOS**: type in terminal (standalone + split) — no input lag
- [ ] **Linux**: verify perf improvement from caching is preserved
- [ ] `cargo build` on all platforms