### PR TITLE
fix: reduce token TTL to 14 days with 3-day refresh threshold

### DIFF
--- a/crates/okena-core/src/client/types.rs
+++ b/crates/okena-core/src/client/types.rs
@@ -85,8 +85,8 @@ pub enum ConnectionEvent {
     },
 }
 
-/// Token age threshold for refresh (14 days).
-pub const TOKEN_REFRESH_AGE_SECS: i64 = 14 * 24 * 3600;
+/// Token age threshold for refresh (3 days). Must be well under the 14-day server TTL.
+pub const TOKEN_REFRESH_AGE_SECS: i64 = 3 * 24 * 3600;
 
 #[cfg(test)]
 mod tests {

--- a/crates/okena-remote-client/src/manager.rs
+++ b/crates/okena-remote-client/src/manager.rs
@@ -362,7 +362,7 @@ impl RemoteConnectionManager {
     }
 
     /// Start a periodic token refresh task.
-    /// Checks every 10 minutes and refreshes tokens older than 20 hours.
+    /// Checks every 10 minutes and refreshes tokens older than 3 days.
     pub fn start_token_refresh_task(&self, cx: &mut Context<Self>) {
         let event_tx = self.event_tx.clone();
         let runtime = self.runtime.clone();

--- a/src/remote/auth.rs
+++ b/src/remote/auth.rs
@@ -11,8 +11,8 @@ use std::time::{Duration, Instant, SystemTime};
 
 type HmacSha256 = Hmac<Sha256>;
 
-/// Token time-to-live in seconds (30 days).
-pub const TOKEN_TTL_SECS: u64 = 30 * 24 * 3600;
+/// Token time-to-live in seconds (14 days).
+pub const TOKEN_TTL_SECS: u64 = 14 * 24 * 3600;
 
 /// A stored token record.
 #[allow(dead_code)]


### PR DESCRIPTION
## Summary
- Token TTL: 30 days → **14 days** (stolen tokens expire sooner)
- Client refresh threshold: 14 days → **3 days** (active clients refresh early, well before expiry)
- Fixed stale doc comment in `manager.rs` (said "20 hours", now says "3 days")

Supersedes #80 — that PR proposed 24h TTL which would break the use case of paired desktops left unused for a week. 14 days is the sweet spot: short enough to limit exposure of stolen tokens, long enough to survive extended inactivity.

Web client (`App.tsx`) uses dynamic `75% of TTL` scheduling — no changes needed there.

## Files changed
- `src/remote/auth.rs` — `TOKEN_TTL_SECS`
- `crates/okena-core/src/client/types.rs` — `TOKEN_REFRESH_AGE_SECS`
- `crates/okena-remote-client/src/manager.rs` — doc comment fix

## Test plan
- [x] `cargo test` — 32 tests pass
- [ ] Verify existing paired clients refresh correctly after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)