### PR TITLE
fix: resolve correct project path when opening existing worktrees in monorepos

### DIFF
--- a/crates/okena-git/src/lib.rs
+++ b/crates/okena-git/src/lib.rs
@@ -9,6 +9,7 @@ pub use repository::{
     remove_worktree_fast,
     get_available_branches_for_worktree,
     get_repo_root,
+    resolve_git_root_and_subdir,
     has_uncommitted_changes,
     get_current_branch,
     get_default_branch,

--- a/crates/okena-git/src/repository.rs
+++ b/crates/okena-git/src/repository.rs
@@ -754,6 +754,23 @@ pub fn normalize_path(path: &Path) -> PathBuf {
     result
 }
 
+/// Resolve the git repository root and the project subdirectory within it.
+///
+/// For a monorepo project at `/repo/packages/app`, returns
+/// `(/repo, packages/app)`. For a root-level project, subdir is empty.
+/// Both paths are normalized before `strip_prefix` to handle symlinks,
+/// trailing slashes, and `..` components.
+pub fn resolve_git_root_and_subdir(project_path: &Path) -> (PathBuf, PathBuf) {
+    let git_root = get_repo_root(project_path)
+        .unwrap_or_else(|| project_path.to_path_buf());
+    let norm_project = normalize_path(project_path);
+    let norm_root = normalize_path(&git_root);
+    let subdir = norm_project.strip_prefix(&norm_root)
+        .unwrap_or(Path::new(""))
+        .to_path_buf();
+    (git_root, subdir)
+}
+
 /// Given a worktree checkout path and a subdir, return the project path.
 /// If subdir is empty, returns the worktree path as-is.
 pub fn project_path_in_worktree(worktree_path: &str, subdir: &Path) -> String {

--- a/crates/okena-views-sidebar/src/worktree_list.rs
+++ b/crates/okena-views-sidebar/src/worktree_list.rs
@@ -32,8 +32,8 @@ pub struct WorktreeListPopover {
     position: Point<Pixels>,
     hooks: HooksConfig,
     focus_handle: FocusHandle,
-    /// Git repository root for the parent project (may differ from project path in monorepos).
-    git_root: std::path::PathBuf,
+    /// Normalized git root (for filtering out the main repo entry).
+    norm_git_root: std::path::PathBuf,
     /// Subdirectory within the git repo (empty for non-monorepo projects).
     subdir: std::path::PathBuf,
 }
@@ -49,15 +49,26 @@ impl WorktreeListPopover {
         let project_path = workspace.read(cx).project(&project_id)
             .map(|p| p.path.clone())
             .unwrap_or_default();
-        let project_pathbuf = std::path::PathBuf::from(&project_path);
-        let git_root = okena_git::get_repo_root(&project_pathbuf)
-            .unwrap_or_else(|| project_pathbuf.clone());
-        let subdir = project_pathbuf.strip_prefix(&git_root)
-            .unwrap_or(std::path::Path::new(""))
-            .to_path_buf();
+        let (git_root, subdir) = okena_git::resolve_git_root_and_subdir(
+            std::path::Path::new(&project_path),
+        );
+        let norm_git_root = okena_git::repository::normalize_path(&git_root);
         let entries = okena_git::repository::list_git_worktrees(&git_root);
         let focus_handle = cx.focus_handle();
-        Self { workspace, project_id, entries, position, hooks, focus_handle, git_root, subdir }
+        Self { workspace, project_id, entries, position, hooks, focus_handle, norm_git_root, subdir }
+    }
+
+    /// Find a tracked worktree project by its worktree root path.
+    /// Checks both the expected project path (with monorepo subdir) and the
+    /// bare worktree root for backwards compatibility with older workspace files.
+    fn find_tracked_project_id(&self, wt_path: &str, cx: &App) -> Option<String> {
+        let expected_path = okena_git::repository::project_path_in_worktree(wt_path, &self.subdir);
+        let ws = self.workspace.read(cx);
+        ws.data().projects.iter()
+            .find(|p| (p.path == expected_path || p.path == wt_path)
+                && p.worktree_info.as_ref()
+                    .map_or(false, |wt| wt.parent_project_id == self.project_id))
+            .map(|p| p.id.clone())
     }
 
     fn close(&self, cx: &mut Context<Self>) {
@@ -77,26 +88,19 @@ impl Render for WorktreeListPopover {
         let project_id = &self.project_id;
         let subdir = &self.subdir;
 
-        // Build set of project paths already tracked in workspace for this parent.
-        // This contains the full project path (which may include a monorepo subdir).
         let tracked_project_paths: std::collections::HashSet<String> = ws.data().projects.iter()
             .filter(|p| p.worktree_info.as_ref()
                 .map_or(false, |wt| wt.parent_project_id == *project_id))
             .map(|p| p.path.clone())
             .collect();
 
-        // Filter: skip the main repo itself (compare worktree root against git root,
-        // not against the project path which may be a subdirectory in monorepos).
-        let norm_git_root = okena_git::repository::normalize_path(&self.git_root);
         let worktrees: Vec<(String, String, bool)> = self.entries.iter()
             .filter(|(wt_path, _)| {
                 let norm_wt = okena_git::repository::normalize_path(std::path::Path::new(wt_path));
-                norm_wt != norm_git_root
+                norm_wt != self.norm_git_root
             })
             .map(|(wt_path, branch)| {
-                // Compute the expected project path (worktree root + monorepo subdir)
                 let expected_path = okena_git::repository::project_path_in_worktree(wt_path, subdir);
-                // Check both the expected path and bare worktree root for backwards compat
                 let is_tracked = tracked_project_paths.contains(&expected_path)
                     || tracked_project_paths.contains(wt_path);
                 (wt_path.clone(), branch.clone(), is_tracked)
@@ -141,39 +145,18 @@ impl Render for WorktreeListPopover {
                     .hover(|s| s.bg(rgb(t.bg_hover)))
                     .on_click(cx.listener(move |this, _, _window, cx| {
                         if is_tracked {
-                            // Find the tracked project by matching both the expected
-                            // project path (with subdir) and the bare worktree root.
-                            let expected_path = okena_git::repository::project_path_in_worktree(
-                                &wt_path_clone, &this.subdir,
-                            );
-                            let ws = this.workspace.read(cx);
-                            let wt_project_id = ws.data().projects.iter()
-                                .find(|p| (p.path == expected_path || p.path == wt_path_clone)
-                                    && p.worktree_info.as_ref()
-                                        .map_or(false, |wt| wt.parent_project_id == project_id))
-                                .map(|p| p.id.clone());
-                            if let Some(id) = wt_project_id {
+                            if let Some(id) = this.find_tracked_project_id(&wt_path_clone, cx) {
                                 this.workspace.update(cx, |ws, cx| {
                                     ws.delete_project(&id, &hooks, cx);
                                 });
                             }
                         } else {
-                            // add_discovered_worktree computes the correct project
-                            // path (worktree root + monorepo subdir) internally.
-                            let expected_path = okena_git::repository::project_path_in_worktree(
-                                &wt_path_clone, &this.subdir,
-                            );
                             this.workspace.update(cx, |ws, cx| {
-                                ws.add_discovered_worktree(
+                                if let Some(new_id) = ws.add_discovered_worktree(
                                     &wt_path_clone,
                                     &branch_clone,
                                     &project_id,
-                                    "",
-                                );
-                                let new_id = ws.data().projects.iter()
-                                    .find(|p| p.path == expected_path || p.path == wt_path_clone)
-                                    .map(|p| p.id.clone());
-                                if let Some(new_id) = new_id {
+                                ) {
                                     ws.add_to_worktree_ids(&project_id, &new_id);
                                 }
                                 ws.notify_data(cx);

--- a/crates/okena-workspace/src/actions/project.rs
+++ b/crates/okena-workspace/src/actions/project.rs
@@ -535,33 +535,25 @@ impl Workspace {
 
     /// Add a worktree project discovered by the periodic sync watcher.
     /// Does NOT fire hooks (the worktree was created outside Okena).
+    /// Returns the new project ID, or None if already tracked.
     pub fn add_discovered_worktree(
         &mut self,
         wt_path: &str,
         branch: &str,
         parent_id: &str,
-        _main_repo_path: &str,
-    ) {
-        // For monorepo projects the parent path may be a subdirectory inside
-        // the git repo (e.g. /repo/packages/app). Discovered worktrees from
-        // `git worktree list` are always the worktree root. We need to append
-        // the same subdirectory so terminals start in the right place.
-        let project_path = {
-            let parent_path = self.project(parent_id)
-                .map(|p| p.path.clone())
-                .unwrap_or_default();
-            let parent_pathbuf = std::path::PathBuf::from(&parent_path);
-            let git_root = okena_git::get_repo_root(&parent_pathbuf)
-                .unwrap_or_else(|| parent_pathbuf.clone());
-            let subdir = parent_pathbuf.strip_prefix(&git_root)
-                .unwrap_or(std::path::Path::new(""));
-            okena_git::repository::project_path_in_worktree(wt_path, subdir)
-        };
+    ) -> Option<String> {
+        // For monorepo projects, resolve the subdirectory offset so the
+        // project path points to the right place inside the worktree.
+        let parent_path = self.project(parent_id)
+            .map(|p| p.path.clone())
+            .unwrap_or_default();
+        let (_git_root, subdir) = okena_git::resolve_git_root_and_subdir(
+            std::path::Path::new(&parent_path),
+        );
+        let project_path = okena_git::repository::project_path_in_worktree(wt_path, &subdir);
 
-        // Double-check it's not already tracked (check both full project path
-        // and bare worktree root for backwards compatibility)
         if self.data.projects.iter().any(|p| p.path == project_path || p.path == wt_path) {
-            return;
+            return None;
         }
 
         let dir_name = std::path::Path::new(wt_path)
@@ -602,11 +594,12 @@ impl Workspace {
         // Insert after parent in project_order
         self.data.projects.push(project);
         if let Some(parent_index) = self.data.project_order.iter().position(|pid| pid == parent_id) {
-            self.data.project_order.insert(parent_index + 1, id);
+            self.data.project_order.insert(parent_index + 1, id.clone());
         } else {
-            self.data.project_order.push(id);
+            self.data.project_order.push(id.clone());
         }
         // Note: caller is responsible for calling notify_data
+        Some(id)
     }
 
     /// Add a worktree project ID to its parent's worktree_ids list (deduped).


### PR DESCRIPTION
## Summary

- When discovering existing worktrees via `git worktree list`, the returned paths are always the worktree root. In monorepo setups where the project is a subdirectory (e.g. `/repo/packages/app`), opening such a worktree incorrectly set the project path to the worktree root instead of the matching subdirectory within it (e.g. `/repo-wt/feature` instead of `/repo-wt/feature/packages/app`).
- Compute the subdirectory offset from the parent project's git root and append it to discovered worktree paths in `add_discovered_worktree`.
- Fix the worktree list popover to correctly filter the main repo entry (compare against git root, not project path) and match tracked worktrees using the computed project path.
- Backwards-compatible: duplicate and tracking checks match both the new full project path and bare worktree root for existing workspace.json files.

Follows up on #34 and #61 which fixed worktree creation and removal in monorepos — this PR fixes the remaining case of **opening existing worktrees**.

## Test plan

- [ ] Manual: in a monorepo, add a subdirectory as a project, create a worktree externally (`git worktree add`), then open it via the worktree list — verify terminal starts in the correct subdirectory
- [ ] Manual: in a non-monorepo, discover and open an existing worktree — verify it still works
- [ ] Manual: verify the main repo entry is correctly filtered from the worktree list in a monorepo
- [ ] Manual: verify toggling tracked/untracked state works correctly for monorepo worktrees

Co-Authored-By: Claude Code