### PR TITLE
feat: Send to Terminal — selection, file, and commit refs

### DIFF
--- a/crates/okena-core/src/lib.rs
+++ b/crates/okena-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod keys;
 pub mod process;
 pub mod profiles;
 pub mod selection;
+pub mod send_payload;
 pub mod theme;
 pub mod timing;
 pub mod types;

--- a/crates/okena-core/src/send_payload.rs
+++ b/crates/okena-core/src/send_payload.rs
@@ -1,0 +1,258 @@
+//! Shared types for "Send to Terminal" — text or code-block payloads emitted by
+//! viewers (file viewer, diff viewer, commit graph) and consumed by the host
+//! that owns the active terminal.
+//!
+//! Lives in `okena-core` so both the producers (`okena-files`, `okena-views-git`)
+//! and the broker queue type (`okena-workspace`) can refer to it without forming
+//! a dependency cycle.
+
+use std::path::{Path, PathBuf};
+
+/// One file's contribution to a code payload: a path-with-range header followed
+/// by a fenced code block of the selected lines.
+#[derive(Clone, Debug)]
+pub struct CodeBlock {
+    /// Absolute path to the source file. The dispatcher rewrites it relative
+    /// to the receiving terminal's CWD before formatting.
+    pub absolute_path: PathBuf,
+    pub first: usize,
+    pub last: usize,
+    pub text: String,
+}
+
+/// A "Send to Terminal" payload.
+///
+/// - `Code` blocks know their absolute paths so the dispatcher can present them
+///   relative to the terminal's CWD.
+/// - `Text` is pre-formatted (used for commit info).
+/// - `Path` is a file/directory reference; the dispatcher writes it relative to
+///   the terminal's CWD and appends a trailing space so the user can type a
+///   command after.
+#[derive(Clone, Debug)]
+pub enum SendPayload {
+    Code(Vec<CodeBlock>),
+    Text(String),
+    Path(PathBuf),
+}
+
+impl SendPayload {
+    pub fn is_empty(&self) -> bool {
+        match self {
+            SendPayload::Code(blocks) => blocks.is_empty(),
+            SendPayload::Text(s) => s.is_empty(),
+            SendPayload::Path(p) => p.as_os_str().is_empty(),
+        }
+    }
+
+    /// Render the payload into the bytes to paste into the terminal.
+    ///
+    /// `terminal_cwd` (if known) is used to express each `CodeBlock`'s or
+    /// `Path` value relative to where the user's shell is sitting, so
+    /// `cat path:5-7` style references work without copy-pasting from
+    /// elsewhere. Falls back to the absolute path when no CWD is available
+    /// or the file isn't under it.
+    ///
+    /// Trailing newlines are stripped: receivers like Claude/Codex TUIs treat a
+    /// trailing LF inside a bracketed paste as Enter and submit the prompt.
+    /// This is the single home for that invariant — callers don't repeat it.
+    pub fn format(&self, terminal_cwd: Option<&Path>) -> String {
+        let mut out = match self {
+            SendPayload::Code(blocks) => {
+                let rendered: Vec<String> = blocks
+                    .iter()
+                    .map(|b| format_code_block(b, terminal_cwd))
+                    .collect();
+                rendered.join("\n\n")
+            }
+            SendPayload::Text(s) => s.clone(),
+            SendPayload::Path(p) => format!("{} ", relative_to_cwd(p, terminal_cwd)),
+        };
+        while out.ends_with('\n') {
+            out.pop();
+        }
+        out
+    }
+}
+
+fn format_code_block(block: &CodeBlock, terminal_cwd: Option<&Path>) -> String {
+    let display_path = relative_to_cwd(&block.absolute_path, terminal_cwd);
+    let lang = markdown_lang_hint(&block.absolute_path);
+    let header = if block.first == block.last {
+        format!("{}:{}", display_path, block.first)
+    } else {
+        format!("{}:{}-{}", display_path, block.first, block.last)
+    };
+    format!("{}\n```{}\n{}\n```", header, lang, block.text)
+}
+
+/// If `path` lives under `cwd`, return the path component relative to it
+/// (with a leading `./` so it's unambiguously a path even when it has no
+/// directory). Otherwise return the absolute path as-is.
+fn relative_to_cwd(path: &Path, cwd: Option<&Path>) -> String {
+    if let Some(cwd) = cwd {
+        if let Ok(rel) = path.strip_prefix(cwd) {
+            let rel_str = rel.to_string_lossy();
+            if rel_str.is_empty() {
+                return ".".into();
+            }
+            return format!("./{}", rel_str);
+        }
+    }
+    path.to_string_lossy().into_owned()
+}
+
+/// Best-effort language hint for a Markdown code fence.
+///
+/// Tries the file name first (so `Makefile`, `Dockerfile`, `CMakeLists.txt`
+/// get a useful hint), then falls back to the extension. Returns an empty
+/// string when no useful hint applies — yields a bare ```` ``` ```` fence.
+pub fn markdown_lang_hint(path: &Path) -> &'static str {
+    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+        match name {
+            "Makefile" | "makefile" | "GNUmakefile" => return "make",
+            "Dockerfile" | "Containerfile" => return "dockerfile",
+            "CMakeLists.txt" => return "cmake",
+            "Cargo.toml" | "Cargo.lock" => return "toml",
+            "package.json" | "tsconfig.json" | "deno.json" => return "json",
+            _ => {}
+        }
+    }
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    match ext {
+        "rs" => "rust",
+        "ts" => "typescript",
+        "tsx" => "tsx",
+        "js" => "javascript",
+        "jsx" => "jsx",
+        "py" => "python",
+        "go" => "go",
+        "rb" => "ruby",
+        "java" => "java",
+        "kt" | "kts" => "kotlin",
+        "swift" => "swift",
+        "c" | "h" => "c",
+        "cpp" | "cc" | "cxx" | "hpp" | "hh" => "cpp",
+        "cs" => "csharp",
+        "php" => "php",
+        "sh" | "bash" | "zsh" => "bash",
+        "fish" => "fish",
+        "ps1" | "psm1" | "psd1" => "powershell",
+        "sql" => "sql",
+        "json" | "jsonc" | "json5" => "json",
+        "yaml" | "yml" => "yaml",
+        "toml" => "toml",
+        "md" | "markdown" => "markdown",
+        "html" | "htm" => "html",
+        "css" => "css",
+        "scss" | "sass" => "scss",
+        "xml" => "xml",
+        "lua" => "lua",
+        "ex" | "exs" => "elixir",
+        "elm" => "elm",
+        "hs" => "haskell",
+        "ml" | "mli" => "ocaml",
+        "scala" => "scala",
+        "dart" => "dart",
+        "vue" => "vue",
+        "svelte" => "svelte",
+        _ => "",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block(path: &str, first: usize, last: usize, text: &str) -> CodeBlock {
+        CodeBlock {
+            absolute_path: PathBuf::from(path),
+            first,
+            last,
+            text: text.into(),
+        }
+    }
+
+    #[test]
+    fn single_block_with_no_cwd_uses_absolute_path() {
+        let p = SendPayload::Code(vec![block("/proj/src/foo.rs", 5, 5, "let x = 1;")]);
+        let out = p.format(None);
+        assert_eq!(out, "/proj/src/foo.rs:5\n```rust\nlet x = 1;\n```");
+    }
+
+    #[test]
+    fn single_block_uses_cwd_relative_path() {
+        let p = SendPayload::Code(vec![block("/proj/src/foo.rs", 5, 7, "a\nb\nc")]);
+        let out = p.format(Some(Path::new("/proj")));
+        assert_eq!(out, "./src/foo.rs:5-7\n```rust\na\nb\nc\n```");
+    }
+
+    #[test]
+    fn block_outside_cwd_falls_back_to_absolute() {
+        let p = SendPayload::Code(vec![block("/other/src/foo.rs", 1, 1, "x")]);
+        let out = p.format(Some(Path::new("/proj")));
+        assert_eq!(out, "/other/src/foo.rs:1\n```rust\nx\n```");
+    }
+
+    #[test]
+    fn multiple_blocks_joined_with_blank_line() {
+        let p = SendPayload::Code(vec![
+            block("/proj/a.rs", 1, 1, "x"),
+            block("/proj/b.rs", 2, 3, "y\nz"),
+        ]);
+        let out = p.format(Some(Path::new("/proj")));
+        assert_eq!(
+            out,
+            "./a.rs:1\n```rust\nx\n```\n\n./b.rs:2-3\n```rust\ny\nz\n```"
+        );
+    }
+
+    #[test]
+    fn unknown_extension_yields_empty_lang_label() {
+        let p = SendPayload::Code(vec![block("/proj/notes.xyz", 1, 1, "hello")]);
+        let out = p.format(Some(Path::new("/proj")));
+        assert_eq!(out, "./notes.xyz:1\n```\nhello\n```");
+    }
+
+    #[test]
+    fn special_filenames_get_language_hint() {
+        assert_eq!(markdown_lang_hint(Path::new("Makefile")), "make");
+        assert_eq!(markdown_lang_hint(Path::new("/proj/Dockerfile")), "dockerfile");
+        assert_eq!(markdown_lang_hint(Path::new("CMakeLists.txt")), "cmake");
+        assert_eq!(markdown_lang_hint(Path::new("Cargo.toml")), "toml");
+    }
+
+    #[test]
+    fn text_variant_is_passthrough_minus_trailing_lf() {
+        let p = SendPayload::Text("commit abc\n\n    subject\n".into());
+        assert_eq!(p.format(None), "commit abc\n\n    subject");
+    }
+
+    #[test]
+    fn never_ends_with_newline_anywhere() {
+        let cases: Vec<SendPayload> = vec![
+            SendPayload::Text("trailing\n\n\n".into()),
+            SendPayload::Code(vec![block("/p/a.rs", 1, 1, "x\n")]),
+            SendPayload::Code(vec![]),
+        ];
+        for p in cases {
+            assert!(!p.format(None).ends_with('\n'), "{:?}", p);
+        }
+    }
+
+    #[test]
+    fn empty_code_payload_is_empty_string() {
+        let p = SendPayload::Code(vec![]);
+        assert_eq!(p.format(None), "");
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn path_variant_resolves_cwd_relative_with_trailing_space() {
+        let p = SendPayload::Path(PathBuf::from("/proj/src/foo.rs"));
+        assert_eq!(p.format(Some(Path::new("/proj"))), "./src/foo.rs ");
+        assert_eq!(p.format(None), "/proj/src/foo.rs ");
+    }
+}

--- a/crates/okena-files/src/file_viewer/context_menu.rs
+++ b/crates/okena-files/src/file_viewer/context_menu.rs
@@ -396,7 +396,8 @@ impl FileViewer {
         let position = menu.position;
         let is_folder = menu.target.is_folder();
 
-        let abs_path = menu.target.abs_path().to_string_lossy().to_string();
+        let abs_path_buf = menu.target.abs_path().to_path_buf();
+        let abs_path = abs_path_buf.to_string_lossy().to_string();
         let project_root = PathBuf::from(self.project_fs.project_id());
         let rel_path = menu
             .target
@@ -405,6 +406,8 @@ impl FileViewer {
             .unwrap_or(menu.target.abs_path())
             .to_string_lossy()
             .to_string();
+
+        let send_path = if is_folder { None } else { Some(abs_path_buf.clone()) };
 
         Some(
             div()
@@ -432,6 +435,22 @@ impl FileViewer {
                                         this.start_rename(window, cx);
                                     })),
                             )
+                            .when_some(send_path, |d, path| {
+                                d.child(
+                                    menu_item(
+                                        "fv-ctx-send-to-terminal",
+                                        "icons/terminal.svg",
+                                        "Send to Terminal",
+                                        t,
+                                    )
+                                    .on_click(cx.listener(move |this, _, _, cx| {
+                                        this.close_context_menu(cx);
+                                        cx.emit(super::FileViewerEvent::SendToTerminal(
+                                            okena_core::send_payload::SendPayload::Path(path.clone()),
+                                        ));
+                                    })),
+                                )
+                            })
                             .child(
                                 menu_item(
                                     "fv-ctx-copy-rel-path",
@@ -493,6 +512,12 @@ impl FileViewer {
         let position = menu.position;
         let tab_index = menu.tab_index;
 
+        let send_path: Option<PathBuf> = self
+            .tabs
+            .get(tab_index)
+            .filter(|t| !t.is_empty())
+            .map(|tab| tab.file_path.clone());
+
         Some(
             div()
                 .id("fv-tab-context-menu-backdrop")
@@ -515,6 +540,24 @@ impl FileViewer {
                 .child(deferred(
                     anchored().position(position).snap_to_window().child(
                         context_menu_panel("fv-tab-context-menu", t)
+                            .when_some(send_path, |d, path| {
+                                d.child(
+                                    menu_item(
+                                        "fv-tab-ctx-send-to-terminal",
+                                        "icons/terminal.svg",
+                                        "Send to Terminal",
+                                        t,
+                                    )
+                                    .on_click(cx.listener(move |this, _, _, cx| {
+                                        this.tab_context_menu = None;
+                                        cx.emit(super::FileViewerEvent::SendToTerminal(
+                                            okena_core::send_payload::SendPayload::Path(path.clone()),
+                                        ));
+                                        cx.notify();
+                                    })),
+                                )
+                                .child(menu_separator(t))
+                            })
                             .child(
                                 menu_item("fv-tab-ctx-close", "icons/close.svg", "Close", t)
                                     .on_click(cx.listener(move |this, _, _, cx| {

--- a/crates/okena-files/src/file_viewer/mod.rs
+++ b/crates/okena-files/src/file_viewer/mod.rs
@@ -285,6 +285,8 @@ pub struct FileViewer {
     pub(super) blame_provider: Option<std::sync::Arc<dyn BlameProvider>>,
     /// Whether the blame gutter column is visible. Persisted in settings.
     pub(super) blame_visible: bool,
+    /// Right-click context menu over a non-empty text selection.
+    pub(super) selection_context_menu: Option<Point<Pixels>>,
 }
 
 impl FileViewer {
@@ -347,6 +349,7 @@ impl FileViewer {
             is_detached: false,
             blame_provider,
             blame_visible,
+            selection_context_menu: None,
         };
 
         // Kick off the root directory listing and any expanded ancestors so
@@ -400,6 +403,7 @@ impl FileViewer {
             is_detached: false,
             blame_provider,
             blame_visible,
+            selection_context_menu: None,
         };
         viewer.fetch_initial_dirs(cx);
         viewer
@@ -792,6 +796,9 @@ pub enum FileViewerEvent {
     OpenCommit(String),
     /// User toggled the blame gutter — host persists the preference.
     BlamePreferenceChanged(bool),
+    /// User clicked "Send to terminal" on a selection. Carries the structured
+    /// payload; the host formats it (relative to terminal CWD) before pasting.
+    SendToTerminal(okena_core::send_payload::SendPayload),
 }
 
 impl EventEmitter<FileViewerEvent> for FileViewer {}

--- a/crates/okena-files/src/file_viewer/render.rs
+++ b/crates/okena-files/src/file_viewer/render.rs
@@ -122,9 +122,18 @@ impl FileViewer {
             })
             .on_mouse_up(
                 MouseButton::Left,
-                cx.listener(|this, _, _window, cx| {
+                cx.listener(|this, _: &MouseUpEvent, _window, cx| {
                     this.active_tab_mut().selection.finish();
                     cx.notify();
+                }),
+            )
+            .on_mouse_down(
+                MouseButton::Right,
+                cx.listener(|this, event: &MouseDownEvent, _window, cx| {
+                    if this.active_tab().selection.normalized_non_empty().is_some() {
+                        this.selection_context_menu = Some(event.position);
+                        cx.notify();
+                    }
                 }),
             )
             .child(
@@ -831,6 +840,11 @@ impl Render for FileViewer {
             .when(!is_preview_mode, |d| d.cursor(CursorStyle::IBeam))
             .on_action(cx.listener(|this, _: &Cancel, window, cx| {
                 // Dismiss overlays in priority order before default close behavior
+                if this.selection_context_menu.is_some() {
+                    this.selection_context_menu = None;
+                    cx.notify();
+                    return;
+                }
                 if this.tab_context_menu.is_some() {
                     this.tab_context_menu = None;
                     cx.notify();
@@ -859,8 +873,7 @@ impl Render for FileViewer {
                     this.active_tab_mut().markdown_selection.clear();
                     cx.notify();
                 } else if this.active_tab().selection.normalized_non_empty().is_some() {
-                    this.active_tab_mut().selection.clear();
-                    cx.notify();
+                    this.clear_source_selection(cx);
                 } else {
                     this.close(cx);
                 }
@@ -1628,6 +1641,67 @@ impl Render for FileViewer {
             )
             .when_some(self.render_context_menu(&t, cx), |d, menu| d.child(menu))
             .when_some(self.render_tab_context_menu(&t, cx), |d, menu| d.child(menu))
+            .when_some(self.render_selection_context_menu(&t, cx), |d, menu| d.child(menu))
             .when_some(self.render_delete_confirm(&t, cx), |d, dialog| d.child(dialog))
+    }
+}
+
+impl FileViewer {
+    /// Right-click context menu over a non-empty text selection. Offers
+    /// "Send to Terminal" and "Copy".
+    fn render_selection_context_menu(
+        &self,
+        t: &ThemeColors,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
+        let position = self.selection_context_menu?;
+        self.active_tab().selection.normalized_non_empty()?;
+
+        let panel = okena_ui::menu::context_menu_panel("fv-selection-context-menu", t)
+            .child(
+                okena_ui::menu::menu_item(
+                    "fv-sel-ctx-send",
+                    "icons/terminal.svg",
+                    "Send to Terminal",
+                    t,
+                )
+                .on_click(cx.listener(|this, _, _, cx| {
+                    this.selection_context_menu = None;
+                    this.send_selection_to_terminal(cx);
+                })),
+            )
+            .child(okena_ui::menu::menu_separator(t))
+            .child(
+                okena_ui::menu::menu_item("fv-sel-ctx-copy", "icons/copy.svg", "Copy", t)
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.selection_context_menu = None;
+                        this.copy_selection(cx);
+                    })),
+            );
+
+        Some(
+            div()
+                .id("fv-selection-context-menu-backdrop")
+                .absolute()
+                .inset_0()
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(|this, _, _, cx| {
+                        this.selection_context_menu = None;
+                        cx.notify();
+                    }),
+                )
+                .on_mouse_down(
+                    MouseButton::Right,
+                    cx.listener(|this, _, _, cx| {
+                        this.selection_context_menu = None;
+                        cx.notify();
+                    }),
+                )
+                .child(deferred(
+                    anchored().position(position).snap_to_window().child(panel),
+                ))
+                .into_any_element(),
+        )
     }
 }

--- a/crates/okena-files/src/file_viewer/selection.rs
+++ b/crates/okena-files/src/file_viewer/selection.rs
@@ -1,8 +1,9 @@
 //! Selection, clipboard, scrollbar, and navigation for the file viewer.
 
 use crate::code_view::{get_selected_text, start_scrollbar_drag, update_scrollbar_drag};
-use crate::selection::{copy_to_clipboard, Selection1DExtension};
+use crate::selection::{copy_to_clipboard, Selection1DExtension, Selection2DNonEmpty};
 use gpui::*;
+use okena_core::send_payload::{CodeBlock, SendPayload};
 
 use super::{DisplayMode, FileViewer, FileViewerEvent};
 
@@ -34,6 +35,51 @@ impl FileViewer {
     /// Copy selected text to clipboard.
     pub(super) fn copy_selection(&self, cx: &mut Context<Self>) {
         copy_to_clipboard(cx, self.get_selected_text());
+    }
+
+    /// Build a single-block code payload from the active tab's selection.
+    /// Returns None for empty selections or unloaded tabs. The block's path is
+    /// the absolute file path on disk; the dispatcher rewrites it relative to
+    /// the receiving terminal's CWD at format time.
+    pub(super) fn selection_to_send_payload(&self) -> Option<SendPayload> {
+        let tab = self.active_tab();
+        if tab.is_empty() {
+            return None;
+        }
+        let ((start_line, _), (end_line, _)) = tab.selection.normalized_non_empty()?;
+
+        // Convert from 0-based line index to 1-based, clamp to file length.
+        let last_line_idx = tab.line_count.checked_sub(1)?;
+        let first_idx = start_line.min(last_line_idx);
+        let last_idx = end_line.min(last_line_idx);
+
+        let text: String = tab.highlighted_lines
+            .get(first_idx..=last_idx)?
+            .iter()
+            .map(|l| l.plain_text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        Some(SendPayload::Code(vec![CodeBlock {
+            absolute_path: tab.file_path.clone(),
+            first: first_idx + 1,
+            last: last_idx + 1,
+            text,
+        }]))
+    }
+
+    /// Emit SendToTerminal with the active selection's payload.
+    pub(super) fn send_selection_to_terminal(&mut self, cx: &mut Context<Self>) {
+        if let Some(payload) = self.selection_to_send_payload() {
+            cx.emit(FileViewerEvent::SendToTerminal(payload));
+        }
+        cx.notify();
+    }
+
+    /// Clear the active tab's source selection.
+    pub(super) fn clear_source_selection(&mut self, cx: &mut Context<Self>) {
+        self.active_tab_mut().selection.clear();
+        cx.notify();
     }
 
     /// Select all text.

--- a/crates/okena-services/src/port_detect.rs
+++ b/crates/okena-services/src/port_detect.rs
@@ -246,6 +246,7 @@ fn get_listening_port_pairs_windows() -> Vec<(u32, u16)> {
 // ---------------------------------------------------------------------------
 
 /// Parse `ss -tlnp` output into (pid, port) pairs.
+#[cfg(any(target_os = "linux", test))]
 pub(crate) fn parse_ss_output(stdout: &str) -> Vec<(u32, u16)> {
     let mut pairs = Vec::new();
     for line in stdout.lines() {
@@ -259,6 +260,7 @@ pub(crate) fn parse_ss_output(stdout: &str) -> Vec<(u32, u16)> {
     pairs
 }
 
+#[cfg(any(target_os = "linux", test))]
 fn extract_pids_from_ss_line(line: &str) -> Vec<u32> {
     let mut pids = Vec::new();
     let mut search = line;
@@ -273,6 +275,7 @@ fn extract_pids_from_ss_line(line: &str) -> Vec<u32> {
     pids
 }
 
+#[cfg(any(target_os = "linux", test))]
 fn extract_port_from_ss_line(line: &str) -> Option<u16> {
     let fields: Vec<&str> = line.split_whitespace().collect();
     if fields.len() < 5 {

--- a/crates/okena-terminal/src/terminal/io.rs
+++ b/crates/okena-terminal/src/terminal/io.rs
@@ -130,24 +130,49 @@ impl Terminal {
         self.had_user_input.store(true, Ordering::Relaxed);
         self.scroll_to_bottom();
 
-        // Convert line endings: \r\n → \r, then \n → \r
-        // Terminals send \r for Enter; shells in bracketed paste mode buffer these.
-        let normalized = text.replace("\r\n", "\r").replace('\n', "\r");
-
         let bracketed = self.term.lock().mode().contains(TermMode::BRACKETED_PASTE);
         if bracketed {
-            // Strip any embedded bracketed paste sequences to prevent escape injection
-            let sanitized = normalized
-                .replace("\x1b[200~", "")
-                .replace("\x1b[201~", "");
-            let mut buf = Vec::with_capacity(sanitized.len() + 12);
-            buf.extend_from_slice(b"\x1b[200~");
-            buf.extend_from_slice(sanitized.as_bytes());
-            buf.extend_from_slice(b"\x1b[201~");
-            self.transport.send_input(&self.terminal_id, &buf);
+            self.write_bracketed_paste(text);
         } else {
+            // No bracketed paste mode: convert all newlines to CR so each line lands
+            // as Enter for the shell. (Multi-line content will execute line-by-line.)
+            let normalized = text.replace("\r\n", "\r").replace('\n', "\r");
             self.transport.send_input(&self.terminal_id, normalized.as_bytes());
         }
+    }
+
+    /// Send text wrapped in bracketed-paste sequences regardless of whether the
+    /// receiving program enabled DECSET 2004. Used by programmatic-paste paths
+    /// (e.g. "Send to Terminal") where the alacritty-tracked mode flag is
+    /// unreliable: multiplexers, prompt frameworks that toggle the mode, and
+    /// fresh terminals where the shell hasn't sent its startup sequence yet all
+    /// cause `BRACKETED_PASTE` to read false even when the receiver supports it.
+    /// Receivers that don't support bracketed paste will see the bracket bytes
+    /// as literal text — annoying but recoverable, vs. multi-line content
+    /// executing each line as a separate command.
+    pub fn send_paste_force_bracketed(&self, text: &str) {
+        self.had_user_input.store(true, Ordering::Relaxed);
+        self.scroll_to_bottom();
+        self.write_bracketed_paste(text);
+    }
+
+    /// Common bracketed-paste byte assembly for both `send_paste` (when mode is
+    /// active) and `send_paste_force_bracketed` (always).
+    fn write_bracketed_paste(&self, text: &str) {
+        // Inside a bracketed paste, newlines should land as literal LF — readers
+        // (zsh's zle, Claude/Codex TUIs, etc.) treat the content as one paste and
+        // CR would be misread as Enter, prematurely submitting the line/prompt.
+        let normalized = text.replace("\r\n", "\n");
+        // Strip any embedded paste markers so callers can't smuggle an early
+        // `\x1b[201~` and break out into raw input.
+        let sanitized = normalized
+            .replace("\x1b[200~", "")
+            .replace("\x1b[201~", "");
+        let mut buf = Vec::with_capacity(sanitized.len() + 12);
+        buf.extend_from_slice(b"\x1b[200~");
+        buf.extend_from_slice(sanitized.as_bytes());
+        buf.extend_from_slice(b"\x1b[201~");
+        self.transport.send_input(&self.terminal_id, &buf);
     }
 
     /// Send raw bytes to the PTY

--- a/crates/okena-views-git/src/commit_send.rs
+++ b/crates/okena-views-git/src/commit_send.rs
@@ -1,0 +1,171 @@
+//! Shared formatting for "Send commit to terminal" — produces a `git log`-style block
+//! used by the diff viewer and the commit graph context menu.
+
+use okena_git::{format_relative_time, CommitLogEntry};
+
+/// Format a commit reference for pasting into a terminal. Mirrors the
+/// `git log` default output:
+///
+/// ```text
+/// commit <hash> (HEAD -> main)
+/// Author: Jane Doe
+/// Date:   2 days ago
+///
+///     Subject line
+/// ```
+///
+/// The returned string may end with a newline; the central send-to-terminal
+/// dispatcher (`SendPayload::format`) strips trailing LF before pasting so the
+/// bracketed-paste isn't interpreted as Enter by receivers like Claude/Codex.
+pub fn format_commit_send_text(
+    hash: &str,
+    message: Option<&str>,
+    author: Option<&str>,
+    timestamp: Option<i64>,
+    refs: &[String],
+) -> String {
+    let mut out = String::new();
+    out.push_str("commit ");
+    out.push_str(hash);
+    if !refs.is_empty() {
+        out.push_str(" (");
+        out.push_str(&refs.join(", "));
+        out.push(')');
+    }
+    out.push('\n');
+    if let Some(author) = author {
+        out.push_str("Author: ");
+        out.push_str(author);
+        out.push('\n');
+    }
+    if let Some(ts) = timestamp {
+        out.push_str("Date:   ");
+        out.push_str(&format_relative_time(ts));
+        out.push('\n');
+    }
+    if let Some(msg) = message {
+        let trimmed = msg.trim();
+        if !trimmed.is_empty() {
+            out.push('\n');
+            let lines: Vec<&str> = trimmed.lines().collect();
+            for (i, line) in lines.iter().enumerate() {
+                out.push_str("    ");
+                out.push_str(line);
+                if i + 1 < lines.len() {
+                    out.push('\n');
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Convenience: format a `CommitLogEntry` for sending.
+pub fn format_commit_entry(entry: &CommitLogEntry) -> String {
+    format_commit_send_text(
+        &entry.hash,
+        Some(&entry.message),
+        Some(&entry.author),
+        Some(entry.timestamp),
+        &entry.refs,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A timestamp far enough in the past that `format_relative_time` produces a
+    /// stable "Nw ago" string regardless of when the test runs.
+    /// (Roughly 30 weeks before the test was written.)
+    const STABLE_PAST_TIMESTAMP: i64 = 1_700_000_000;
+
+    #[test]
+    fn bare_hash_produces_single_line() {
+        let s = format_commit_send_text("abc1234", None, None, None, &[]);
+        // Trailing LF is stripped centrally by SendPayload::format.
+        assert_eq!(s, "commit abc1234\n");
+    }
+
+    #[test]
+    fn refs_appended_in_parens_after_hash() {
+        let s = format_commit_send_text(
+            "abc1234",
+            None,
+            None,
+            None,
+            &["HEAD -> main".to_string(), "origin/main".to_string()],
+        );
+        assert_eq!(s, "commit abc1234 (HEAD -> main, origin/main)\n");
+    }
+
+    #[test]
+    fn full_form_matches_git_log_default_layout() {
+        let s = format_commit_send_text(
+            "abc1234",
+            Some("fix the thing"),
+            Some("Jane Doe"),
+            Some(STABLE_PAST_TIMESTAMP),
+            &["HEAD -> main".to_string()],
+        );
+        let mut lines = s.lines();
+        assert_eq!(lines.next(), Some("commit abc1234 (HEAD -> main)"));
+        assert_eq!(lines.next(), Some("Author: Jane Doe"));
+        assert!(lines.next().unwrap().starts_with("Date:"));
+        assert_eq!(lines.next(), Some(""));
+        assert_eq!(lines.next(), Some("    fix the thing"));
+        assert_eq!(lines.next(), None);
+    }
+
+    #[test]
+    fn multi_line_message_is_indented_and_preserved() {
+        let s = format_commit_send_text(
+            "abc1234",
+            Some("subject\n\nfirst body line\nsecond body line"),
+            None,
+            None,
+            &[],
+        );
+        let mut lines = s.lines();
+        assert_eq!(lines.next(), Some("commit abc1234"));
+        assert_eq!(lines.next(), Some(""));
+        assert_eq!(lines.next(), Some("    subject"));
+        assert_eq!(lines.next(), Some("    "));
+        assert_eq!(lines.next(), Some("    first body line"));
+        assert_eq!(lines.next(), Some("    second body line"));
+        assert_eq!(lines.next(), None);
+    }
+
+    #[test]
+    fn whitespace_only_message_is_dropped() {
+        let s = format_commit_send_text("abc1234", Some("   \n\n  "), None, None, &[]);
+        assert_eq!(s, "commit abc1234\n");
+    }
+
+    #[test]
+    fn wrapping_in_send_payload_strips_trailing_lf() {
+        use okena_core::send_payload::SendPayload;
+        let text = format_commit_send_text("abc1234", Some("subject"), None, None, &[]);
+        let formatted = SendPayload::Text(text).format(None);
+        assert!(!formatted.ends_with('\n'), "got: {:?}", formatted);
+        assert!(formatted.ends_with("    subject"));
+    }
+
+    #[test]
+    fn entry_wrapper_uses_all_fields() {
+        let entry = CommitLogEntry {
+            hash: "abc1234".into(),
+            message: "subject".into(),
+            author: "Jane".into(),
+            timestamp: STABLE_PAST_TIMESTAMP,
+            is_merge: false,
+            graph: String::new(),
+            refs: vec!["main".into()],
+        };
+        let s = format_commit_entry(&entry);
+        assert!(s.starts_with("commit abc1234 (main)"));
+        assert!(s.contains("Author: Jane"));
+        assert!(s.contains("Date:"));
+        assert!(s.contains("    subject"));
+    }
+}

--- a/crates/okena-views-git/src/commit_send.rs
+++ b/crates/okena-views-git/src/commit_send.rs
@@ -158,8 +158,7 @@ mod tests {
             message: "subject".into(),
             author: "Jane".into(),
             timestamp: STABLE_PAST_TIMESTAMP,
-            is_merge: false,
-            graph: String::new(),
+            parents: vec![],
             refs: vec!["main".into()],
         };
         let s = format_commit_entry(&entry);

--- a/crates/okena-views-git/src/diff_viewer/context_menu.rs
+++ b/crates/okena-views-git/src/diff_viewer/context_menu.rs
@@ -13,6 +13,7 @@ use okena_core::theme::ThemeColors;
 use okena_git::DiffMode;
 use okena_ui::button::button;
 use okena_ui::icon_button::icon_button_sized;
+use okena_files::selection::Selection2DNonEmpty;
 use okena_ui::menu::{context_menu_panel, menu_item, menu_item_with_color, menu_separator};
 use okena_ui::modal::{modal_backdrop, modal_content};
 use okena_ui::tokens::{ui_text_md, ui_text_ms, ui_text_xl};
@@ -65,6 +66,15 @@ pub(crate) struct DiscardConfirmState {
     pub error_message: Option<String>,
 }
 
+/// Right-click context menu state for the commit hash.
+pub(crate) struct CommitHashContextMenu {
+    pub position: Point<Pixels>,
+    pub hash: String,
+    /// Formatted "Send to Terminal" payload, computed once at open time so we
+    /// don't re-walk `self.commits` and re-format on every render.
+    pub send_text: String,
+}
+
 impl DiffViewer {
     // ── Menu open/close ─────────────────────────────────────────────────────
 
@@ -84,6 +94,32 @@ impl DiffViewer {
         cx.notify();
     }
 
+    pub(super) fn open_commit_hash_menu(
+        &mut self,
+        position: Point<Pixels>,
+        hash: String,
+        cx: &mut Context<Self>,
+    ) {
+        let entry = self.commits.iter().find(|c| c.hash == hash).cloned();
+        let send_text = match entry {
+            Some(e) => crate::commit_send::format_commit_entry(&e),
+            None => crate::commit_send::format_commit_send_text(
+                &hash,
+                self.commit_message.as_deref(),
+                None,
+                None,
+                &[],
+            ),
+        };
+        self.commit_hash_menu = Some(CommitHashContextMenu { position, hash, send_text });
+        cx.notify();
+    }
+
+    pub(super) fn close_commit_hash_menu(&mut self, cx: &mut Context<Self>) {
+        self.commit_hash_menu = None;
+        cx.notify();
+    }
+
     /// Close the topmost transient UI (confirm modal → menu → selection).
     /// Returns `true` if something was dismissed, so the caller knows not to
     /// close the whole diff viewer.
@@ -100,6 +136,16 @@ impl DiffViewer {
         }
         if self.context_menu.is_some() {
             self.context_menu = None;
+            cx.notify();
+            return true;
+        }
+        if self.commit_hash_menu.is_some() {
+            self.commit_hash_menu = None;
+            cx.notify();
+            return true;
+        }
+        if self.selection_context_menu.is_some() {
+            self.selection_context_menu = None;
             cx.notify();
             return true;
         }
@@ -242,7 +288,129 @@ impl DiffViewer {
         if let Some(el) = self.render_discard_confirm(t, cx) {
             return Some(el);
         }
-        self.render_context_menu(t, cx)
+        if let Some(el) = self.render_context_menu(t, cx) {
+            return Some(el);
+        }
+        if let Some(el) = self.render_commit_hash_menu(t, cx) {
+            return Some(el);
+        }
+        self.render_selection_context_menu(t, cx)
+    }
+
+    /// Render the right-click context menu over a non-empty text selection.
+    /// Offers "Send to Terminal" and "Copy".
+    fn render_selection_context_menu(
+        &self,
+        t: &ThemeColors,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
+        let position = self.selection_context_menu?;
+        self.selection.normalized_non_empty()?;
+
+        let panel = context_menu_panel("dv-selection-context-menu", t)
+            .child(
+                menu_item(
+                    "dv-sel-ctx-send",
+                    "icons/terminal.svg",
+                    "Send to Terminal",
+                    t,
+                )
+                .on_click(cx.listener(|this, _, _, cx| {
+                    this.selection_context_menu = None;
+                    this.send_selection_to_terminal(cx);
+                })),
+            )
+            .child(menu_separator(t))
+            .child(
+                menu_item("dv-sel-ctx-copy", "icons/copy.svg", "Copy", t)
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.selection_context_menu = None;
+                        this.copy_selection(cx);
+                    })),
+            );
+
+        Some(
+            div()
+                .id("dv-selection-context-menu-backdrop")
+                .absolute()
+                .inset_0()
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(|this, _, _, cx| {
+                        this.selection_context_menu = None;
+                        cx.notify();
+                    }),
+                )
+                .on_mouse_down(
+                    MouseButton::Right,
+                    cx.listener(|this, _, _, cx| {
+                        this.selection_context_menu = None;
+                        cx.notify();
+                    }),
+                )
+                .child(deferred(
+                    anchored().position(position).snap_to_window().child(panel),
+                ))
+                .into_any_element(),
+        )
+    }
+
+    fn render_commit_hash_menu(
+        &self,
+        t: &ThemeColors,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
+        let menu = self.commit_hash_menu.as_ref()?;
+        let position = menu.position;
+        let hash_for_copy = menu.hash.clone();
+        let send_text = menu.send_text.clone();
+
+        let panel = context_menu_panel("dv-commit-hash-context-menu", t)
+            .child(
+                menu_item(
+                    "dv-ctx-send-commit-hash",
+                    "icons/terminal.svg",
+                    "Send to Terminal",
+                    t,
+                )
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.close_commit_hash_menu(cx);
+                    cx.emit(super::DiffViewerEvent::SendToTerminal(
+                        okena_core::send_payload::SendPayload::Text(send_text.clone()),
+                    ));
+                })),
+            )
+            .child(menu_separator(t))
+            .child(
+                menu_item("dv-ctx-copy-commit-hash", "icons/copy.svg", "Copy Hash", t)
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        cx.write_to_clipboard(ClipboardItem::new_string(hash_for_copy.clone()));
+                        this.close_commit_hash_menu(cx);
+                    })),
+            );
+
+        Some(
+            div()
+                .id("dv-commit-hash-menu-backdrop")
+                .absolute()
+                .inset_0()
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(|this, _, _, cx| {
+                        this.close_commit_hash_menu(cx);
+                    }),
+                )
+                .on_mouse_down(
+                    MouseButton::Right,
+                    cx.listener(|this, _, _, cx| {
+                        this.close_commit_hash_menu(cx);
+                    }),
+                )
+                .child(deferred(
+                    anchored().position(position).snap_to_window().child(panel),
+                ))
+                .into_any_element(),
+        )
     }
 
     fn render_context_menu(
@@ -314,6 +482,28 @@ impl DiffViewer {
                 )
                 .on_click(cx.listener(|this, _, _, cx| {
                     this.unstage_from_menu(cx);
+                })),
+            );
+            panel = panel.child(menu_separator(t));
+        }
+
+        {
+            let abs_for_send: std::path::PathBuf = abs_path
+                .clone()
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|| std::path::PathBuf::from(&path));
+            panel = panel.child(
+                menu_item(
+                    "dv-ctx-send-to-terminal",
+                    "icons/terminal.svg",
+                    "Send to Terminal",
+                    t,
+                )
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.close_context_menu(cx);
+                    cx.emit(super::DiffViewerEvent::SendToTerminal(
+                        okena_core::send_payload::SendPayload::Path(abs_for_send.clone()),
+                    ));
                 })),
             );
             panel = panel.child(menu_separator(t));

--- a/crates/okena-views-git/src/diff_viewer/line_render.rs
+++ b/crates/okena-views-git/src/diff_viewer/line_render.rs
@@ -8,6 +8,7 @@ use super::DiffViewer;
 use okena_git::DiffLineType;
 use okena_core::theme::ThemeColors;
 use okena_files::code_view::{build_styled_text_with_backgrounds, find_word_boundaries, selection_bg_ranges};
+use okena_files::selection::Selection2DNonEmpty;
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::h_flex;
@@ -339,6 +340,15 @@ impl DiffViewer {
                 cx.listener(|this, _, _window, cx| {
                     this.selection.finish();
                     cx.notify();
+                }),
+            )
+            .on_mouse_down(
+                MouseButton::Right,
+                cx.listener(|this, event: &MouseDownEvent, _window, cx| {
+                    if this.selection.normalized_non_empty().is_some() {
+                        this.selection_context_menu = Some(event.position);
+                        cx.notify();
+                    }
                 }),
             )
             // Left accent bar (fixed width, always present for alignment)

--- a/crates/okena-views-git/src/diff_viewer/mod.rs
+++ b/crates/okena-views-git/src/diff_viewer/mod.rs
@@ -103,6 +103,10 @@ pub struct DiffViewer {
     /// True when this viewer is hosted inside a detached window.
     /// Hides the "detach" button and is set by the detached host.
     pub(super) is_detached: bool,
+    /// Open commit-hash right-click context menu.
+    pub(super) commit_hash_menu: Option<context_menu::CommitHashContextMenu>,
+    /// Right-click context menu over a non-empty text selection.
+    pub(super) selection_context_menu: Option<Point<Pixels>>,
 }
 
 impl DiffViewer {
@@ -161,6 +165,8 @@ impl DiffViewer {
             delete_confirm: None,
             discard_confirm: None,
             is_detached: false,
+            commit_hash_menu: None,
+            selection_context_menu: None,
         };
 
         if !provider.is_git_repo() {
@@ -195,6 +201,9 @@ pub enum DiffViewerEvent {
     Close,
     /// User requested to detach the viewer into a separate OS window.
     Detach,
+    /// User clicked "Send to terminal" on a selection. Carries the structured
+    /// payload; the host formats it (relative to terminal CWD) before pasting.
+    SendToTerminal(okena_core::send_payload::SendPayload),
 }
 
 impl EventEmitter<DiffViewerEvent> for DiffViewer {}

--- a/crates/okena-views-git/src/diff_viewer/render.rs
+++ b/crates/okena-views-git/src/diff_viewer/render.rs
@@ -74,6 +74,8 @@ impl DiffViewer {
                         },
                         |d, hash| {
                             let short = if hash.len() > 7 { hash[..7].to_string() } else { hash.clone() };
+                            let hash_for_click = hash.clone();
+                            let hash_for_rclick = hash.clone();
                             d.child(
                                 div()
                                     .id("commit-hash-copy")
@@ -86,9 +88,15 @@ impl DiffViewer {
                                     .rounded(px(4.0))
                                     .hover(|s| s.bg(rgb(t.bg_hover)))
                                     .on_click(move |_, _, cx| {
-                                        cx.write_to_clipboard(ClipboardItem::new_string(hash.clone()));
+                                        cx.write_to_clipboard(ClipboardItem::new_string(hash_for_click.clone()));
                                     })
-                                    .tooltip(|_window, cx| gpui_component::tooltip::Tooltip::new("Copy commit hash").build(_window, cx))
+                                    .on_mouse_down(
+                                        MouseButton::Right,
+                                        cx.listener(move |this, event: &MouseDownEvent, _, cx| {
+                                            this.open_commit_hash_menu(event.position, hash_for_rclick.clone(), cx);
+                                        }),
+                                    )
+                                    .tooltip(|_window, cx| gpui_component::tooltip::Tooltip::new("Click: copy hash \u{00B7} Right-click: more").build(_window, cx))
                                     .child(short),
                             )
                         },
@@ -328,9 +336,11 @@ impl DiffViewer {
             .when_some(commit.cloned(), |d, commit| {
                 let hash = commit.hash.clone();
                 let short = if hash.len() > 7 { hash[..7].to_string() } else { hash.clone() };
+                let hash_for_click = hash.clone();
+                let hash_for_rclick = hash.clone();
                 let time_str = okena_git::format_relative_time(commit.timestamp);
                 d
-                    // Hash (clickable, copies to clipboard)
+                    // Hash (clickable, copies to clipboard; right-click for menu)
                     .child(
                         div()
                             .id("commit-info-hash")
@@ -343,9 +353,15 @@ impl DiffViewer {
                             .rounded(px(3.0))
                             .hover(|s| s.bg(rgb(t.bg_hover)))
                             .on_click(move |_, _, cx| {
-                                cx.write_to_clipboard(ClipboardItem::new_string(hash.clone()));
+                                cx.write_to_clipboard(ClipboardItem::new_string(hash_for_click.clone()));
                             })
-                            .tooltip(|_window, cx| Tooltip::new("Copy hash").build(_window, cx))
+                            .on_mouse_down(
+                                MouseButton::Right,
+                                cx.listener(move |this, event: &MouseDownEvent, _, cx| {
+                                    this.open_commit_hash_menu(event.position, hash_for_rclick.clone(), cx);
+                                }),
+                            )
+                            .tooltip(|_window, cx| Tooltip::new("Click: copy hash \u{00B7} Right-click: more").build(_window, cx))
                             .child(short),
                     )
                     // Author

--- a/crates/okena-views-git/src/diff_viewer/selection_ops.rs
+++ b/crates/okena-views-git/src/diff_viewer/selection_ops.rs
@@ -5,7 +5,7 @@ use super::DiffViewer;
 
 use okena_core::types::DiffViewMode;
 use okena_files::code_view::extract_selected_text;
-use okena_files::selection::copy_to_clipboard;
+use okena_files::selection::{copy_to_clipboard, Selection2DNonEmpty};
 
 use gpui::*;
 
@@ -124,6 +124,91 @@ impl DiffViewer {
 
     pub(super) fn copy_selection(&self, cx: &mut Context<Self>) {
         copy_to_clipboard(cx, self.get_selected_text());
+    }
+
+    /// Build a single-block code payload from the current file's selection.
+    /// Returns None for empty/header-only selections, or when the current file
+    /// is binary or pure-deletion.
+    pub(super) fn selection_to_send_payload(&self) -> Option<okena_core::send_payload::SendPayload> {
+        use okena_core::send_payload::{CodeBlock, SendPayload};
+        use std::path::PathBuf;
+
+        let file = self.current_file.as_ref()?;
+        let stats = self.file_stats.get(self.selected_file_index)?;
+        if stats.is_deleted || stats.is_binary {
+            return None;
+        }
+
+        let (first, last, text) = if let Some(side) = self.selection_side {
+            // side-by-side
+            let ((start, _), (end, _)) = self.selection.normalized_non_empty()?;
+            let end = end.min(self.side_by_side_lines.len().saturating_sub(1));
+            let mut first_num: Option<usize> = None;
+            let mut last_num: usize = 0;
+            let mut texts: Vec<String> = Vec::new();
+            for i in start..=end {
+                let sbs_line = self.side_by_side_lines.get(i)?;
+                if sbs_line.expander.is_some() || sbs_line.is_header {
+                    continue;
+                }
+                let content = match side {
+                    SideBySideSide::Left => sbs_line.left.as_ref(),
+                    SideBySideSide::Right => sbs_line.right.as_ref(),
+                }?;
+                if first_num.is_none() {
+                    first_num = Some(content.line_num);
+                }
+                last_num = content.line_num;
+                texts.push(content.plain_text.clone());
+            }
+            let first = first_num?;
+            if texts.is_empty() {
+                return None;
+            }
+            (first, last_num, texts.join("\n"))
+        } else {
+            // unified
+            let ((start, _), (end, _)) = self.selection.normalized_non_empty()?;
+            let end = end.min(file.items.len().saturating_sub(1));
+            let mut first_num: Option<usize> = None;
+            let mut last_num: usize = 0;
+            let mut texts: Vec<String> = Vec::new();
+            for i in start..=end {
+                let DisplayItem::Line(line) = file.items.get(i)? else { continue };
+                let line_num = line.new_line_num.or(line.old_line_num)?;
+                if first_num.is_none() {
+                    first_num = Some(line_num);
+                }
+                last_num = line_num;
+                texts.push(line.plain_text.clone());
+            }
+            let first = first_num?;
+            if texts.is_empty() {
+                return None;
+            }
+            (first, last_num, texts.join("\n"))
+        };
+
+        let absolute_path = self
+            .provider
+            .absolute_file_path(&stats.path)
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(&stats.path));
+
+        Some(SendPayload::Code(vec![CodeBlock {
+            absolute_path,
+            first,
+            last,
+            text,
+        }]))
+    }
+
+    /// Emit SendToTerminal with the selection payload.
+    pub(super) fn send_selection_to_terminal(&mut self, cx: &mut Context<Self>) {
+        if let Some(payload) = self.selection_to_send_payload() {
+            cx.emit(super::DiffViewerEvent::SendToTerminal(payload));
+        }
+        cx.notify();
     }
 
     pub(super) fn select_all(&mut self, cx: &mut Context<Self>) {

--- a/crates/okena-views-git/src/diff_viewer/side_by_side.rs
+++ b/crates/okena-views-git/src/diff_viewer/side_by_side.rs
@@ -5,7 +5,7 @@ use super::types::{ChangedRange, DisplayItem, DisplayLine, SideBySideLine, SideB
 use super::DiffViewer;
 use okena_git::DiffLineType;
 use okena_core::theme::ThemeColors;
-use okena_files::selection::Selection2DExtension;
+use okena_files::selection::{Selection2DExtension, Selection2DNonEmpty};
 use okena_files::code_view::{find_word_boundaries, selection_bg_ranges};
 use gpui::prelude::*;
 use gpui::*;
@@ -373,6 +373,15 @@ impl DiffViewer {
                         cx.listener(|this, _, _window, cx| {
                             this.selection.finish();
                             cx.notify();
+                        }),
+                    )
+                    .on_mouse_down(
+                        MouseButton::Right,
+                        cx.listener(|this, event: &MouseDownEvent, _window, cx| {
+                            if this.selection.normalized_non_empty().is_some() {
+                                this.selection_context_menu = Some(event.position);
+                                cx.notify();
+                            }
                         }),
                     );
 

--- a/crates/okena-views-git/src/git_header.rs
+++ b/crates/okena-views-git/src/git_header.rs
@@ -52,6 +52,16 @@ enum BranchKind {
     Remote,
 }
 
+/// State for the right-click context menu on a commit row in the graph.
+/// Captured once at open time so the menu doesn't need a live reference
+/// back to the underlying `CommitLogEntry`.
+pub(super) struct CommitRowContextMenu {
+    pub(super) position: Point<Pixels>,
+    pub(super) hash: String,
+    /// Formatted payload computed once at open time.
+    pub(super) send_text: String,
+}
+
 /// Self-contained GPUI entity managing git status display, diff summary
 /// popover, and commit log popover.
 pub struct GitHeader {
@@ -102,6 +112,9 @@ pub struct GitHeader {
     // ── CI checks popover state ─────────────────────────────────────
     ci_checks_visible: bool,
     ci_badge_bounds: Bounds<Pixels>,
+
+    /// Open right-click context menu for a commit row in the graph.
+    pub(super) commit_row_menu: Option<CommitRowContextMenu>,
 }
 
 impl GitHeader {
@@ -158,6 +171,7 @@ impl GitHeader {
             branch_picker_status: BranchPickerStatus::Idle,
             ci_checks_visible: false,
             ci_badge_bounds: Bounds::default(),
+            commit_row_menu: None,
         }
     }
 

--- a/crates/okena-views-git/src/git_header/commit_log.rs
+++ b/crates/okena-views-git/src/git_header/commit_log.rs
@@ -1,7 +1,7 @@
 //! Commit log popover — git graph with optional compare mode and an inline
 //! branch picker. Anchored under the commit log button.
 
-use super::{BranchPickerTarget, GitHeader};
+use super::{BranchPickerTarget, CommitRowContextMenu, GitHeader};
 use crate::project_header;
 
 use okena_core::theme::ThemeColors;
@@ -185,16 +185,38 @@ impl GitHeader {
                         });
                     }))
                 };
+            let on_commit_right_click: Option<Arc<dyn Fn(&str, Point<Pixels>, &mut Window, &mut App)>> = {
+                let entity_handle = cx.entity().clone();
+                Some(Arc::new(move |hash: &str, position: Point<Pixels>, _window: &mut Window, cx: &mut App| {
+                    let hash = hash.to_string();
+                    let _ = entity_handle.update(cx, |this, cx| {
+                        let entry = this
+                            .commit_log_entries
+                            .iter()
+                            .find(|e| e.hash == hash)
+                            .cloned();
+                        if let Some(entry) = entry {
+                            this.commit_row_menu = Some(CommitRowContextMenu {
+                                position,
+                                hash: entry.hash.clone(),
+                                send_text: crate::commit_send::format_commit_entry(&entry),
+                            });
+                            cx.notify();
+                        }
+                    });
+                }))
+            };
             project_header::render_commit_log_content(
                 &self.commit_log_entries,
                 self.commit_log_loading,
                 on_commit_click,
+                on_commit_right_click,
                 t,
                 cx,
             )
         };
 
-        deferred(
+        let popover = deferred(
             anchored()
                 .position(position)
                 .snap_to_window()
@@ -544,7 +566,77 @@ impl GitHeader {
                                 .child(content),
                         ),
                 ),
+        );
+
+        // Mount the commit row right-click menu as a sibling so it overlays
+        // above the popover — `Deferred` can't take additional children, so we
+        // wrap the pair in a parent div.
+        div()
+            .child(popover)
+            .when_some(self.render_commit_row_menu(t, cx), |d, menu| d.child(menu))
+            .into_any_element()
+    }
+
+    /// Render the right-click context menu for a commit row in the graph.
+    /// Returns `None` when no menu is currently open.
+    pub(super) fn render_commit_row_menu(
+        &self,
+        t: &ThemeColors,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
+        use okena_ui::menu::{context_menu_panel, menu_item, menu_separator};
+
+        let menu = self.commit_row_menu.as_ref()?;
+        let position = menu.position;
+        let send_text = menu.send_text.clone();
+        let hash_for_copy = menu.hash.clone();
+        let request_broker = self.request_broker.clone();
+
+        let panel = context_menu_panel("commit-row-context-menu", t)
+            .child(
+                menu_item(
+                    "commit-row-ctx-send",
+                    "icons/terminal.svg",
+                    "Send to Terminal",
+                    t,
+                )
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.commit_row_menu = None;
+                    request_broker.update(cx, |broker, cx| {
+                        broker.push_send_to_terminal(
+                            okena_core::send_payload::SendPayload::Text(send_text.clone()),
+                            cx,
+                        );
+                    });
+                })),
+            )
+            .child(menu_separator(t))
+            .child(
+                menu_item("commit-row-ctx-copy", "icons/copy.svg", "Copy Hash", t)
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        cx.write_to_clipboard(ClipboardItem::new_string(hash_for_copy.clone()));
+                        this.commit_row_menu = None;
+                        cx.notify();
+                    })),
+            );
+
+        Some(
+            div()
+                .id("commit-row-menu-backdrop")
+                .absolute()
+                .inset_0()
+                .on_mouse_down(MouseButton::Left, cx.listener(|this, _, _, cx| {
+                    this.commit_row_menu = None;
+                    cx.notify();
+                }))
+                .on_mouse_down(MouseButton::Right, cx.listener(|this, _, _, cx| {
+                    this.commit_row_menu = None;
+                    cx.notify();
+                }))
+                .child(deferred(
+                    anchored().position(position).snap_to_window().child(panel),
+                ))
+                .into_any_element(),
         )
-        .into_any_element()
     }
 }

--- a/crates/okena-views-git/src/git_header/commit_log.rs
+++ b/crates/okena-views-git/src/git_header/commit_log.rs
@@ -593,6 +593,10 @@ impl GitHeader {
         let request_broker = self.request_broker.clone();
 
         let panel = context_menu_panel("commit-row-context-menu", t)
+            .on_mouse_down_out(cx.listener(|this, _, _, cx| {
+                this.commit_row_menu = None;
+                cx.notify();
+            }))
             .child(
                 menu_item(
                     "commit-row-ctx-send",
@@ -608,6 +612,7 @@ impl GitHeader {
                             cx,
                         );
                     });
+                    cx.notify();
                 })),
             )
             .child(menu_separator(t))
@@ -621,21 +626,7 @@ impl GitHeader {
             );
 
         Some(
-            div()
-                .id("commit-row-menu-backdrop")
-                .absolute()
-                .inset_0()
-                .on_mouse_down(MouseButton::Left, cx.listener(|this, _, _, cx| {
-                    this.commit_row_menu = None;
-                    cx.notify();
-                }))
-                .on_mouse_down(MouseButton::Right, cx.listener(|this, _, _, cx| {
-                    this.commit_row_menu = None;
-                    cx.notify();
-                }))
-                .child(deferred(
-                    anchored().position(position).snap_to_window().child(panel),
-                ))
+            deferred(anchored().position(position).snap_to_window().child(panel))
                 .into_any_element(),
         )
     }

--- a/crates/okena-views-git/src/lib.rs
+++ b/crates/okena-views-git/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod blame;
+pub mod commit_send;
 pub mod diff_viewer;
 pub mod git_header;
 pub mod project_header;

--- a/crates/okena-views-git/src/project_header/commit_log.rs
+++ b/crates/okena-views-git/src/project_header/commit_log.rs
@@ -16,10 +16,15 @@ use std::sync::Arc;
 ///
 /// `on_commit_click` is called with `(commit_hash, commit_message, commit_index)`
 /// when the user clicks on a commit row.
+///
+/// `on_commit_right_click` is called with `(commit_hash, mouse_position)` when
+/// the user right-clicks a commit row — used to open a context menu (e.g.
+/// "Send to Terminal", "Copy Hash").
 pub fn render_commit_log_content(
     entries: &[CommitLogEntry],
     loading: bool,
     on_commit_click: Option<Arc<dyn Fn(&str, &str, usize, &mut Window, &mut App)>>,
+    on_commit_right_click: Option<Arc<dyn Fn(&str, gpui::Point<gpui::Pixels>, &mut Window, &mut App)>>,
     t: &ThemeColors,
     cx: &App,
 ) -> AnyElement {
@@ -36,7 +41,16 @@ pub fn render_commit_log_content(
 
     div()
         .children(layout.rows.iter().enumerate().map(|(i, r)| {
-            render_lane_row(r, i, max_col, &palette, on_commit_click.clone(), t, cx)
+            render_lane_row(
+                r,
+                i,
+                max_col,
+                &palette,
+                on_commit_click.clone(),
+                on_commit_right_click.clone(),
+                t,
+                cx,
+            )
         }))
         .when(loading, |d| {
             d.child(

--- a/crates/okena-views-git/src/project_header/graph.rs
+++ b/crates/okena-views-git/src/project_header/graph.rs
@@ -158,12 +158,20 @@ fn render_ref_label(ref_name: &str, t: &ThemeColors, cx: &App) -> AnyElement {
 
 /// Render a single commit row. The rails canvas lives *inside* the row
 /// container; the row's `.hover()` background tint paints behind it.
+///
+/// `on_commit_click` is called with `(commit_hash, commit_message, commit_index)`
+/// when the user clicks a commit row.
+///
+/// `on_commit_right_click` is called with `(commit_hash, mouse_position)` when
+/// the user right-clicks a commit row — used to open a context menu (e.g.
+/// "Send to Terminal", "Copy Hash").
 pub(super) fn render_lane_row(
     row: &LaneRow,
     index: usize,
     max_col: usize,
     palette: &BTreeMap<LaneId, usize>,
     on_commit_click: Option<Arc<dyn Fn(&str, &str, usize, &mut Window, &mut App)>>,
+    on_commit_right_click: Option<Arc<dyn Fn(&str, gpui::Point<gpui::Pixels>, &mut Window, &mut App)>>,
     t: &ThemeColors,
     cx: &App,
 ) -> AnyElement {
@@ -194,7 +202,7 @@ pub(super) fn render_lane_row(
     let dot_x = GRAPH_PAD_LEFT + dot_col as f32 * GRAPH_CELL_W + (GRAPH_CELL_W - DOT_SIZE) / 2.0;
     let dot_y = (row_h - DOT_SIZE) / 2.0;
 
-    let row_el = h_flex()
+    let mut row_el = h_flex()
         .id(ElementId::Name(format!("graph-row-{}", index).into()))
         .relative()
         .pr(px(12.0))
@@ -246,6 +254,16 @@ pub(super) fn render_lane_row(
                         .child(entry.author.clone()),
                 ),
         );
+
+    if let Some(cb) = on_commit_right_click {
+        let hash = entry.hash.clone();
+        row_el = row_el.on_mouse_down(
+            MouseButton::Right,
+            move |event: &MouseDownEvent, window, cx| {
+                cb(&hash, event.position, window, cx);
+            },
+        );
+    }
 
     if let Some(cb) = on_commit_click {
         let hash = entry.hash.clone();

--- a/crates/okena-views-terminal/src/layout/terminal_pane/actions.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/actions.rs
@@ -2,6 +2,7 @@
 
 use crate::ActionDispatch;
 use okena_core::api::ActionRequest;
+#[cfg(target_os = "windows")]
 use okena_terminal::shell_config::ShellType;
 use okena_workspace::state::SplitDirection;
 use gpui::*;
@@ -93,7 +94,13 @@ impl<D: ActionDispatch + Send + Sync> TerminalPane<D> {
         // wl-copy / xclip aren't installed.
         #[cfg(target_os = "windows")]
         {
-            let shell = self.resolved_shell(cx);
+            let settings = crate::terminal_view_settings(cx);
+            let ws = self.workspace.read(cx);
+            let shell = self.shell_type.clone().resolve_default(
+                ws.project(&self.project_id)
+                    .and_then(|p| p.default_shell.as_ref()),
+                &settings.default_shell,
+            );
             if let Some(distro) = wsl_distro(&shell) {
                 let unc = format!(r"\\wsl$\{}\tmp\{}", distro, filename);
                 if std::fs::write(&unc, &image.bytes).is_ok() {
@@ -122,15 +129,6 @@ impl<D: ActionDispatch + Send + Sync> TerminalPane<D> {
             let Some(path) = write_paste_image_to_temp(&image, &filename) else { return };
             terminal.send_paste(&path.to_string_lossy());
         }
-    }
-
-    fn resolved_shell(&self, cx: &mut Context<Self>) -> ShellType {
-        let settings = crate::terminal_view_settings(cx);
-        let ws = self.workspace.read(cx);
-        self.shell_type.clone().resolve_default(
-            ws.project(&self.project_id).and_then(|p| p.default_shell.as_ref()),
-            &settings.default_shell,
-        )
     }
 
     pub(super) fn handle_jump_prev_prompt(&mut self, cx: &mut Context<Self>) {

--- a/crates/okena-workspace/src/request_broker.rs
+++ b/crates/okena-workspace/src/request_broker.rs
@@ -1,5 +1,6 @@
 use crate::requests::{OverlayRequest, SidebarRequest};
 use gpui::*;
+use okena_core::send_payload::SendPayload;
 use std::collections::VecDeque;
 
 /// Dedicated entity for transient UI request routing.
@@ -10,6 +11,7 @@ use std::collections::VecDeque;
 pub struct RequestBroker {
     overlay_requests: VecDeque<OverlayRequest>,
     sidebar_requests: VecDeque<SidebarRequest>,
+    send_to_terminal: VecDeque<SendPayload>,
 }
 
 impl RequestBroker {
@@ -17,6 +19,7 @@ impl RequestBroker {
         Self {
             overlay_requests: VecDeque::new(),
             sidebar_requests: VecDeque::new(),
+            send_to_terminal: VecDeque::new(),
         }
     }
 
@@ -30,6 +33,13 @@ impl RequestBroker {
         cx.notify();
     }
 
+    /// Queue a "Send to Terminal" payload. The host drains this on observation,
+    /// resolves the focused terminal's CWD, and formats + pastes the result.
+    pub fn push_send_to_terminal(&mut self, payload: SendPayload, cx: &mut Context<Self>) {
+        self.send_to_terminal.push_back(payload);
+        cx.notify();
+    }
+
     pub fn drain_overlay_requests(&mut self) -> Vec<OverlayRequest> {
         self.overlay_requests.drain(..).collect()
     }
@@ -38,11 +48,19 @@ impl RequestBroker {
         self.sidebar_requests.drain(..).collect()
     }
 
+    pub fn drain_send_to_terminal(&mut self) -> Vec<SendPayload> {
+        self.send_to_terminal.drain(..).collect()
+    }
+
     pub fn has_overlay_requests(&self) -> bool {
         !self.overlay_requests.is_empty()
     }
 
     pub fn has_sidebar_requests(&self) -> bool {
         !self.sidebar_requests.is_empty()
+    }
+
+    pub fn has_send_to_terminal(&self) -> bool {
+        !self.send_to_terminal.is_empty()
     }
 }

--- a/src/views/overlay_manager.rs
+++ b/src/views/overlay_manager.rs
@@ -1438,7 +1438,8 @@ impl OverlayManager {
     }
 
     /// Subscribe to a FileViewer's events: Close hides modal (keeps cache),
-    /// Detach moves it to a separate OS window, OpenCommit bubbles up to RootView.
+    /// Detach moves it to a separate OS window, OpenCommit bubbles up to
+    /// RootView, SendToTerminal routes to the focused terminal via the broker.
     fn subscribe_file_viewer(&mut self, viewer: &Entity<FileViewer>, cx: &mut Context<Self>) {
         cx.subscribe(viewer, |this, viewer_entity, event: &FileViewerEvent, cx| {
             match event {
@@ -1466,6 +1467,11 @@ impl OverlayManager {
                 FileViewerEvent::BlamePreferenceChanged(visible) => {
                     crate::settings::settings_entity(cx).update(cx, |state, cx| {
                         state.set_blame_visible(*visible, cx);
+                    });
+                }
+                FileViewerEvent::SendToTerminal(payload) => {
+                    this.request_broker.update(cx, |broker, cx| {
+                        broker.push_send_to_terminal(payload.clone(), cx);
                     });
                 }
             }
@@ -1516,6 +1522,11 @@ impl OverlayManager {
                 }
                 DiffViewerEvent::Detach => {
                     this.detach_active_modal(cx);
+                }
+                DiffViewerEvent::SendToTerminal(payload) => {
+                    this.request_broker.update(cx, |broker, cx| {
+                        broker.push_send_to_terminal(payload.clone(), cx);
+                    });
                 }
             }
         })

--- a/src/views/window/handlers.rs
+++ b/src/views/window/handlers.rs
@@ -73,6 +73,53 @@ impl WindowView {
         }
     }
 
+    /// Resolve the focused terminal_id from this window's focus_manager and the
+    /// project layout. Returns (project_id, terminal_id) or None if no terminal
+    /// is focused or the path doesn't lead to a Terminal node with an assigned id.
+    fn focused_terminal_id(&self, cx: &Context<Self>) -> Option<(String, String)> {
+        let state = self.focus_manager.read(cx).focused_terminal_state()?;
+        let ws = self.workspace.read(cx);
+        let project = ws.project(&state.project_id)?;
+        let layout = project.layout.as_ref()?;
+        let node = layout.get_at_path(&state.layout_path)?;
+        if let LayoutNode::Terminal { terminal_id: Some(id), .. } = node {
+            Some((state.project_id, id.clone()))
+        } else {
+            None
+        }
+    }
+
+    /// Paste a "Send to Terminal" payload into the currently focused terminal.
+    ///
+    /// Resolves the focused terminal's working directory (OSC 7-reported, else
+    /// the PTY's initial cwd) and formats the payload relative to it before
+    /// sending. Always wrapped in bracketed-paste sequences — see
+    /// `Terminal::send_paste_force_bracketed` for rationale on why we don't
+    /// trust the tracked DECSET 2004 mode flag. Toasts a warning if no
+    /// terminal is focused.
+    fn send_payload_to_active_terminal(
+        &self,
+        payload: okena_core::send_payload::SendPayload,
+        cx: &mut Context<Self>,
+    ) {
+        let Some((_project_id, terminal_id)) = self.focused_terminal_id(cx) else {
+            okena_workspace::toast::ToastManager::warning(
+                "No active terminal to send selection to",
+                cx,
+            );
+            return;
+        };
+        let terminals = self.terminals.lock();
+        if let Some(terminal) = terminals.get(&terminal_id) {
+            let cwd = terminal.current_cwd();
+            let cwd_path = std::path::Path::new(&cwd);
+            let text = payload.format(Some(cwd_path));
+            if !text.is_empty() {
+                terminal.send_paste_force_bracketed(&text);
+            }
+        }
+    }
+
     /// Build a ProjectFs provider for the given project (local or remote).
     fn build_project_fs(
         &self,
@@ -589,6 +636,18 @@ impl WindowView {
                     }
                 }
             }
+        }
+    }
+
+    /// Drain the broker's "send to terminal" queue and paste each payload into
+    /// the currently focused terminal. Resolves the terminal's CWD per call so
+    /// queued payloads sent while the user navigates use the latest known cwd.
+    pub(super) fn process_pending_send_to_terminal(&mut self, cx: &mut Context<Self>) {
+        let payloads = self.request_broker.update(cx, |broker, _cx| {
+            broker.drain_send_to_terminal()
+        });
+        for payload in payloads {
+            self.send_payload_to_active_terminal(payload, cx);
         }
     }
 

--- a/src/views/window/mod.rs
+++ b/src/views/window/mod.rs
@@ -248,10 +248,17 @@ impl WindowView {
         // Subscribe to overlay manager events
         cx.subscribe(&overlay_manager, Self::handle_overlay_manager_event).detach();
 
-        // Observe RequestBroker to process overlay requests outside of render()
+        // Observe RequestBroker to process overlay + terminal-send requests
+        // outside of render().
         cx.observe(&request_broker, |this, _broker, cx| {
-            if this.request_broker.read(cx).has_overlay_requests() {
+            let broker = this.request_broker.read(cx);
+            let has_overlay = broker.has_overlay_requests();
+            let has_send = broker.has_send_to_terminal();
+            if has_overlay {
                 this.process_pending_requests(cx);
+            }
+            if has_send {
+                this.process_pending_send_to_terminal(cx);
             }
         }).detach();
 


### PR DESCRIPTION
## Summary

Adds a "Send to Terminal" feature across the file viewer, diff viewer, and commit graph. Selecting code in either viewer reveals a floating button that pastes a `path:N-M` header + fenced code block into the focused terminal. Right-click menus on file-tree rows and tabs send the bare path; right-clicks on commit-hash badges and commit-graph rows send a `git log`-style block (hash + refs + author + relative date + indented subject).

Targets the focused terminal regardless of project (local or remote — the `Terminal` abstraction's transport handles routing). Always wraps payloads in DECSET 2004 brackets so multi-line content lands as one editable paste in zsh / bash / fish / Claude / Codex, instead of executing line-by-line. Strips trailing newlines so receivers don't auto-submit at end-of-paste.

### Entry points

- **Selection in file viewer or diff viewer** → floating button → fenced code block (one per file in multi-file diff selections).
- **File-tree right-click** (both viewers) + **tab right-click** (file viewer) → "Send to Terminal" → `path `.
- **Commit hash badge** (diff viewer header + commit info bar) → right-click → menu with "Send to Terminal" + "Copy Hash".
- **Commit graph row** → right-click → same menu (left-click still opens the diff viewer).

### Architecture

- Viewer events bubble up via existing `cx.subscribe` chains into a new `OverlayManagerEvent::SendSelectionToActiveTerminal` (for selections) or directly via a new top-level `OverlayRequest::SendTextToActiveTerminal` (for the commit graph, which doesn't sit under `OverlayManager`).
- `RootView::send_text_to_active_terminal` resolves the focused terminal via `focus_manager.focused_terminal_state()` + `LayoutNode::get_at_path()`, then calls `Terminal::send_paste_force_bracketed()`.
- Pure formatting helpers live in `okena-files::send_payload` and `okena-views-git::commit_send`. Floating button extracted to `okena-ui::floating_send_button`.

### Tests

25 new unit tests covering the four pure functions:

- `markdown_lang_hint` (6) — extension mapping, unknown ext fallback, multi-dot paths.
- `format_send_block` (5) — single-line vs range header, no-trailing-newline invariant.
- `format_commit_send_text` / `format_commit_entry` (7) — refs, full layout, multi-line message, no-trailing-newline invariant.
- `build_selection_segments` (7) — same-file merging, file boundaries, all-skipped, alternating files.

### Notes for review

- Branch is based on a stale local main (11 commits behind origin) — there will be merge conflicts against the upstream `feat: detachable file viewer and diff viewer overlays` commit which touched the same files. Rebase before merging.
- Three files in `crates/okena-views-git/src/diff_viewer/` (`scrollbar.rs`, `syntax.rs`, `types.rs`) had pre-existing local edits that aren't part of this work and were intentionally left out of the commits — they remain as uncommitted changes in the working tree.
- "Always bracket" means receivers that don't speak bracketed paste (rare modern shells, `cat`-style readers) will see literal `\x1b[200~` and `\x1b[201~` bytes. Acceptable failure mode vs. multi-line content executing line-by-line.

## Test plan

- [x] In an empty zsh terminal, right-click a commit hash in the diff viewer header and click "Send to Terminal" — block lands as one editable paste, Enter only submits when you press it.
- [x] In a Claude/Codex terminal, same flow — block appears in the prompt as multi-line text, no auto-submit.
- [x] Select multiple lines in the file viewer, click "Send to terminal" button — `path:N-M` + fenced block appears in active terminal.
- [x] Multi-file selection in unified diff — produces one fenced block per file.
- [x] Right-click a file in the file tree → "Send to Terminal" → just the `path ` lands.
- [x] Right-click a commit row in the graph popover → menu shows; "Copy Hash" copies the short hash; "Send to Terminal" pastes the block.
- [x] No focused terminal → toast warning appears.
- [ ] Remote project → still works (uses the same terminal-registry path).
- [x] `cargo test` — 25 new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)