### PR TITLE
fix(ext-claude): refresh expired OAuth token for usage indicator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5556,6 +5556,7 @@ name = "okena-ext-claude"
 version = "0.1.0"
 dependencies = [
  "dirs 5.0.1",
+ "filetime",
  "gpui",
  "gpui-component",
  "jiff",

--- a/crates/okena-ext-claude/Cargo.toml
+++ b/crates/okena-ext-claude/Cargo.toml
@@ -17,6 +17,7 @@ dirs = "5.0"
 log = "0.4"
 jiff = "0.2"
 sha2 = "0.10"
+filetime = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/okena-ext-claude/src/usage.rs
+++ b/crates/okena-ext-claude/src/usage.rs
@@ -25,6 +25,15 @@ const HOVER_DELAY_MS: u64 = 300;
 /// Minimum interval between hover-triggered re-fetches.
 const HOVER_REFETCH_THROTTLE: Duration = Duration::from_secs(60);
 
+/// Claude Code OAuth client ID (public, used by the Claude CLI).
+const CLAUDE_OAUTH_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+
+/// OAuth token endpoint used to refresh the access token.
+const CLAUDE_OAUTH_TOKEN_URL: &str = "https://platform.claude.com/v1/oauth/token";
+
+/// Refresh the access token this long before its `expiresAt` to avoid 401s mid-flight.
+const TOKEN_REFRESH_LEEWAY_MS: u64 = 5 * 60 * 1000;
+
 /// Usage info for a single rate-limit tier
 #[derive(Clone)]
 struct TierUsage {
@@ -149,37 +158,548 @@ fn keychain_service_name(claude_dir: &Path) -> String {
     }
 }
 
-fn read_access_token(claude_dir: &Path) -> Option<String> {
-    fn extract_token(json_str: &str) -> Option<String> {
-        let v: serde_json::Value = serde_json::from_str(json_str).ok()?;
-        v["claudeAiOauth"]["accessToken"].as_str().map(String::from)
-    }
-
-    // Try credentials file first
-    if let Some(token) = std::fs::read_to_string(claude_dir.join(".credentials.json"))
-        .ok()
-        .and_then(|content| extract_token(&content))
-    {
-        return Some(token);
-    }
-
-    // macOS: fall back to Keychain using the per-config-dir service name
+/// Where a set of credentials was loaded from, so a refreshed token can be
+/// written back to the same place.
+#[derive(Clone)]
+enum CredsSource {
+    File(PathBuf),
     #[cfg(target_os = "macos")]
-    {
-        let user = std::env::var("USER").ok()?;
+    Keychain { service: String, account: String },
+}
+
+/// Parsed Claude OAuth credentials plus enough context to refresh + persist them.
+#[derive(Clone)]
+struct ClaudeCreds {
+    access_token: String,
+    refresh_token: Option<String>,
+    /// Epoch milliseconds when the access token expires.
+    expires_at_ms: Option<u64>,
+    source: CredsSource,
+    /// Full parsed credentials JSON, preserved so persistence keeps unrelated fields.
+    raw: serde_json::Value,
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Truncate a string to at most `max` bytes without splitting a UTF-8 char.
+/// Server-controlled error bodies may contain multi-byte chars straddling the
+/// byte limit; naive `&s[..max]` would panic on a non-char-boundary index.
+fn clip(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// True if the access token expires within the refresh leeway. Returns false when
+/// no expiry is recorded — we don't preemptively refresh then, relying on the
+/// reactive 401 path instead.
+fn needs_refresh(creds: &ClaudeCreds) -> bool {
+    match creds.expires_at_ms {
+        Some(expiry) => now_ms() + TOKEN_REFRESH_LEEWAY_MS >= expiry,
+        None => false,
+    }
+}
+
+fn read_claude_creds(claude_dir: &Path) -> Option<ClaudeCreds> {
+    fn parse(content: &str, source: CredsSource) -> Option<ClaudeCreds> {
+        let raw: serde_json::Value = serde_json::from_str(content).ok()?;
+        let oauth = raw.get("claudeAiOauth")?;
+        let access_token = oauth["accessToken"].as_str()?.to_string();
+        let refresh_token = oauth["refreshToken"].as_str().map(String::from);
+        let expires_at_ms = oauth["expiresAt"].as_u64();
+        Some(ClaudeCreds {
+            access_token,
+            refresh_token,
+            expires_at_ms,
+            source,
+            raw,
+        })
+    }
+
+    // Mirror Claude Code's storage precedence. On macOS the Keychain is
+    // authoritative: Claude Code reads it first and ignores a plaintext
+    // ~/.claude/.credentials.json when a Keychain entry exists. Picking the
+    // "freshest" across both stores would let a stale plaintext file shadow the
+    // Keychain, and a subsequent refresh would persist only to that file —
+    // leaving the Keychain (what Claude Code actually uses) with a now-rotated,
+    // invalid refresh token. So: Keychain first, file only as a fallback.
+    #[cfg(target_os = "macos")]
+    if let Ok(user) = std::env::var("USER") {
         let service = keychain_service_name(claude_dir);
-        let output = okena_core::process::safe_output(
+        if let Ok(output) = okena_core::process::safe_output(
             okena_core::process::command("security")
                 .args(["find-generic-password", "-s", &service, "-a", &user, "-w"]),
-        )
-        .ok()?;
-        if output.status.success() {
+        ) && output.status.success()
+        {
+            // A Keychain entry exists, so it is authoritative — return its parse
+            // result directly. A malformed entry must NOT fall through to the
+            // plaintext file: doing so is exactly the split-brain (refresh
+            // persists to the file, Keychain keeps a stale token) this precedence
+            // rule exists to prevent.
             let content = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            return extract_token(&content);
+            let creds = parse(
+                &content,
+                CredsSource::Keychain {
+                    service,
+                    account: user,
+                },
+            );
+            if creds.is_none() {
+                log::warn!("[claude-usage] Keychain credentials present but unparseable");
+            }
+            return creds;
         }
     }
 
-    None
+    let file_path = claude_dir.join(".credentials.json");
+    let content = std::fs::read_to_string(&file_path).ok()?;
+    parse(&content, CredsSource::File(file_path))
+}
+
+/// Atomically write `contents` to `path`: write a temp file in the same
+/// directory, then rename over the target. A failed or partial write (disk full,
+/// I/O error, crash) thus never truncates the existing credentials — the old file
+/// stays intact, so the user keeps a usable cached token. On Unix the temp file
+/// is created 0o600 so the credentials are never world-readable.
+fn atomic_write_0600(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("credentials.json");
+    // Same-dir temp so the rename is atomic (same filesystem). PID-suffixed to
+    // avoid clashing with a concurrent writer's temp.
+    let tmp = parent.join(format!(".{file_name}.tmp.{}", std::process::id()));
+
+    let write = || -> std::io::Result<()> {
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut f = opts.open(&tmp)?;
+        f.write_all(contents)?;
+        f.sync_all()
+    };
+
+    if let Err(e) = write() {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+
+    // rename replaces the destination atomically (incl. on Windows, where Rust's
+    // std maps to MoveFileEx with REPLACE_EXISTING).
+    std::fs::rename(&tmp, path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp);
+    })
+}
+
+/// Write refreshed token fields back to the source they came from, preserving
+/// all other fields in the stored JSON.
+///
+/// Returns an error if the write fails. Callers MUST treat a failure here as a
+/// failed refresh: the OAuth server has already rotated the refresh token, so
+/// silently keeping the now-stale one on disk would make the *next* refresh fail
+/// with `invalid_grant`.
+fn persist_creds(
+    source: &CredsSource,
+    mut raw: serde_json::Value,
+    access_token: &str,
+    refresh_token: Option<&str>,
+    expires_at_ms: Option<u64>,
+) -> std::io::Result<()> {
+    let oauth = raw
+        .get_mut("claudeAiOauth")
+        .and_then(|v| v.as_object_mut())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "malformed credentials: missing claudeAiOauth object",
+            )
+        })?;
+    oauth.insert(
+        "accessToken".to_string(),
+        serde_json::Value::String(access_token.to_string()),
+    );
+    if let Some(rt) = refresh_token {
+        oauth.insert(
+            "refreshToken".to_string(),
+            serde_json::Value::String(rt.to_string()),
+        );
+    }
+    if let Some(exp) = expires_at_ms {
+        oauth.insert("expiresAt".to_string(), serde_json::Value::from(exp));
+    }
+
+    let serialized = serde_json::to_string(&raw)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    match source {
+        CredsSource::File(path) => atomic_write_0600(path, serialized.as_bytes()),
+        #[cfg(target_os = "macos")]
+        CredsSource::Keychain { service, account } => {
+            // NOTE: `-w &serialized` puts the tokens on this process's argv,
+            // briefly visible to `ps`/process listing while `security` runs.
+            // `security add-generic-password` has no stdin password input, so
+            // there's no clean alternative; accepted as a short-lived exposure
+            // on the user's own machine. The read path (`find-generic-password
+            // -w`) is unaffected — it only outputs the secret, never passes it.
+            let status = std::process::Command::new("security")
+                .args([
+                    "add-generic-password",
+                    "-U",
+                    "-s",
+                    service,
+                    "-a",
+                    account,
+                    "-w",
+                    &serialized,
+                ])
+                .status()?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err(std::io::Error::other(format!(
+                    "security add-generic-password exited with {status}"
+                )))
+            }
+        }
+    }
+}
+
+/// Claude Code's OAuth refresh lock directory.
+///
+/// Claude Code guards its single-use refresh token with the `proper-lockfile`
+/// protocol: the lock is an atomically `mkdir`'d *directory* at this path, kept
+/// alive by periodic mtime updates, treated as stale after [`LOCK_STALE`], and
+/// released by `rmdir`. We speak the exact same protocol on the exact same path
+/// so an okena refresh and a concurrent Claude Code refresh mutually exclude —
+/// otherwise both could POST the same refresh token and one would get
+/// `invalid_grant`. (`mkdir`/`rmdir` are atomic and cross-platform, so this also
+/// serializes okena-vs-okena on every OS, Windows included.)
+const CLAUDE_LOCK_DIR: &str = ".oauth_refresh.lock";
+
+/// `proper-lockfile`'s default staleness threshold: a lock whose mtime is older
+/// than this is considered abandoned and may be stolen.
+const LOCK_STALE: Duration = Duration::from_secs(10);
+/// Give up waiting for a contended lock after this long and skip the refresh
+/// this cycle (rather than post a token exchange we can't safely serialize).
+const LOCK_MAX_WAIT: Duration = Duration::from_secs(15);
+/// Poll interval while waiting for a held lock to be released.
+const LOCK_POLL: Duration = Duration::from_millis(100);
+/// How often we bump the lock dir's mtime while holding it. Must be well below
+/// `LOCK_STALE` so peers never see our active lock as stale (proper-lockfile's
+/// own heartbeat is `stale/2`).
+const LOCK_HEARTBEAT: Duration = Duration::from_secs(3);
+/// Settle delay when claiming a stale lock: after stamping our mtime we wait this
+/// long, then re-read to confirm a competing stealer didn't stamp a later one.
+const LOCK_CLAIM_SETTLE: Duration = Duration::from_millis(50);
+
+/// A held (or attempted) `proper-lockfile`-compatible directory lock. Owns the
+/// lock dir only when [`OAuthRefreshLock::held`] is true; dropped → `rmdir`.
+struct OAuthRefreshLock {
+    dir: PathBuf,
+    held: bool,
+    /// Set on drop to stop the heartbeat thread.
+    stop: Arc<AtomicBool>,
+    heartbeat: Option<std::thread::JoinHandle<()>>,
+}
+
+impl OAuthRefreshLock {
+    /// Take the shared lock, stealing it if the current holder's lock is stale.
+    /// If it can't be taken within [`LOCK_MAX_WAIT`], returns a guard with
+    /// `held == false` — the caller must NOT post a token exchange in that case.
+    fn acquire(claude_dir: &Path) -> Self {
+        let dir = claude_dir.join(CLAUDE_LOCK_DIR);
+        let start = Instant::now();
+        loop {
+            match std::fs::create_dir(&dir) {
+                Ok(()) => return Self::owned(dir),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    // Bound acquisition on every path (incl. repeated stale-steal
+                    // attempts) so we never spin or block past LOCK_MAX_WAIT.
+                    if start.elapsed() >= LOCK_MAX_WAIT {
+                        log::warn!(
+                            "[claude-usage] oauth refresh lock busy >{}s; skipping refresh this cycle",
+                            LOCK_MAX_WAIT.as_secs()
+                        );
+                        return Self::not_held(dir);
+                    }
+                    // Holder appears to have vanished (mtime older than LOCK_STALE,
+                    // i.e. no live heartbeat). Try to claim it. We do NOT blindly
+                    // delete+recreate: a competing stealer could create a fresh
+                    // lock in that window and we'd clobber it, granting the lock to
+                    // two holders. Instead claim-by-mtime and verify (see below).
+                    if lock_is_stale(&dir) && claim_stale_lock(&dir) {
+                        return Self::owned(dir);
+                    }
+                    std::thread::sleep(LOCK_POLL);
+                }
+                Err(e) => {
+                    log::warn!(
+                        "[claude-usage] could not take oauth refresh lock ({e}); skipping refresh"
+                    );
+                    return Self::not_held(dir);
+                }
+            }
+        }
+    }
+
+    /// Construct an owned lock and start its mtime heartbeat so peers don't deem
+    /// it stale while we do slow work (network refresh, blocked Keychain, etc.).
+    fn owned(dir: PathBuf) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let hb_dir = dir.clone();
+        let hb_stop = stop.clone();
+        let heartbeat = std::thread::spawn(move || {
+            let mut since_touch = Duration::ZERO;
+            // Poll the stop flag finely so drop joins quickly, but only touch the
+            // mtime every LOCK_HEARTBEAT.
+            while !hb_stop.load(Ordering::Relaxed) {
+                std::thread::sleep(LOCK_POLL);
+                since_touch += LOCK_POLL;
+                if since_touch >= LOCK_HEARTBEAT {
+                    since_touch = Duration::ZERO;
+                    let _ = filetime::set_file_mtime(&hb_dir, filetime::FileTime::now());
+                }
+            }
+        });
+        Self {
+            dir,
+            held: true,
+            stop,
+            heartbeat: Some(heartbeat),
+        }
+    }
+
+    fn not_held(dir: PathBuf) -> Self {
+        Self {
+            dir,
+            held: false,
+            stop: Arc::new(AtomicBool::new(false)),
+            heartbeat: None,
+        }
+    }
+
+    fn held(&self) -> bool {
+        self.held
+    }
+}
+
+impl Drop for OAuthRefreshLock {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(h) = self.heartbeat.take() {
+            let _ = h.join();
+        }
+        // Only ever remove a lock we actually own — never someone else's.
+        if self.held {
+            let _ = std::fs::remove_dir(&self.dir);
+        }
+    }
+}
+
+/// Whether a lock directory's mtime is older than [`LOCK_STALE`]. A metadata
+/// error (e.g. the dir was just released) counts as "not stale" so we retry the
+/// `mkdir` rather than stealing something we can't measure.
+fn lock_is_stale(dir: &Path) -> bool {
+    std::fs::metadata(dir)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|mtime| mtime.elapsed().ok())
+        .is_some_and(|age| age > LOCK_STALE)
+}
+
+/// Try to claim an abandoned (stale) lock directory by stamping it with a fresh
+/// mtime and confirming no competing stealer stamped a later one. Returns `true`
+/// iff we won the claim and may treat ourselves as the holder.
+///
+/// We adopt the existing directory rather than delete+recreate, so we never
+/// clobber a lock another process freshly created in the steal window. The
+/// stamped mtime acts as a compare-and-set token: if two stealers race, the
+/// later stamp wins and the earlier one observes the changed value and backs off.
+/// This is the same best-effort guarantee `proper-lockfile` provides for stale
+/// recovery (a sub-resolution timestamp tie on a coarse filesystem is the only
+/// residual window).
+fn claim_stale_lock(dir: &Path) -> bool {
+    // Stamp now. If the dir vanished (released/removed), bail so the caller's
+    // loop retries the fast mkdir path.
+    if filetime::set_file_mtime(dir, filetime::FileTime::now()).is_err() {
+        return false;
+    }
+    // Read back the *stored* stamp (the filesystem may coarsen it); that's our
+    // token to compare against after the settle window.
+    let Some(token) = std::fs::metadata(dir).and_then(|m| m.modified()).ok() else {
+        return false;
+    };
+    std::thread::sleep(LOCK_CLAIM_SETTLE);
+    std::fs::metadata(dir)
+        .and_then(|m| m.modified())
+        .is_ok_and(|current| current == token)
+}
+
+/// Exchange the refresh token for a fresh access token, persist it, and return it.
+///
+/// Takes the shared Claude refresh lock and re-reads the credentials before
+/// posting: if another refresher (another okena instance or Claude Code, which
+/// shares this lock) rotated the token while we waited, we reuse their fresh
+/// token instead of posting an already-consumed one.
+fn refresh_access_token(claude_dir: &Path, current: &ClaudeCreds) -> Option<String> {
+    let lock = OAuthRefreshLock::acquire(claude_dir);
+
+    // Re-read under the lock. A concurrent refresher may have just rotated the
+    // token; in that case the stored refresh token differs from ours and the
+    // stored access token is already fresh — use it and skip the exchange.
+    let creds = read_claude_creds(claude_dir).unwrap_or_else(|| current.clone());
+    if creds.refresh_token != current.refresh_token {
+        log::info!("[claude-usage] credentials refreshed by another process; reusing stored token");
+        return Some(creds.access_token);
+    }
+
+    // We never actually got the lock and nobody else rotated the token — another
+    // holder is mid-refresh. Posting the same single-use token now would race and
+    // invalidate one side; skip and retry next cycle (the holder will have
+    // rotated it by then, picked up via the re-read above).
+    if !lock.held() {
+        return None;
+    }
+
+    let refresh_token = creds.refresh_token.as_deref()?;
+
+    let resp = okena_core::http::send(
+        okena_core::http::HttpRequest::post(CLAUDE_OAUTH_TOKEN_URL)
+            .json(&serde_json::json!({
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": CLAUDE_OAUTH_CLIENT_ID,
+            }))
+            // Sane network bound. Holding the refresh lock longer than LOCK_STALE
+            // is safe because the lock's heartbeat keeps its mtime fresh, so peers
+            // won't steal it.
+            .timeout(Duration::from_secs(10))
+            .label("claude.oauth.refresh"),
+    )
+    .ok()?;
+
+    if !resp.is_success() {
+        log::warn!(
+            "[claude-usage] token refresh failed: HTTP {} body={}",
+            resp.status(),
+            clip(&resp.text(), 300)
+        );
+        return None;
+    }
+
+    let body: serde_json::Value = resp.json().ok()?;
+    let new_access = body["access_token"].as_str()?;
+    let new_refresh = body["refresh_token"].as_str();
+    let expires_at_ms = body["expires_in"]
+        .as_u64()
+        .map(|secs| now_ms().saturating_add(secs.saturating_mul(1000)));
+
+    // The server has now rotated the refresh token. If we can't persist the new
+    // one, treat the whole refresh as failed — otherwise the stale token left on
+    // disk would fail the next refresh with `invalid_grant`.
+    if let Err(e) = persist_creds(
+        &creds.source,
+        creds.raw.clone(),
+        new_access,
+        new_refresh,
+        expires_at_ms,
+    ) {
+        log::error!(
+            "[claude-usage] refreshed token but failed to persist it ({e}); \
+             discarding to avoid leaving a stale refresh token — sign in again \
+             via the Claude CLI if usage stops updating"
+        );
+        return None;
+    }
+
+    log::info!("[claude-usage] access token refreshed");
+    Some(new_access.to_string())
+}
+
+/// Outcome of a single usage-endpoint request.
+enum Fetch {
+    // Boxed: `UsageData` dwarfs the other variants; boxing keeps `Fetch` small.
+    Ok(Box<UsageData>),
+    /// 429 — retry after this delay (from `retry-after`, or a default).
+    RateLimited(Duration),
+    /// 401 — access token expired/invalid; caller may refresh and retry once.
+    Unauthorized,
+    /// Any other failure (network, parse, other status).
+    Failed,
+}
+
+fn fetch_usage_once(token: &str) -> Fetch {
+    let response = okena_core::http::send(
+        okena_core::http::HttpRequest::get("https://api.anthropic.com/api/oauth/usage")
+            .bearer(token)
+            .header("anthropic-beta", "oauth-2025-04-20")
+            .timeout(Duration::from_secs(10))
+            .label("claude.usage")
+            // Safety floor: real cadence is 300s (≥30s on retry); a 5s floor only
+            // ever catches a runaway re-spawn. The reactive refresh path may issue
+            // a second usage call within the same tick; if that retry trips the
+            // floor it just fails this tick and recovers on the next (with backoff),
+            // since the refresh already wrote a fresh expiry.
+            .min_interval(Duration::from_secs(5)),
+    );
+
+    let resp = match response {
+        Ok(resp) => resp,
+        Err(e) => {
+            log::warn!("[claude-usage] request failed: {}", e);
+            return Fetch::Failed;
+        }
+    };
+
+    let status = resp.status();
+
+    if status == 429 {
+        let retry_secs = resp
+            .header("retry-after")
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(USAGE_INTERVAL.as_secs() * 2);
+        log::warn!("[claude-usage] rate limited (429), retry-after {}s", retry_secs);
+        return Fetch::RateLimited(Duration::from_secs(retry_secs));
+    }
+
+    // Only 401 means the access token is stale and worth refreshing. 403 is an
+    // authorization/scope problem (e.g. the account lacks usage access) that a
+    // refresh grant cannot fix — refreshing on 403 just rotates the refresh
+    // token every poll and risks invalidating it. Let 403 fall through to Failed.
+    if status == 401 {
+        return Fetch::Unauthorized;
+    }
+
+    let body = resp.text();
+    log::info!(
+        "[claude-usage] HTTP {} body={}",
+        status,
+        clip(&body, 500)
+    );
+    if !resp.is_success() {
+        return Fetch::Failed;
+    }
+    match serde_json::from_str::<serde_json::Value>(&body) {
+        Ok(parsed) => Fetch::Ok(Box::new(parse_usage(&parsed))),
+        Err(_) => Fetch::Failed,
+    }
 }
 
 fn parse_usage(resp: &serde_json::Value) -> UsageData {
@@ -370,69 +890,51 @@ impl ClaudeUsageData {
                 // Returns (Option<UsageData>, Option<Duration>) — data + optional retry delay
                 let dir = claude_dir_for_task.lock().clone();
                 let (result, retry_after) = smol::unblock(move || {
-                    let token = match read_access_token(&dir) {
-                        Some(t) => {
-                            log::info!("[claude-usage] token found (len={})", t.len());
-                            t
-                        }
+                    let creds = match read_claude_creds(&dir) {
+                        Some(c) => c,
                         None => {
                             log::warn!("[claude-usage] no access token found");
                             return (None, None);
                         }
                     };
 
-                    let response = okena_core::http::send(
-                        okena_core::http::HttpRequest::get(
-                            "https://api.anthropic.com/api/oauth/usage",
-                        )
-                        .bearer(&token)
-                        .header("anthropic-beta", "oauth-2025-04-20")
-                        .timeout(Duration::from_secs(10))
-                        .label("claude.usage")
-                        // Safety floor: real cadence is 300s (≥30s on retry); a
-                        // 5s floor only ever catches a runaway re-spawn. One
-                        // request per tick, so it never clips a legit retry.
-                        .min_interval(Duration::from_secs(5)),
-                    );
-
-                    match response {
-                        Ok(resp) => {
-                            let status = resp.status();
-
-                            if status == 429 {
-                                let retry_secs = resp
-                                    .header("retry-after")
-                                    .and_then(|v| v.parse::<u64>().ok())
-                                    .unwrap_or(USAGE_INTERVAL.as_secs() * 2);
-                                let effective = Duration::from_secs(retry_secs)
-                                    .max(MIN_RETRY_DELAY);
-                                log::warn!(
-                                    "[claude-usage] rate limited (429), retrying in {}s",
-                                    effective.as_secs()
-                                );
-                                return (None, Some(Duration::from_secs(retry_secs)));
-                            }
-
-                            let body = resp.text();
-                            log::info!(
-                                "[claude-usage] HTTP {} body={}",
-                                status,
-                                &body[..body.len().min(500)]
-                            );
-                            if !resp.is_success() {
-                                return (None, None);
-                            }
-                            let parsed: serde_json::Value =
-                                match serde_json::from_str(&body) {
-                                    Ok(v) => v,
-                                    Err(_) => return (None, None),
-                                };
-                            (Some(parse_usage(&parsed)), None)
+                    // Proactively refresh if the token is expired or about to expire,
+                    // so we don't waste a request that we know will 401.
+                    let mut token = creds.access_token.clone();
+                    let mut refreshed = false;
+                    if needs_refresh(&creds) {
+                        refreshed = true;
+                        // If refresh fails, still try the current token: within the
+                        // refresh leeway it may remain valid for a few more minutes.
+                        if let Some(fresh) = refresh_access_token(&dir, &creds) {
+                            token = fresh;
                         }
-                        Err(e) => {
-                            log::warn!("[claude-usage] request failed: {}", e);
+                    }
+
+                    let mut outcome = fetch_usage_once(&token);
+
+                    // Reactively refresh once on a rejected token (e.g. expiry we
+                    // couldn't predict, or a revoked token) — but skip it if we
+                    // already attempted a refresh this cycle, since that attempt
+                    // (under lock) just succeeded or failed; retrying is pointless.
+                    if matches!(outcome, Fetch::Unauthorized)
+                        && !refreshed
+                        && let Some(fresh) = refresh_access_token(&dir, &creds)
+                    {
+                        outcome = fetch_usage_once(&fresh);
+                    }
+
+                    match outcome {
+                        Fetch::Ok(data) => (Some(*data), None),
+                        Fetch::RateLimited(delay) => (None, Some(delay)),
+                        Fetch::Unauthorized => {
+                            log::warn!(
+                                "[claude-usage] token rejected and refresh failed; \
+                                 sign in again via the Claude CLI"
+                            );
                             (None, None)
                         }
+                        Fetch::Failed => (None, None),
                     }
                 })
                 .await;
@@ -1027,13 +1529,214 @@ mod tests {
         use std::io::Write;
         let dir = tempfile::tempdir().unwrap();
         let creds = serde_json::json!({
-            "claudeAiOauth": { "accessToken": "test-token-abc" }
+            "claudeAiOauth": {
+                "accessToken": "test-token-abc",
+                "refreshToken": "refresh-xyz",
+                "expiresAt": 1779244706022u64,
+            }
         });
         let mut f = std::fs::File::create(dir.path().join(".credentials.json")).unwrap();
         write!(f, "{}", creds).unwrap();
-        // The file-based path should win over Keychain when a valid file is present
-        let token = read_access_token(dir.path()).unwrap();
-        assert_eq!(token, "test-token-abc");
+        // The tempdir-derived Keychain service name can't match a real entry, so
+        // the file is the only source here and is read as the fallback.
+        let parsed = read_claude_creds(dir.path()).unwrap();
+        assert_eq!(parsed.access_token, "test-token-abc");
+        assert_eq!(parsed.refresh_token.as_deref(), Some("refresh-xyz"));
+        assert_eq!(parsed.expires_at_ms, Some(1779244706022));
+        assert!(matches!(parsed.source, CredsSource::File(_)));
+    }
+
+    #[test]
+    fn test_clip_respects_char_boundaries() {
+        // ASCII shorter than max -> unchanged.
+        assert_eq!(clip("hello", 10), "hello");
+        // ASCII truncated exactly at max.
+        assert_eq!(clip("hello", 3), "hel");
+        // Multi-byte char straddling the limit must not panic and must back off
+        // to the previous char boundary. "é" is 2 bytes (0xC3 0xA9).
+        let s = "aé"; // bytes: 'a'(1) + 'é'(2) = 3 bytes
+        assert_eq!(clip(s, 2), "a"); // can't include half of 'é'
+        assert_eq!(clip(s, 3), "aé");
+        // Limit landing mid-multibyte for a 4-byte emoji.
+        let emoji = "😀"; // 4 bytes
+        assert_eq!(clip(emoji, 1), "");
+        assert_eq!(clip(emoji, 3), "");
+        assert_eq!(clip(emoji, 4), "😀");
+    }
+
+    #[test]
+    fn test_needs_refresh_when_expired() {
+        let expired = ClaudeCreds {
+            access_token: "a".into(),
+            refresh_token: Some("r".into()),
+            expires_at_ms: Some(now_ms().saturating_sub(1000)),
+            source: CredsSource::File(PathBuf::from("/tmp/x")),
+            raw: serde_json::json!({}),
+        };
+        assert!(needs_refresh(&expired));
+
+        let fresh = ClaudeCreds {
+            expires_at_ms: Some(now_ms() + 60 * 60 * 1000),
+            ..expired.clone()
+        };
+        assert!(!needs_refresh(&fresh));
+
+        // No expiry recorded -> don't preemptively refresh (rely on reactive 401).
+        let no_expiry = ClaudeCreds {
+            expires_at_ms: None,
+            ..expired.clone()
+        };
+        assert!(!needs_refresh(&no_expiry));
+    }
+
+    #[test]
+    fn test_persist_creds_round_trip_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".credentials.json");
+        let raw = serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "old",
+                "refreshToken": "old-refresh",
+                "expiresAt": 1u64,
+                "subscriptionType": "max",
+            }
+        });
+        std::fs::write(&path, raw.to_string()).unwrap();
+
+        persist_creds(
+            &CredsSource::File(path.clone()),
+            raw,
+            "new-access",
+            Some("new-refresh"),
+            Some(999),
+        )
+        .expect("persist should succeed");
+
+        let reread = read_claude_creds(dir.path()).unwrap();
+        assert_eq!(reread.access_token, "new-access");
+        assert_eq!(reread.refresh_token.as_deref(), Some("new-refresh"));
+        assert_eq!(reread.expires_at_ms, Some(999));
+        // Unrelated fields are preserved.
+        assert_eq!(reread.raw["claudeAiOauth"]["subscriptionType"], "max");
+    }
+
+    #[test]
+    fn test_persist_creds_errors_on_unwritable_path() {
+        // A path whose parent directory does not exist must surface an error,
+        // so the caller treats the refresh as failed instead of dropping the
+        // rotated refresh token.
+        let bad = CredsSource::File(PathBuf::from("/nonexistent-dir-xyz/creds.json"));
+        let raw = serde_json::json!({ "claudeAiOauth": { "accessToken": "x" } });
+        let res = persist_creds(&bad, raw, "a", Some("r"), Some(1));
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_persist_creds_errors_on_malformed_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("creds.json");
+        // No `claudeAiOauth` object -> cannot persist.
+        let raw = serde_json::json!({ "something_else": 1 });
+        let res = persist_creds(&CredsSource::File(path), raw, "a", Some("r"), Some(1));
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_oauth_lock_acquire_and_release() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join(CLAUDE_LOCK_DIR);
+
+        let lock = OAuthRefreshLock::acquire(dir.path());
+        assert!(lock.held(), "first acquire on a free dir should hold");
+        assert!(lock_path.is_dir(), "lock should be a directory (proper-lockfile)");
+
+        drop(lock);
+        assert!(!lock_path.exists(), "drop must rmdir a held lock");
+    }
+
+    #[test]
+    fn test_oauth_lock_heartbeat_bumps_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join(CLAUDE_LOCK_DIR);
+
+        let lock = OAuthRefreshLock::acquire(dir.path());
+        assert!(lock.held());
+        let t0 = std::fs::metadata(&lock_path).unwrap().modified().unwrap();
+
+        // Hold past one heartbeat tick; the mtime must advance so peers don't
+        // see the active lock as stale.
+        std::thread::sleep(LOCK_HEARTBEAT + 3 * LOCK_POLL);
+        let t1 = std::fs::metadata(&lock_path).unwrap().modified().unwrap();
+        assert!(t1 > t0, "heartbeat should refresh the lock dir mtime");
+
+        drop(lock);
+        assert!(!lock_path.exists());
+    }
+
+    #[test]
+    fn test_oauth_lock_does_not_remove_unowned() {
+        // A guard that never acquired (held == false) must never delete the dir.
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join(CLAUDE_LOCK_DIR);
+        std::fs::create_dir(&lock_path).unwrap();
+
+        let unowned = OAuthRefreshLock::not_held(lock_path.clone());
+        drop(unowned);
+        assert!(lock_path.exists(), "must not remove a lock we don't own");
+    }
+
+    #[test]
+    fn test_lock_is_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join(CLAUDE_LOCK_DIR);
+
+        // Missing -> not stale (can't measure; retry rather than steal).
+        assert!(!lock_is_stale(&lock_path));
+
+        // Freshly created -> not stale.
+        std::fs::create_dir(&lock_path).unwrap();
+        assert!(!lock_is_stale(&lock_path));
+
+        // Backdated past LOCK_STALE -> stale.
+        let old = filetime::FileTime::from_unix_time(
+            (now_ms() / 1000) as i64 - LOCK_STALE.as_secs() as i64 - 5,
+            0,
+        );
+        filetime::set_file_mtime(&lock_path, old).unwrap();
+        assert!(lock_is_stale(&lock_path));
+    }
+
+    #[test]
+    fn test_claim_stale_lock_freshens_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join(CLAUDE_LOCK_DIR);
+        std::fs::create_dir(&lock_path).unwrap();
+        let old = filetime::FileTime::from_unix_time(
+            (now_ms() / 1000) as i64 - LOCK_STALE.as_secs() as i64 - 5,
+            0,
+        );
+        filetime::set_file_mtime(&lock_path, old).unwrap();
+
+        assert!(claim_stale_lock(&lock_path), "uncontended stale claim should win");
+        assert!(!lock_is_stale(&lock_path), "claim must freshen the mtime");
+    }
+
+    #[test]
+    fn test_acquire_steals_stale_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join(CLAUDE_LOCK_DIR);
+        // Simulate a crashed holder: a stale lock dir left behind.
+        std::fs::create_dir(&lock_path).unwrap();
+        let old = filetime::FileTime::from_unix_time(
+            (now_ms() / 1000) as i64 - LOCK_STALE.as_secs() as i64 - 5,
+            0,
+        );
+        filetime::set_file_mtime(&lock_path, old).unwrap();
+
+        let lock = OAuthRefreshLock::acquire(dir.path());
+        assert!(lock.held(), "should steal a stale lock");
+        drop(lock);
+        assert!(!lock_path.exists(), "drop releases the stolen lock");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The Claude usage indicator read the stored `accessToken` directly and never refreshed it. Once the token expired, the usage API returned `401 Unauthorized` and the indicator silently disappeared.

## Change

Add an OAuth refresh flow to `okena-ext-claude`:

- **Read** creds with Claude Code's storage precedence — macOS Keychain is authoritative (a present-but-malformed entry does *not* fall back to the plaintext file), `~/.claude/.credentials.json` otherwise — now parsing `refreshToken`/`expiresAt`.
- **Refresh** proactively within a leeway before expiry, and reactively on `401`, via the OAuth token endpoint. `403` and other statuses are treated as non-refreshable failures (refreshing can't fix scope/permission and would churn the single-use token).
- **Persist** the rotated token atomically (same-dir temp + `rename`, `0600`); a failed persist is treated as a failed refresh so a rotated token is never lost into a stale file.
- **Serialize** concurrent refreshes (other okena instances *and* Claude Code) with a `proper-lockfile`-compatible `mkdir` directory lock: mtime heartbeat, bounded non-spinning acquire, and a race-free claim-by-mtime stale steal.

## Notes

- `filetime` is declared as a direct dependency but is already in the build tree transitively via `gpui`, so no new crate is compiled. It's needed to set a directory's mtime cross-platform (std can't on Windows directories).
- Keychain write exposes the secret on `security`'s argv briefly — documented in-code; `security add-generic-password` has no stdin input, matching Claude Code's own behavior.

## Tests

31 unit tests (clip char-boundary, creds parsing/precedence, atomic-write errors, lock acquire/release/steal/heartbeat, stale detection). `cargo test -p okena-ext-claude` green; clippy clean for the changed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)