### PR TITLE
feat(sidebar): show git branch instead of worktree name

### DIFF
--- a/crates/okena-views-sidebar/src/sidebar.rs
+++ b/crates/okena-views-sidebar/src/sidebar.rs
@@ -1357,9 +1357,17 @@ pub struct SidebarProjectInfo {
 impl SidebarProjectInfo {
     pub(crate) fn from_project(project: &ProjectData) -> Self {
         let layout = project.layout.as_ref();
+        // For worktree projects, show the git branch instead of the stored name.
+        let name = if project.worktree_info.is_some() {
+            okena_git::get_git_status(std::path::Path::new(&project.path))
+                .and_then(|s| s.branch)
+                .unwrap_or_else(|| project.name.clone())
+        } else {
+            project.name.clone()
+        };
         Self {
             id: project.id.clone(),
-            name: project.name.clone(),
+            name,
             show_in_overview: project.show_in_overview,
             folder_color: project.folder_color,
             has_layout: layout.is_some(),


### PR DESCRIPTION
## Summary
- Worktree entries in the sidebar now display the current git branch name instead of the stored project name
- Uses the existing non-blocking git status cache (populated by background poller), falling back to the project name if not yet cached

## Changes
- Modified `SidebarProjectInfo::from_project` to resolve the branch from `okena_git::get_git_status` for worktree projects

## Test plan
- [ ] Open Okena with a project that has worktrees
- [ ] Verify worktree entries in the sidebar show the branch name (e.g. `feat/my-feature`) instead of the directory or stored name
- [ ] Verify non-worktree projects still show their project name as before
- [ ] Verify that before git status cache populates, the fallback name is shown correctly