### PR TITLE
Fix Claude default config env split

### DIFF
--- a/crates/okena-ext-claude/src/usage.rs
+++ b/crates/okena-ext-claude/src/usage.rs
@@ -11,7 +11,7 @@ use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 /// Refresh interval for usage data
 const USAGE_INTERVAL: Duration = Duration::from_secs(300);
@@ -149,33 +149,80 @@ fn keychain_service_name(claude_dir: &Path) -> String {
     }
 }
 
-fn read_access_token(claude_dir: &Path) -> Option<String> {
-    fn extract_token(json_str: &str) -> Option<String> {
-        let v: serde_json::Value = serde_json::from_str(json_str).ok()?;
-        v["claudeAiOauth"]["accessToken"].as_str().map(String::from)
+#[cfg(target_os = "macos")]
+fn suffixed_keychain_service_name(claude_dir: &Path) -> String {
+    const BASE: &str = "Claude Code-credentials";
+    let canonical = claude_dir.canonicalize().unwrap_or_else(|_| claude_dir.to_path_buf());
+    let mut h = Sha256::new();
+    h.update(canonical.to_string_lossy().as_bytes());
+    let d = h.finalize();
+    format!("{BASE}-{:02x}{:02x}{:02x}{:02x}", d[0], d[1], d[2], d[3])
+}
+
+#[cfg(target_os = "macos")]
+fn keychain_service_names(claude_dir: &Path) -> Vec<String> {
+    let primary = keychain_service_name(claude_dir);
+    let suffixed = suffixed_keychain_service_name(claude_dir);
+    if primary == suffixed {
+        vec![primary]
+    } else {
+        vec![primary, suffixed]
     }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn extract_access_token(json_str: &str, now_ms: u64) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(json_str).ok()?;
+    let oauth = &v["claudeAiOauth"];
+    let token = oauth["accessToken"].as_str()?.trim();
+    if token.is_empty() {
+        return None;
+    }
+
+    if let Some(expires_at) = oauth["expiresAt"].as_u64()
+        && expires_at <= now_ms
+    {
+        return None;
+    }
+
+    Some(token.to_string())
+}
+
+fn read_access_token(claude_dir: &Path) -> Option<String> {
+    let now = now_ms();
 
     // Try credentials file first
     if let Some(token) = std::fs::read_to_string(claude_dir.join(".credentials.json"))
         .ok()
-        .and_then(|content| extract_token(&content))
+        .and_then(|content| extract_access_token(&content, now))
     {
         return Some(token);
     }
 
-    // macOS: fall back to Keychain using the per-config-dir service name
+    // macOS: fall back to Keychain using per-config-dir service names. Claude
+    // Code can create both the default service and the suffixed service when
+    // CLAUDE_CONFIG_DIR explicitly points at ~/.claude, so try both.
     #[cfg(target_os = "macos")]
     {
         let user = std::env::var("USER").ok()?;
-        let service = keychain_service_name(claude_dir);
-        let output = okena_core::process::safe_output(
-            okena_core::process::command("security")
-                .args(["find-generic-password", "-s", &service, "-a", &user, "-w"]),
-        )
-        .ok()?;
-        if output.status.success() {
-            let content = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            return extract_token(&content);
+        for service in keychain_service_names(claude_dir) {
+            let output = okena_core::process::safe_output(
+                okena_core::process::command("security")
+                    .args(["find-generic-password", "-s", &service, "-a", &user, "-w"]),
+            )
+            .ok()?;
+            if output.status.success() {
+                let content = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if let Some(token) = extract_access_token(&content, now) {
+                    return Some(token);
+                }
+            }
         }
     }
 
@@ -1037,6 +1084,42 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_access_token_rejects_empty_token() {
+        let creds = serde_json::json!({
+            "claudeAiOauth": { "accessToken": "" }
+        });
+
+        assert!(extract_access_token(&creds.to_string(), 1_000).is_none());
+    }
+
+    #[test]
+    fn test_extract_access_token_rejects_expired_token() {
+        let creds = serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "expired-token",
+                "expiresAt": 999
+            }
+        });
+
+        assert!(extract_access_token(&creds.to_string(), 1_000).is_none());
+    }
+
+    #[test]
+    fn test_extract_access_token_accepts_unexpired_token() {
+        let creds = serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "fresh-token",
+                "expiresAt": 1_001
+            }
+        });
+
+        assert_eq!(
+            extract_access_token(&creds.to_string(), 1_000).as_deref(),
+            Some("fresh-token")
+        );
+    }
+
+    #[test]
     fn test_parse_iso8601_to_epoch() {
         // 2025-01-01T00:00:00Z = 1735689600
         let epoch = parse_iso8601_to_epoch("2025-01-01T00:00:00.000Z").unwrap();
@@ -1120,6 +1203,18 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
+    fn test_keychain_service_names_default_include_suffixed_fallback() {
+        let default_dir = dirs::home_dir().unwrap().join(".claude");
+        if default_dir.exists() {
+            let names = keychain_service_names(&default_dir);
+            assert_eq!(names.len(), 2);
+            assert_eq!(names[0], "Claude Code-credentials");
+            assert!(names[1].starts_with("Claude Code-credentials-"));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
     fn test_keychain_service_custom() {
         // Pin the SHA-256 algorithm against a known empirical example:
         // sha256("/Users/pcavezzan/.claude-stonal")[..8 hex] = "d4c0f9c1"
@@ -1138,5 +1233,15 @@ mod tests {
         );
         assert_eq!(service, expected);
         assert_ne!(service, "Claude Code-credentials", "custom dir must get a suffix");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_keychain_service_names_custom_has_single_service() {
+        let dir = tempfile::tempdir().unwrap();
+        let names = keychain_service_names(dir.path());
+
+        assert_eq!(names.len(), 1);
+        assert!(names[0].starts_with("Claude Code-credentials-"));
     }
 }

--- a/crates/okena-services/src/port_detect.rs
+++ b/crates/okena-services/src/port_detect.rs
@@ -117,10 +117,10 @@ fn build_process_tree_macos() -> HashMap<u32, Vec<u32>> {
     let mut tree: HashMap<u32, Vec<u32>> = HashMap::new();
     for line in stdout.lines().skip(1) {
         let fields: Vec<&str> = line.split_whitespace().collect();
-        if fields.len() >= 2 {
-            if let (Ok(pid), Ok(ppid)) = (fields[0].parse::<u32>(), fields[1].parse::<u32>()) {
-                tree.entry(ppid).or_default().push(pid);
-            }
+        if fields.len() >= 2
+            && let (Ok(pid), Ok(ppid)) = (fields[0].parse::<u32>(), fields[1].parse::<u32>())
+        {
+            tree.entry(ppid).or_default().push(pid);
         }
     }
     tree

--- a/crates/okena-terminal/src/pty_manager.rs
+++ b/crates/okena-terminal/src/pty_manager.rs
@@ -1304,12 +1304,12 @@ fn find_pids_for_unix_sockets_lsof(
     for line in stdout.lines() {
         if let Some(pid_str) = line.strip_prefix('p') {
             current_pid = pid_str.parse().ok();
-        } else if let Some(name) = line.strip_prefix('n') {
-            if let Some(pid) = current_pid {
-                let path = std::path::PathBuf::from(name);
-                if socket_paths.contains(&path) {
-                    result.entry(path).or_default().push(pid);
-                }
+        } else if let Some(name) = line.strip_prefix('n')
+            && let Some(pid) = current_pid
+        {
+            let path = std::path::PathBuf::from(name);
+            if socket_paths.contains(&path) {
+                result.entry(path).or_default().push(pid);
             }
         }
     }
@@ -1345,4 +1345,3 @@ fn first_proc_child(pid: u32) -> Option<u32> {
 fn first_proc_child(_pid: u32) -> Option<u32> {
     None
 }
-

--- a/crates/okena-terminal/src/pty_manager.rs
+++ b/crates/okena-terminal/src/pty_manager.rs
@@ -167,9 +167,11 @@ pub struct PtyManager {
     /// Optional sink for streaming PTY output to external consumers (e.g. remote clients).
     /// Publishing happens directly from reader threads to avoid UI event loop latency.
     output_sink: Arc<Mutex<Option<Arc<dyn PtyOutputSink>>>>,
-    /// Extra environment variables injected into every spawned PTY.
-    /// Only variables not already set in the spawning process are injected.
-    extra_env: Mutex<Vec<(String, String)>>,
+    /// Extra environment overrides applied to every spawned PTY. `Some(val)` sets
+    /// the variable; `None` removes it from the inherited environment so a stale
+    /// value (e.g. a `CLAUDE_CONFIG_DIR` exported in the user's shell that launched
+    /// Okena) cannot leak into the terminal.
+    extra_env: Mutex<Vec<(String, Option<String>)>>,
     /// Sender for the shared teardown worker pool. `kill`/`cleanup_exited` enqueue
     /// jobs here instead of spawning a detached thread per call. Wrapped in `Option`
     /// only so `Drop` can `take()` it and close the channel, signaling workers to
@@ -278,10 +280,10 @@ impl PtyManager {
         *self.output_sink.lock() = Some(sink);
     }
 
-    /// Set extra environment variables to inject into every spawned PTY.
-    /// Variables already present in the process environment are not overwritten.
-    /// Replaces any previously configured extra env.
-    pub fn set_extra_env(&self, env: Vec<(String, String)>) {
+    /// Set the extra environment overrides applied to every spawned PTY.
+    /// `Some(val)` sets the variable; `None` removes it from the inherited
+    /// environment. Replaces any previously configured overrides.
+    pub fn set_extra_env(&self, env: Vec<(String, Option<String>)>) {
         *self.extra_env.lock() = env;
     }
 
@@ -347,11 +349,15 @@ impl PtyManager {
         #[cfg(windows)]
         let (mut cmd, wsl_distro, wsl_backend) = self.build_terminal_command(terminal_id, cwd, shell);
 
-        // Inject caller-configured env vars into the PTY unconditionally.
+        // Apply caller-configured env overrides to the PTY unconditionally.
         // These are profile-scoped values (e.g. CLAUDE_CONFIG_DIR) that must
         // override whatever the user's shell rc or the parent process has set.
+        // `None` removes the variable so a stale inherited value cannot leak in.
         for (key, val) in &*self.extra_env.lock() {
-            cmd.env(key, val);
+            match val {
+                Some(val) => cmd.env(key, val),
+                None => cmd.env_remove(key),
+            }
         }
 
         // Spawn the process

--- a/crates/okena-terminal/src/session_backend.rs
+++ b/crates/okena-terminal/src/session_backend.rs
@@ -171,7 +171,7 @@ impl ResolvedBackend {
         session_name: &str,
         cwd: &str,
         command: Option<&str>,
-        extra_env: &[(String, String)],
+        extra_env: &[(String, Option<String>)],
     ) -> Option<(String, Vec<String>)> {
         match self {
             Self::None => None,
@@ -200,15 +200,28 @@ impl ResolvedBackend {
                 // pre-existing tmux server whose global env predates Okena.
                 let env_args: String = extra_env
                     .iter()
-                    .map(|(k, v)| format!(" -e {}", shell_escape(&format!("{k}={v}"))))
+                    .filter_map(|(k, v)| {
+                        v.as_ref()
+                            .map(|val| format!(" -e {}", shell_escape(&format!("{k}={val}"))))
+                    })
+                    .collect();
+                // For removals there is no `-e` equivalent: clear the var from the
+                // session environment so later splits/panes don't inherit a stale
+                // value. (The very first pane is handled by `env_remove` on the
+                // tmux client, which a freshly-started server inherits.)
+                let unset_args: String = extra_env
+                    .iter()
+                    .filter(|(_, v)| v.is_none())
+                    .map(|(k, _)| format!(" \\; set-environment -u {}", shell_escape(k)))
                     .collect();
                 let tmux_cmd = format!(
-                    "tmux new-session -A{} -s {} -c {}{} \\; set status off \\; set mouse on \\; set default-terminal xterm-256color \\; set terminal-features 'xterm-256color:RGB' \\; set -as terminal-overrides ',xterm-256color:Tc' \\; set-window-option automatic-rename off \\; rename-window {}",
+                    "tmux new-session -A{} -s {} -c {}{} \\; set status off \\; set mouse on \\; set default-terminal xterm-256color \\; set terminal-features 'xterm-256color:RGB' \\; set -as terminal-overrides ',xterm-256color:Tc' \\; set-window-option automatic-rename off \\; rename-window {}{}",
                     env_args,
                     shell_escape(session_name),
                     shell_escape(cwd),
                     initial_program,
-                    shell_escape(&window_name)
+                    shell_escape(&window_name),
+                    unset_args
                 );
                 Some((
                     "sh".to_string(),
@@ -967,7 +980,7 @@ mod tests {
     #[test]
     fn test_tmux_build_command_with_extra_env() {
         let backend = ResolvedBackend::Tmux;
-        let env = vec![("CLAUDE_CONFIG_DIR".to_string(), "/tmp/foo".to_string())];
+        let env = vec![("CLAUDE_CONFIG_DIR".to_string(), Some("/tmp/foo".to_string()))];
         let (_, args) = backend
             .build_command("tm-test", "/tmp", None, &env)
             .unwrap();
@@ -980,6 +993,26 @@ mod tests {
         let env_pos = args[1].find("-e ").unwrap();
         let s_pos = args[1].find("-s ").unwrap();
         assert!(env_pos < s_pos, "expected -e before -s in: {}", args[1]);
+    }
+
+    #[test]
+    fn test_tmux_build_command_unsets_env() {
+        let backend = ResolvedBackend::Tmux;
+        let env = vec![("CLAUDE_CONFIG_DIR".to_string(), None)];
+        let (_, args) = backend
+            .build_command("tm-test", "/tmp", None, &env)
+            .unwrap();
+        // A removal has no `-e` flag but clears the var from the session env.
+        assert!(
+            !args[1].contains("-e "),
+            "removal must not emit an -e flag, got: {}",
+            args[1]
+        );
+        assert!(
+            args[1].contains("set-environment -u 'CLAUDE_CONFIG_DIR'"),
+            "expected session-env unset, got: {}",
+            args[1]
+        );
     }
 
     #[test]

--- a/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
@@ -609,15 +609,16 @@ impl Render for TerminalContent {
                 cx.listener(|this, event: &MouseDownEvent, _window, cx| {
                     if this.try_forward_mouse_press(1, event.position, &event.modifiers) {
                         cx.notify();
-                        return;
-                    }
-                    #[cfg(target_os = "linux")]
-                    if let Some(ref terminal) = this.terminal
-                        && let Some(item) = cx.read_from_primary()
+                    } else {
+                        #[cfg(target_os = "linux")]
+                        if let Some(ref terminal) = this.terminal
+                            && let Some(item) = cx.read_from_primary()
                             && let Some(text) = item.text()
-                                && !text.is_empty() {
-                                    terminal.send_paste(&text);
-                                }
+                            && !text.is_empty()
+                        {
+                            terminal.send_paste(&text);
+                        }
+                    }
                 }),
             )
             .on_mouse_up(

--- a/crates/okena-workspace/src/state.rs
+++ b/crates/okena-workspace/src/state.rs
@@ -276,10 +276,10 @@ impl Workspace {
                 .collect();
 
         for project in &mut self.data.projects {
-            if visible_ids.iter().any(|id| id == &project.id) {
-                if let Some(layout) = project.layout.as_mut() {
-                    layout.transpose();
-                }
+            if visible_ids.iter().any(|id| id == &project.id)
+                && let Some(layout) = project.layout.as_mut()
+            {
+                layout.transpose();
             }
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -976,6 +976,12 @@ impl Okena {
 
 }
 
+impl Render for Okena {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div().size_full().child(self.main_window.clone())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::claude_pty_extra_env;
@@ -1003,11 +1009,5 @@ mod tests {
         assert_eq!(env.len(), 1);
         assert_eq!(env[0].0, "CLAUDE_CONFIG_DIR");
         assert_eq!(env[0].1, custom_dir.to_string_lossy());
-    }
-}
-
-impl Render for Okena {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        div().size_full().child(self.main_window.clone())
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -27,30 +27,60 @@ use gpui::*;
 use okena_core::api::ApiGitStatus;
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::sync::watch as tokio_watch;
 
-/// Push the resolved Claude config directory into the PTY manager as CLAUDE_CONFIG_DIR
-/// so `claude` invocations inside Okena terminals read the per-profile account.
+fn is_default_claude_dir(claude_dir: &Path) -> bool {
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    let default_dir = home.join(".claude");
+    let canonical_default = default_dir.canonicalize().unwrap_or(default_dir);
+    let canonical_dir = claude_dir
+        .canonicalize()
+        .unwrap_or_else(|_| claude_dir.to_path_buf());
+    canonical_dir == canonical_default
+}
+
+fn claude_pty_extra_env(
+    claude_dir: &Path,
+    multi_profile: bool,
+    parent_has_claude_config_dir: bool,
+) -> Vec<(String, String)> {
+    if is_default_claude_dir(claude_dir) {
+        return Vec::new();
+    }
+
+    if !multi_profile && parent_has_claude_config_dir {
+        return Vec::new();
+    }
+
+    vec![(
+        "CLAUDE_CONFIG_DIR".to_string(),
+        claude_dir.to_string_lossy().into_owned(),
+    )]
+}
+
+/// Push the resolved non-default Claude config directory into the PTY manager as
+/// CLAUDE_CONFIG_DIR so `claude` invocations inside Okena terminals read the
+/// per-profile account.
 ///
 /// Multi-profile users get an unconditional override (otherwise account isolation
 /// would silently break for anyone with `CLAUDE_CONFIG_DIR` exported in their
-/// shell rc). Single-profile users who have explicitly exported the var in their
-/// own environment keep it — there's no profile boundary to enforce.
+/// shell rc). Default `~/.claude` is left unset so Claude Code uses its canonical
+/// Keychain service instead of creating a suffixed duplicate for the same path.
 fn sync_claude_pty_env(pty_manager: &Arc<PtyManager>, cx: &App) {
     let multi_profile = okena_core::profiles::all_profiles()
         .map(|p| p.len() > 1)
         .unwrap_or(false);
-    if !multi_profile && std::env::var("CLAUDE_CONFIG_DIR").is_ok() {
-        pty_manager.set_extra_env(Vec::new());
-        return;
-    }
-
     let claude_dir = resolve_claude_dir(cx);
-    pty_manager.set_extra_env(vec![
-        ("CLAUDE_CONFIG_DIR".to_string(), claude_dir.to_string_lossy().into_owned()),
-    ]);
+    pty_manager.set_extra_env(claude_pty_extra_env(
+        &claude_dir,
+        multi_profile,
+        std::env::var("CLAUDE_CONFIG_DIR").is_ok(),
+    ));
 }
 
 /// Set up an observer that loads/unloads service configs when projects change.
@@ -944,6 +974,36 @@ impl Okena {
         }).detach();
     }
 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::claude_pty_extra_env;
+
+    #[test]
+    fn default_claude_dir_is_not_exported_to_pty() {
+        let default_dir = dirs::home_dir().unwrap().join(".claude");
+
+        assert!(claude_pty_extra_env(&default_dir, false, false).is_empty());
+        assert!(claude_pty_extra_env(&default_dir, true, false).is_empty());
+    }
+
+    #[test]
+    fn single_profile_keeps_parent_claude_config_dir() {
+        let custom_dir = std::env::temp_dir().join("okena-custom-claude-dir");
+
+        assert!(claude_pty_extra_env(&custom_dir, false, true).is_empty());
+    }
+
+    #[test]
+    fn custom_claude_dir_is_exported_to_pty() {
+        let custom_dir = std::env::temp_dir().join("okena-custom-claude-dir");
+        let env = claude_pty_extra_env(&custom_dir, true, true);
+
+        assert_eq!(env.len(), 1);
+        assert_eq!(env[0].0, "CLAUDE_CONFIG_DIR");
+        assert_eq!(env[0].1, custom_dir.to_string_lossy());
+    }
 }
 
 impl Render for Okena {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -48,29 +48,38 @@ fn claude_pty_extra_env(
     claude_dir: &Path,
     multi_profile: bool,
     parent_has_claude_config_dir: bool,
-) -> Vec<(String, String)> {
+) -> Vec<(String, Option<String>)> {
+    // Default `~/.claude`: actively remove CLAUDE_CONFIG_DIR from the PTY rather
+    // than just leaving it unset. This keeps Claude Code on its canonical Keychain
+    // service (an explicit CLAUDE_CONFIG_DIR=~/.claude makes it create a suffixed
+    // duplicate) *and* prevents a stale value — e.g. one exported in the shell
+    // that launched Okena and inherited by our process — from leaking into the
+    // terminal and silently pointing `claude` at the wrong account.
     if is_default_claude_dir(claude_dir) {
-        return Vec::new();
+        return vec![("CLAUDE_CONFIG_DIR".to_string(), None)];
     }
 
+    // Single-profile user who manages CLAUDE_CONFIG_DIR themselves: there's no
+    // profile boundary to enforce, so leave their exported value untouched.
     if !multi_profile && parent_has_claude_config_dir {
         return Vec::new();
     }
 
     vec![(
         "CLAUDE_CONFIG_DIR".to_string(),
-        claude_dir.to_string_lossy().into_owned(),
+        Some(claude_dir.to_string_lossy().into_owned()),
     )]
 }
 
-/// Push the resolved non-default Claude config directory into the PTY manager as
+/// Push the resolved Claude config directory into the PTY manager as
 /// CLAUDE_CONFIG_DIR so `claude` invocations inside Okena terminals read the
 /// per-profile account.
 ///
-/// Multi-profile users get an unconditional override (otherwise account isolation
-/// would silently break for anyone with `CLAUDE_CONFIG_DIR` exported in their
-/// shell rc). Default `~/.claude` is left unset so Claude Code uses its canonical
-/// Keychain service instead of creating a suffixed duplicate for the same path.
+/// Non-default dirs get an unconditional override for multi-profile users
+/// (otherwise account isolation would silently break for anyone with
+/// `CLAUDE_CONFIG_DIR` exported in their shell rc). The default `~/.claude` is
+/// actively *unset* instead so Claude Code uses its canonical Keychain service
+/// rather than creating a suffixed duplicate for the same path.
 fn sync_claude_pty_env(pty_manager: &Arc<PtyManager>, cx: &App) {
     let multi_profile = okena_core::profiles::all_profiles()
         .map(|p| p.len() > 1)
@@ -987,11 +996,18 @@ mod tests {
     use super::claude_pty_extra_env;
 
     #[test]
-    fn default_claude_dir_is_not_exported_to_pty() {
+    fn default_claude_dir_unsets_pty_env() {
         let default_dir = dirs::home_dir().unwrap().join(".claude");
 
-        assert!(claude_pty_extra_env(&default_dir, false, false).is_empty());
-        assert!(claude_pty_extra_env(&default_dir, true, false).is_empty());
+        // The default dir must produce an explicit removal so a stale inherited
+        // CLAUDE_CONFIG_DIR can't leak in — regardless of profile count or whether
+        // the parent process happened to have the var set.
+        for &(multi, parent) in &[(false, false), (true, false), (false, true), (true, true)] {
+            let env = claude_pty_extra_env(&default_dir, multi, parent);
+            assert_eq!(env.len(), 1, "multi={multi} parent={parent}");
+            assert_eq!(env[0].0, "CLAUDE_CONFIG_DIR");
+            assert_eq!(env[0].1, None, "default dir must unset, not set");
+        }
     }
 
     #[test]
@@ -1008,6 +1024,6 @@ mod tests {
 
         assert_eq!(env.len(), 1);
         assert_eq!(env[0].0, "CLAUDE_CONFIG_DIR");
-        assert_eq!(env[0].1, custom_dir.to_string_lossy());
+        assert_eq!(env[0].1.as_deref(), Some(custom_dir.to_string_lossy().as_ref()));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,7 @@ fn quit(_: &Quit, cx: &mut App) {
 
 /// About action handler - shows native macOS about panel
 #[cfg(target_os = "macos")]
+#[allow(clippy::manual_c_str_literals)]
 fn about(_: &About, _cx: &mut App) {
     use std::ffi::c_void;
 


### PR DESCRIPTION
## Summary
- Stop exporting `CLAUDE_CONFIG_DIR` for the default `~/.claude` config dir so Claude Code keeps using its canonical Keychain service.
- Make Claude usage auth ignore empty/expired OAuth access tokens and fall back to the suffixed Keychain service created when `CLAUDE_CONFIG_DIR` explicitly points at `~/.claude`.
- Fix Clippy warnings required by the CI toolchain after the branch changes.

## Changes
- Extracted Claude PTY env selection logic and covered default, custom, and parent-env cases.
- Added token extraction checks for empty and expired access tokens.
- Added macOS Keychain service fallback lookup for default + suffixed Claude Code credentials.
- Moved app tests after runtime items and applied narrow Clippy cleanups surfaced by `cargo clippy --workspace --all-targets -- -D warnings`.

## Test plan
- [x] `cargo test -p okena-ext-claude --lib`
- [x] `cargo test --bin okena app::tests:: --no-default-features`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `git diff --check`