### PR TITLE
fix: wire up content pane registry for PTY dirty notifications

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -631,6 +631,11 @@ fn main() {
                     })
                     .detach();
 
+                // Wire up content pane registration so PTY events can notify terminal views
+                okena_views_terminal::set_register_content_pane_fn(Box::new(|terminal_id, weak_content| {
+                    crate::views::root::content_pane_registry().lock().insert(terminal_id, weak_content);
+                }));
+
                 // Create the main app view wrapped in Root (required for gpui_component inputs)
                 let okena = cx.new(|cx| {
                     Okena::new(workspace_data, pty_manager.clone(), pty_events, listen_addr, window, cx)


### PR DESCRIPTION
## Summary
- The content pane registry callback (`set_register_content_pane_fn`) was never connected at startup
- PTY events couldn't find terminal content panes to notify, so terminals only updated via GPUI's entity-tracking mechanism
- Entity tracking doesn't work reliably through `cached()` views, causing 200–1300ms frame stalls

## Changes
Wire up `set_register_content_pane_fn` in `main.rs` to insert into the existing `content_pane_registry()`. This is a 5-line fix — the registry and callback infrastructure already existed but were never connected.

## Test plan
- [x] Type in a terminal — keystrokes render immediately (no lag)
- [x] Test with split panes and tabs — all terminals responsive
- [x] Verify `cached()` view optimization (from previous commit) still works