### PR TITLE
fix: kill orphaned terminals when deleting a project

### DIFF
--- a/crates/okena-workspace/src/actions/project.rs
+++ b/crates/okena-workspace/src/actions/project.rs
@@ -204,6 +204,18 @@ impl Workspace {
 
     /// Delete a project
     pub fn delete_project(&mut self, project_id: &str, global_hooks: &HooksConfig, cx: &mut Context<Self>) {
+        // Queue all project terminals for killing before removing state.
+        // Okena (which owns PtyManager) drains this queue via observer.
+        if let Some(project) = self.project(project_id) {
+            let mut kill_ids: Vec<String> = Vec::new();
+            if let Some(layout) = &project.layout {
+                kill_ids.extend(layout.collect_terminal_ids());
+            }
+            kill_ids.extend(project.hook_terminals.keys().cloned());
+            kill_ids.extend(project.service_terminals.values().cloned());
+            self.queue_terminal_kills(kill_ids);
+        }
+
         // Capture project info before removal for the hook
         let folder = self.folder_for_project_or_parent(project_id);
         let hook_folder_id = folder.map(|f| f.id.clone());

--- a/crates/okena-workspace/src/state.rs
+++ b/crates/okena-workspace/src/state.rs
@@ -46,6 +46,8 @@ pub struct Workspace {
     /// Transient folder filter — when set, only projects from this folder are shown.
     /// Not serialized; resets to None on restart.
     pub active_folder_filter: Option<String>,
+    /// Terminal IDs queued for killing by the app layer (drained by Okena observer).
+    pending_terminal_kills: Vec<String>,
 }
 
 impl Workspace {
@@ -58,6 +60,7 @@ impl Workspace {
             access_history: ProjectAccessHistory::new(),
             data_version: 0,
             active_folder_filter: None,
+            pending_terminal_kills: Vec::new(),
         }
     }
 
@@ -134,6 +137,16 @@ impl Workspace {
 
     pub fn finish_closing_project(&mut self, project_id: &str) {
         self.lifecycle.finish_closing(project_id);
+    }
+
+    // === Terminal kill queue ===
+
+    pub fn queue_terminal_kills(&mut self, ids: impl IntoIterator<Item = String>) {
+        self.pending_terminal_kills.extend(ids);
+    }
+
+    pub fn drain_pending_terminal_kills(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.pending_terminal_kills)
     }
 
     // === RemoteSyncState conveniences ===

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -335,6 +335,19 @@ impl Okena {
             Arc::new(crate::terminal::backend::LocalBackend::new(manager.pty_manager.clone()));
         manager.start_remote_command_loop(bridge_rx, local_backend, cx);
 
+        // Kill orphaned terminals when projects are deleted
+        cx.observe(&workspace, move |this, workspace, cx| {
+            let kills = workspace.update(cx, |ws, _| ws.drain_pending_terminal_kills());
+            if !kills.is_empty() {
+                let mut reg = this.terminals.lock();
+                for tid in &kills {
+                    this.pty_manager.kill(tid);
+                    reg.remove(tid);
+                }
+            }
+        })
+        .detach();
+
         // Set up observer for detached terminals
         cx.observe(&workspace, move |this, workspace, cx| {
             this.handle_detached_terminals_changed(workspace, cx);


### PR DESCRIPTION
## Summary
- When a project is deleted, its layout terminals, hook terminals, and service terminals are now killed instead of left running as orphans
- Uses a queue-based approach: `Workspace` queues terminal IDs for killing, and the `Okena` app-layer observer drains and kills them via `PtyManager`
- Keeps ownership boundaries clean — `Workspace` (which has no access to `PtyManager`) signals intent, `Okena` (which owns `PtyManager`) executes

## Test plan
- [x] Delete a project that has running terminals → verify PTY processes are killed (check `ps` for orphaned shells)
- [ ] Delete an empty project → no crash, no-op
- [x] Delete project with hook/service terminals → those are also cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)