### PR TITLE
fix(terminal): escape tool name in WSL command -v check

### DIFF
--- a/crates/okena-terminal/src/session_backend.rs
+++ b/crates/okena-terminal/src/session_backend.rs
@@ -423,7 +423,7 @@ fn is_wsl_tool_available(distro: Option<&str>, tool: &str) -> bool {
     if let Some(d) = distro {
         cmd.args(["-d", d]);
     }
-    cmd.args(["--", "sh", "-c", &format!("command -v {}", tool)]);
+    cmd.args(["--", "sh", "-c", &format!("command -v {}", shell_escape(tool))]);
     crate::process::safe_output(&mut cmd)
         .map(|o| o.status.success())
         .unwrap_or(false)


### PR DESCRIPTION
## Summary
- Fixes command injection vulnerability in `is_wsl_tool_available()` where the `tool` parameter was interpolated directly into a shell command string passed to `wsl.exe -- sh -c "command -v <tool>"`
- Uses the existing `shell_escape()` function (already used elsewhere in the same file) to sanitize the input

Closes #73

## Test plan
- [x] `cargo test` passes (32 tests)
- [ ] Manual verification on Windows with WSL: confirm `is_wsl_tool_available()` still correctly detects tools like `dtach`, `tmux`, `screen`

Co-Authored-By: Claude Code