### PR TITLE
fix(codex): match renamed status-page component

### DIFF
--- a/crates/okena-ext-codex/src/status.rs
+++ b/crates/okena-ext-codex/src/status.rs
@@ -73,12 +73,16 @@ impl CodexStatus {
                         .json()
                         .ok()?;
 
-                    // Find the Codex component and its ID
+                    // Find the Codex component and its ID. OpenAI renamed the
+                    // component from "Codex" to "Codex API" (2026), so match
+                    // on a `Codex`-prefix: future renames like "Codex Cloud"
+                    // would still resolve without another code change.
                     let components = resp["components"].as_array()?;
                     let mut component_status = None;
                     let mut component_id = None;
                     for component in components {
-                        if component["name"].as_str() == Some("Codex") {
+                        let name = component["name"].as_str().unwrap_or("");
+                        if name == "Codex" || name.starts_with("Codex ") {
                             component_status =
                                 component["status"].as_str().map(|s| s.to_string());
                             component_id = component["id"].as_str().map(|s| s.to_string());


### PR DESCRIPTION
## Summary
- Status-bar Codex widget was stuck showing `...` because OpenAI renamed the status.openai.com component from `Codex` to `Codex API`.
- Match on a `Codex`-prefix instead of exact `"Codex"`, so the current name and plausible future renames (`Codex Cloud`, `Codex Web`) keep resolving without another patch.

## Repro
```
curl -s https://status.openai.com/api/v2/summary.json | jq -r '.components[].name' | grep -i codex
# Codex API
```
The previous `== Some("Codex")` check never hit → `component_status?` short-circuited → `data` stayed `None` → widget rendered the initial-loading placeholder forever.

## Test plan
- [x] `cargo check -p okena-ext-codex`
- [x] Manual: launch app, status bar shows `Codex OK` (or whatever the live status is) instead of `Codex ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)