### PR TITLE
fix: make manage-worktrees popover list scrollable

### DIFF
--- a/crates/okena-views-sidebar/src/worktree_list.rs
+++ b/crates/okena-views-sidebar/src/worktree_list.rs
@@ -110,24 +110,33 @@ impl Render for WorktreeListPopover {
         let panel = okena_ui::popover::popover_panel("worktree-list-panel", &t)
             .w(px(280.0))
             .max_h(px(400.0))
+            .flex()
+            .flex_col()
             .child(
                 div()
+                    .flex_shrink_0()
                     .text_size(ui_text_ms(cx))
                     .font_weight(FontWeight::SEMIBOLD)
                     .text_color(rgb(t.text_secondary))
                     .pb(px(6.0))
                     .child("WORKTREES")
             )
-            .when(worktrees.is_empty(), |d| {
-                d.child(
-                    div()
-                        .text_size(ui_text_md(cx))
-                        .text_color(rgb(t.text_muted))
-                        .py(px(8.0))
-                        .child("No worktrees found")
-                )
-            })
-            .children(worktrees.into_iter().map(|(wt_path, branch, is_tracked)| {
+            .child(
+                div()
+                    .id("worktree-list-scroll")
+                    .flex_1()
+                    .min_h_0()
+                    .overflow_y_scroll()
+                    .when(worktrees.is_empty(), |d| {
+                        d.child(
+                            div()
+                                .text_size(ui_text_md(cx))
+                                .text_color(rgb(t.text_muted))
+                                .py(px(8.0))
+                                .child("No worktrees found")
+                        )
+                    })
+                    .children(worktrees.into_iter().map(|(wt_path, branch, is_tracked)| {
                 let project_id = self.project_id.clone();
                 let wt_path_clone = wt_path.clone();
                 let branch_clone = branch.clone();
@@ -198,7 +207,8 @@ impl Render for WorktreeListPopover {
                                     .child(branch.clone())
                             )
                     )
-            }));
+            }))
+            );
 
         let position = self.position;
 


### PR DESCRIPTION
## Summary
- Right-click project → "Manage worktrees" opened a popover with `max_h(400px)` but no scrollable container, so long worktree lists rendered past the panel bounds and off the window edge, making the bottom entries unclickable
- Wrapped the list rows in a `flex_1 / min_h_0 / overflow_y_scroll` div and made the panel a flex column with a pinned "WORKTREES" header
- `snap_to_window()` can now correctly reposition the popover because its layout size actually respects the 400px cap (same pattern already used by `dropdown_overlay`)

## Test plan
- [x] `cargo check -p okena-views-sidebar` passes
- [ ] With a project that has many worktrees (≥15), right-click → "Manage worktrees" — all entries are reachable via scroll, none clipped off-window
- [ ] With a short list (2–3 worktrees), the popover shrinks to fit content (no empty scroll area)
- [ ] Popover opened near the bottom edge of the window snaps upward and stays fully on-screen
- [ ] Clicking a checkbox toggles worktree visibility as before; scrolling the list does not close the popover
