### PR TITLE
fix: load services for worktree projects after directory is created

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -267,6 +267,11 @@ impl Okena {
                     .collect();
                 let mut known = known_project_ids.lock();
                 for (id, path, saved_terminals) in &local_projects {
+                    // Skip projects whose directory doesn't exist yet (deferred worktrees).
+                    // They'll be picked up by the observer once the directory is ready.
+                    if !std::path::Path::new(path).exists() {
+                        continue;
+                    }
                     service_manager.update(cx, |sm, cx| {
                         sm.load_project_services(id, path, saved_terminals, cx);
                     });
@@ -290,24 +295,28 @@ impl Okena {
 
                 let mut known = known_project_ids.lock();
 
-                // Load services for new projects
+                // Load services for new projects (or deferred worktrees whose directory now exists)
                 for (id, path, saved_terminals) in &local_projects {
                     if !known.contains(id) {
+                        // Skip projects whose directory doesn't exist yet (deferred worktrees).
+                        if !std::path::Path::new(path).exists() {
+                            continue;
+                        }
                         service_manager.update(cx, |sm, cx| {
                             sm.load_project_services(id, path, saved_terminals, cx);
                         });
+                        known.insert(id.clone());
                     }
                 }
 
                 // Unload services for removed projects
                 let removed: Vec<String> = known.difference(&current_ids).cloned().collect();
-                for id in removed {
+                for id in &removed {
                     service_manager.update(cx, |sm, cx| {
-                        sm.unload_project_services(&id, cx);
+                        sm.unload_project_services(id, cx);
                     });
+                    known.remove(id);
                 }
-
-                *known = current_ids;
             })
             .detach();
         }


### PR DESCRIPTION
## Summary

- When creating a worktree with deferred hooks, the project is registered in the workspace before the directory exists on disk. The service loading observer would run immediately, find no `okena.yaml` or `docker-compose.yml` (directory doesn't exist yet), and mark the project as "known" — never retrying once the directory was ready.
- Skip service loading for projects whose directory doesn't exist yet, so they get picked up on the next workspace notification after `fire_worktree_hooks` runs and the directory is available.
- Same class of issue as #33 and #60 (worktree path handling).

## Test plan

- [ ] Manual: add a project with `docker-compose.yml`, create a worktree from it, verify Services section appears in the sidebar for the worktree project
- [ ] Manual: restart the app with an existing worktree project that has services — verify services load on startup
- [ ] Manual: verify non-worktree projects still load services normally

Co-Authored-By: Claude Code