### PR TITLE
fix: require authentication for /v1/auth/reload endpoint

### DIFF
--- a/src/remote/routes/mod.rs
+++ b/src/remote/routes/mod.rs
@@ -63,6 +63,10 @@ pub fn build_router(
         .route("/v1/refresh", axum::routing::post(refresh::post_refresh))
         .route("/v1/tokens", axum::routing::get(tokens::list_tokens))
         .route("/v1/tokens/{id}", axum::routing::delete(tokens::revoke_token))
+        .route(
+            "/v1/auth/reload",
+            axum::routing::post(auth_reload::post_reload),
+        )
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth_middleware,
@@ -71,11 +75,7 @@ pub fn build_router(
     // Public routes (no auth required)
     let public = Router::new()
         .route("/health", axum::routing::get(health::get_health))
-        .route("/v1/pair", axum::routing::post(pair::post_pair))
-        .route(
-            "/v1/auth/reload",
-            axum::routing::post(auth_reload::post_reload),
-        );
+        .route("/v1/pair", axum::routing::post(pair::post_pair));
 
     public
         .merge(protected)


### PR DESCRIPTION
## Summary
- Move `/v1/auth/reload` route from the public router to the protected router
- The endpoint now requires a valid bearer token, preventing unauthenticated token reloads

Closes #69

## Test plan
- [ ] Verify unauthenticated `POST /v1/auth/reload` returns 401
- [ ] Verify authenticated `POST /v1/auth/reload` still works

Co-Authored-By: Claude Code