### PR TITLE
fix: session manager inputs not focusable/typeable on Windows

### DIFF
--- a/crates/okena-ui/src/simple_input.rs
+++ b/crates/okena-ui/src/simple_input.rs
@@ -896,7 +896,7 @@ impl Render for SimpleInputState {
         };
 
         div()
-            .id("simple-input")
+            .id(ElementId::from(&focus_handle))
             .track_focus(&focus_handle)
             .relative()
             .flex()

--- a/src/views/overlays/session_manager/render.rs
+++ b/src/views/overlays/session_manager/render.rs
@@ -509,8 +509,8 @@ impl Render for SessionManager {
         let error_message = self.error_message.clone();
         let active_tab = self.active_tab;
 
-        // Focus on first render
-        if !focus_handle.is_focused(window) {
+        // Focus on first open, but don't steal focus from our own children (e.g. inputs)
+        if !focus_handle.contains_focused(window, cx) {
             window.focus(&focus_handle, cx);
         }
 


### PR DESCRIPTION
## Problem

On Windows, clicking into any text input inside the Session Manager modal (new session name, export path, import path, rename) would immediately lose focus — making it impossible to type anything and save session becasue name is required.

## Root Cause

`SessionManager::render()` called `window.focus(&focus_handle, cx)` whenever `!focus_handle.is_focused(window)`. Since clicking a child input moves focus to that input (not to the Session Manager itself), every re-render triggered by input state changes would steal focus back to the Session Manager container, clearing the input's focus.

## Changes

### `src/views/overlays/session_manager/render.rs`
Changed the focus-guard condition from:
```rust
if !focus_handle.is_focused(window) {
```
to:
```rust
if !focus_handle.contains_focused(window, cx) {
```
This grabs focus when the Session Manager first opens (nothing within it is focused), but does **not** steal focus from its own child inputs during re-renders.

### `crates/okena-ui/src/simple_input.rs`
Changed element ID from hardcoded `"simple-input"` to `ElementId::from(&focus_handle)`. When multiple `SimpleInput` instances exist simultaneously (as in Session Manager), the hardcoded ID caused GPUI element state collisions. Each instance now gets a unique ID derived from its focus handle.

## Testing

- [x] Open Session Manager on Windows — "Enter session name" field is now clickable and focusable
- [x] Creating a new session succeeds without triggering _"Session name cannot be empty"_
- [x] Multiple `SimpleInput` instances on the same screen all respond to clicks independently
- [x] Multiple `SimpleInput` is working on different options
- [ ] Existing behaviour on macOS/Linux is unchanged
