### PR TITLE
feat: add CreateWorktree API action

### DIFF
--- a/crates/okena-core/src/api.rs
+++ b/crates/okena-core/src/api.rs
@@ -259,6 +259,12 @@ pub enum ActionRequest {
     ReloadServices {
         project_id: String,
     },
+    CreateWorktree {
+        project_id: String,
+        branch: String,
+        #[serde(default)]
+        create_branch: bool,
+    },
 }
 
 /// POST /v1/pair request

--- a/crates/okena-git/src/lib.rs
+++ b/crates/okena-git/src/lib.rs
@@ -10,6 +10,8 @@ pub use repository::{
     get_available_branches_for_worktree,
     get_repo_root,
     resolve_git_root_and_subdir,
+    compute_target_paths,
+    project_path_in_worktree,
     has_uncommitted_changes,
     get_current_branch,
     get_default_branch,

--- a/src/action_dispatch.rs
+++ b/src/action_dispatch.rs
@@ -564,5 +564,14 @@ fn strip_remote_ids(action: ActionRequest, connection_id: &str) -> ActionRequest
         ActionRequest::ReloadServices { project_id } => ActionRequest::ReloadServices {
             project_id: s(&project_id),
         },
+        ActionRequest::CreateWorktree {
+            project_id,
+            branch,
+            create_branch,
+        } => ActionRequest::CreateWorktree {
+            project_id: s(&project_id),
+            branch,
+            create_branch,
+        },
     }
 }

--- a/src/workspace/actions/execute.rs
+++ b/src/workspace/actions/execute.rs
@@ -368,6 +368,35 @@ pub fn execute_action(
         | ActionRequest::ReloadServices { .. } => {
             ActionResult::Err("service actions must be handled via ServiceManager".to_string())
         }
+        ActionRequest::CreateWorktree { project_id, branch, create_branch } => {
+            let project = match ws.project(&project_id) {
+                Some(p) => p,
+                None => return ActionResult::Err(format!("project not found: {}", project_id)),
+            };
+            let project_path = std::path::PathBuf::from(&project.path);
+            let (git_root, subdir) = okena_git::resolve_git_root_and_subdir(&project_path);
+            let path_template = settings(cx).worktree.path_template.clone();
+            let (worktree_path, wt_project_path) = okena_git::compute_target_paths(&git_root, &subdir, &path_template, &branch);
+            let global_hooks = settings(cx).hooks.clone();
+
+            match ws.create_worktree_project(&project_id, &branch, &git_root, &worktree_path, &wt_project_path, create_branch, &global_hooks, cx) {
+                Ok(new_project_id) => {
+                    let result = spawn_uninitialized_terminals(ws, &new_project_id, backend, terminals, cx);
+                    let terminal_id = ws.project(&new_project_id)
+                        .and_then(|p| p.layout.as_ref())
+                        .and_then(|l| find_first_terminal_id(l));
+                    match result {
+                        ActionResult::Ok(_) => ActionResult::Ok(Some(serde_json::json!({
+                            "project_id": new_project_id,
+                            "terminal_id": terminal_id,
+                            "path": wt_project_path,
+                        }))),
+                        err => err,
+                    }
+                }
+                Err(e) => ActionResult::Err(e),
+            }
+        }
     }
 }
 
@@ -506,6 +535,16 @@ pub fn spawn_uninitialized_terminals(
     }
 
     ActionResult::Ok(None)
+}
+
+/// Find the first terminal_id in a layout tree (depth-first).
+fn find_first_terminal_id(node: &LayoutNode) -> Option<String> {
+    match node {
+        LayoutNode::Terminal { terminal_id, .. } => terminal_id.clone(),
+        LayoutNode::Split { children, .. } | LayoutNode::Tabs { children, .. } => {
+            children.iter().find_map(find_first_terminal_id)
+        }
+    }
 }
 
 /// Find the layout path for a terminal within a project.


### PR DESCRIPTION
## Summary

- Add `CreateWorktree` variant to `ActionRequest` API enum with `project_id`, `branch`, and optional `create_branch` fields
- Implement the action handler: resolves git root, computes worktree target paths, creates the worktree project, spawns terminals, and returns `project_id`, `terminal_id`, and `path`
- Re-export `compute_target_paths` and `project_path_in_worktree` from `okena-git`
- Wire up `strip_remote_ids` for the new action variant

## Test plan

- [ ] Call `CreateWorktree` via API with an existing branch — verify worktree is created and terminals spawn
- [ ] Call with `create_branch: true` and a new branch name — verify branch is created
- [ ] Call with an invalid `project_id` — verify error response
- [ ] Verify remote connections strip project IDs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)