### PR TITLE
fix: split above tab group instead of inside active tab

### DIFF
--- a/crates/okena-views-terminal/src/layout/tabs/mod.rs
+++ b/crates/okena-views-terminal/src/layout/tabs/mod.rs
@@ -99,17 +99,10 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
             .child(
                 header_button_base(HeaderAction::SplitVertical, &id_suffix, ButtonSize::COMPACT, &t, None, None)
                     .on_click(move |_, _window, cx| {
-                        let child_path = if ctx_split_v.standalone {
-                            ctx_split_v.layout_path.clone()
-                        } else {
-                            let mut p = ctx_split_v.layout_path.clone();
-                            p.push(ctx_split_v.active_tab);
-                            p
-                        };
                         if let Some(ref dispatcher) = ctx_split_v.action_dispatcher {
                             dispatcher.dispatch(okena_core::api::ActionRequest::SplitTerminal {
                                 project_id: ctx_split_v.project_id.clone(),
-                                path: child_path,
+                                path: ctx_split_v.layout_path.clone(),
                                 direction: SplitDirection::Vertical,
                             }, cx);
                         }
@@ -118,17 +111,10 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
             .child(
                 header_button_base(HeaderAction::SplitHorizontal, &id_suffix, ButtonSize::COMPACT, &t, None, None)
                     .on_click(move |_, _window, cx| {
-                        let child_path = if ctx_split_h.standalone {
-                            ctx_split_h.layout_path.clone()
-                        } else {
-                            let mut p = ctx_split_h.layout_path.clone();
-                            p.push(ctx_split_h.active_tab);
-                            p
-                        };
                         if let Some(ref dispatcher) = ctx_split_h.action_dispatcher {
                             dispatcher.dispatch(okena_core::api::ActionRequest::SplitTerminal {
                                 project_id: ctx_split_h.project_id.clone(),
-                                path: child_path,
+                                path: ctx_split_h.layout_path.clone(),
                                 direction: SplitDirection::Horizontal,
                             }, cx);
                         }

--- a/crates/okena-workspace/src/actions/layout.rs
+++ b/crates/okena-workspace/src/actions/layout.rs
@@ -39,11 +39,33 @@ impl Workspace {
     ) {
         log::info!("Workspace::split_terminal called for project {} at path {:?}", project_id, path);
 
+        // If the target node is inside a Tabs container, split the Tabs container
+        // instead of splitting inside the tab. This avoids nested splits within tabs
+        // which creates a clunky UI.
+        let split_path = if let Some(project) = self.project(project_id) {
+            if let Some(ref layout) = project.layout {
+                if path.len() >= 1 {
+                    let parent_path = &path[..path.len() - 1];
+                    if let Some(LayoutNode::Tabs { .. }) = layout.get_at_path(parent_path) {
+                        parent_path.to_vec()
+                    } else {
+                        path.to_vec()
+                    }
+                } else {
+                    path.to_vec()
+                }
+            } else {
+                path.to_vec()
+            }
+        } else {
+            path.to_vec()
+        };
+
         // Perform the split and find the new terminal's path after normalization.
         let new_path = if let Some(project) = self.project_mut(project_id) {
             if let Some(ref mut layout) = project.layout {
-                if let Some(node) = layout.get_at_path_mut(path) {
-                    log::info!("Found node at path, splitting...");
+                if let Some(node) = layout.get_at_path_mut(&split_path) {
+                    log::info!("Found node at path {:?}, splitting...", split_path);
                     let old_node = node.clone();
                     *node = LayoutNode::Split {
                         direction,


### PR DESCRIPTION
## Summary
- When splitting a terminal inside a tab group, the split now wraps the entire Tabs container rather than nesting a split inside the active tab
- Fixes clunky UI where tabs would contain inner splits with their own sub-tabs appearance
- Centralizes the tab-escape logic in `split_terminal()` so both keyboard shortcuts and tab bar buttons behave consistently

## Test plan
- [ ] Open a tab group with multiple tabs, press split → new terminal appears beside the tab group, not inside a tab
- [ ] Split a standalone terminal (no tabs) → works as before
- [ ] Split inside an existing split (no tabs involved) → works as before
- [ ] Drag & drop a pane into a tab → still allows creating splits inside tabs via intentional gesture

🤖 Generated with [Claude Code](https://claude.com/claude-code)