### PR TITLE
fix: bind cmd-q / ctrl-q to quit action

### DIFF
--- a/src/keybindings/config.rs
+++ b/src/keybindings/config.rs
@@ -31,6 +31,13 @@ impl KeybindingConfig {
 
         // Global keybindings
         bindings.insert(
+            "Quit".to_string(),
+            vec![
+                KeybindingEntry::new("cmd-q", None),
+                KeybindingEntry::new("ctrl-q", None),
+            ],
+        );
+        bindings.insert(
             "ToggleSidebar".to_string(),
             vec![
                 KeybindingEntry::new("cmd-b", None),

--- a/src/keybindings/descriptions.rs
+++ b/src/keybindings/descriptions.rs
@@ -6,7 +6,7 @@ use super::{
     CreateWorktree, FocusActiveProject, FocusDown, FocusLeft, FocusNextTerminal, FocusPrevTerminal, FocusRight,
     FocusSidebar, FocusUp, FullscreenNextTerminal, FullscreenPrevTerminal, InstallUpdate,
     JumpToNextPrompt, JumpToPreviousPrompt,
-    MinimizeTerminal, NewProject, OpenSettingsFile, Paste, ResetZoom, ScrollDown, ScrollUp,
+    MinimizeTerminal, NewProject, OpenSettingsFile, Paste, Quit, ResetZoom, ScrollDown, ScrollUp,
     Search, SearchNext, SearchPrev, SendEscape, ShowCommandPalette, ShowDiffViewer,
     ShowContentSearch, ShowFileSearch, ShowHookLog, ShowKeybindings, ShowProjectSwitcher, ShowSessionManager,
     ShowSettings, ShowThemeSelector, SplitHorizontal, SplitVertical, StartAllServices,
@@ -19,6 +19,15 @@ pub fn get_action_descriptions() -> HashMap<&'static str, ActionDescription> {
     let mut map = HashMap::new();
 
     // Global actions
+    map.insert(
+        "Quit",
+        ActionDescription {
+            name: "Quit",
+            description: "Quit Okena",
+            category: "Global",
+            factory: || Box::new(Quit),
+        },
+    );
     map.insert(
         "Cancel",
         ActionDescription {

--- a/src/keybindings/mod.rs
+++ b/src/keybindings/mod.rs
@@ -260,6 +260,7 @@ fn register_bindings_from_config(cx: &mut App, config: &KeybindingConfig) {
 fn create_keybinding(action: &str, keystroke: &str, context: Option<&str>) -> Option<KeyBinding> {
     // Map action names to actual actions
     match action {
+        "Quit" => Some(KeyBinding::new(keystroke, Quit, context)),
         "Cancel" => Some(KeyBinding::new(keystroke, Cancel, context)),
         "SendEscape" => Some(KeyBinding::new(keystroke, SendEscape, context)),
         "ToggleSidebar" => Some(KeyBinding::new(keystroke, ToggleSidebar, context)),


### PR DESCRIPTION
## Summary

- The `Quit` action, its handler, and the macOS "Quit Okena" menu item were already in place, but no default keybinding was registered for it and `"Quit"` was missing from the `create_keybinding()` dispatcher in `src/keybindings/mod.rs`.
- As a result, **Cmd+Q on macOS did nothing** and the menu item displayed no shortcut (GPUI derives the menu item shortcut from the registered keybinding).
- This PR adds the dispatcher arm, the default `cmd-q` / `ctrl-q` bindings, and a description so the action shows up in the Keyboard Shortcuts overlay.

## Files changed

- `src/keybindings/mod.rs` — added `"Quit"` arm to `create_keybinding()`
- `src/keybindings/config.rs` — added default `cmd-q` / `ctrl-q` entries to `KeybindingConfig::defaults()`
- `src/keybindings/descriptions.rs` — added `Quit` import and description (Global category)

## Migration note

`KeybindingConfig::defaults()` only seeds `keybindings.json` when it does not yet exist. Users who already have a `keybindings.json` will not get the new binding automatically — they need to either delete the file, hit "Reset to defaults" in the keybindings UI, or add the entry by hand. Fresh installs get it out of the box.

## Test plan

- [ ] `cargo build` — clean compile
- [ ] `cargo run` on macOS, press **Cmd+Q** — app quits gracefully
- [ ] macOS "Okena → Quit Okena" menu shows ⌘Q next to it
- [ ] Keyboard Shortcuts overlay (Cmd+K Cmd+S) lists "Quit" under Global with ⌘Q
- [ ] On Linux, **Ctrl+Q** quits the app
- [ ] With dirty workspace state (open terminals), Cmd+Q still flushes saves before exit (existing `quit()` handler in `src/main.rs:69`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)