### PR TITLE
fix: cap worktree popover scroll area to viewport height

### DIFF
--- a/crates/okena-views-sidebar/src/worktree_list.rs
+++ b/crates/okena-views-sidebar/src/worktree_list.rs
@@ -108,7 +108,8 @@ impl Render for WorktreeListPopover {
             .collect();
 
         let viewport_h = window.viewport_size().height;
-        let scroll_max_h = (viewport_h - px(120.0)).max(px(160.0)).min(px(500.0));
+        let available = (viewport_h - px(120.0)).max(px(0.0));
+        let scroll_max_h = available.min(px(500.0));
 
         let panel = okena_ui::popover::popover_panel("worktree-list-panel", &t)
             .w(px(280.0))

--- a/crates/okena-views-sidebar/src/worktree_list.rs
+++ b/crates/okena-views-sidebar/src/worktree_list.rs
@@ -107,14 +107,15 @@ impl Render for WorktreeListPopover {
             })
             .collect();
 
+        let viewport_h = window.viewport_size().height;
+        let scroll_max_h = (viewport_h - px(120.0)).max(px(160.0)).min(px(500.0));
+
         let panel = okena_ui::popover::popover_panel("worktree-list-panel", &t)
             .w(px(280.0))
-            .max_h(px(400.0))
             .flex()
             .flex_col()
             .child(
                 div()
-                    .flex_shrink_0()
                     .text_size(ui_text_ms(cx))
                     .font_weight(FontWeight::SEMIBOLD)
                     .text_color(rgb(t.text_secondary))
@@ -124,8 +125,7 @@ impl Render for WorktreeListPopover {
             .child(
                 div()
                     .id("worktree-list-scroll")
-                    .flex_1()
-                    .min_h_0()
+                    .max_h(scroll_max_h)
                     .overflow_y_scroll()
                     .when(worktrees.is_empty(), |d| {
                         d.child(


### PR DESCRIPTION
## Summary

- Worktree popover still rendered rows past the window edge when the project had many worktrees (see screenshot below) — the previous `max_h(400px)` + `flex_1`/`min_h_0` scroll child wasn't constraining the inner list, so rows grew to their content height and overflowed the panel.
- Move `max_h` and `overflow_y_scroll` directly onto the scroll container, and size it from the current viewport height (clamped to `160px..=500px`) so the popover always fits the window and the list is reliably scrollable.

## Test plan

- [ ] Open a project with many worktrees (e.g. monorepo with 30+) and click the manage-worktrees button — verify the popover stays within the window and the list scrolls.
- [ ] Resize the window vertically — verify the popover scroll area shrinks/grows accordingly and never exceeds the viewport.
- [ ] Open the popover for a project with only a few worktrees — verify the panel sizes to content with no scrollbar.

Co-Authored-By: Claude Code


<img width="380" height="826" alt="image" src="https://github.com/user-attachments/assets/77522d59-1d26-49c4-84ad-79a56550e3b3" />
