### PR TITLE
feat(sidebar): activity-sorted project view with pinning

### DIFF
--- a/crates/okena-state/src/lib.rs
+++ b/crates/okena-state/src/lib.rs
@@ -20,7 +20,7 @@ pub use okena_layout::{LayoutNode, SplitDirection};
 pub use toast::{Toast, ToastAction, ToastActionStyle, ToastLevel};
 pub use transient::{DropZone, FocusedTerminalState, PendingWorktreeClose};
 pub use window_id::WindowId;
-pub use window_state::{ProjectLayoutMode, WindowBounds, WindowState};
+pub use window_state::{ProjectLayoutMode, ProjectSortMode, WindowBounds, WindowState};
 pub use workspace_data::{
     FolderData, HookTerminalEntry, HookTerminalStatus, ProjectData, WorkspaceData,
     WorktreeMetadata, is_bash_prompt_title,

--- a/crates/okena-state/src/window_state.rs
+++ b/crates/okena-state/src/window_state.rs
@@ -41,6 +41,39 @@ impl ProjectLayoutMode {
     }
 }
 
+/// How the sidebar orders projects in a window.
+///
+/// `Manual` (default) follows the persisted `project_order` and folder
+/// grouping — the user's hand-arranged layout. `Activity` ignores
+/// `project_order` and folders and instead groups projects into fixed tiers
+/// (pinned, needs-attention, running, rest) sorted by recent activity, so the
+/// projects that need attention float to the top. Stored per-window so each
+/// window can flip its own view independently.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectSortMode {
+    /// Hand-arranged order from `project_order` + folders. Default.
+    #[default]
+    Manual,
+    /// Tiered, activity-sorted view that ignores `project_order` and folders.
+    Activity,
+}
+
+impl ProjectSortMode {
+    /// Return the other mode.
+    pub fn toggled(self) -> Self {
+        match self {
+            ProjectSortMode::Manual => ProjectSortMode::Activity,
+            ProjectSortMode::Activity => ProjectSortMode::Manual,
+        }
+    }
+
+    /// True when the sidebar should use the activity-sorted view.
+    pub fn is_activity(self) -> bool {
+        matches!(self, ProjectSortMode::Activity)
+    }
+}
+
 /// Restore bounds for an OS window: origin + size in screen pixels.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct WindowBounds {
@@ -91,6 +124,9 @@ pub struct WindowState {
     /// Orientation of the project grid in this window (columns vs rows).
     #[serde(default)]
     pub project_layout: ProjectLayoutMode,
+    /// How the sidebar orders projects in this window (manual vs activity).
+    #[serde(default)]
+    pub project_sort_mode: ProjectSortMode,
     /// Per-folder collapsed state in this window's sidebar.
     #[serde(default)]
     pub folder_collapsed: HashMap<String, bool>,
@@ -113,6 +149,7 @@ impl Default for WindowState {
             folder_filter: None,
             project_widths: HashMap::new(),
             project_layout: ProjectLayoutMode::default(),
+            project_sort_mode: ProjectSortMode::default(),
             folder_collapsed: HashMap::new(),
             os_bounds: None,
             sidebar_open: None,
@@ -152,6 +189,7 @@ mod tests {
             folder_filter: Some("folder-7".to_string()),
             project_widths: widths,
             project_layout: ProjectLayoutMode::Rows,
+            project_sort_mode: ProjectSortMode::Activity,
             folder_collapsed: collapsed,
             os_bounds: Some(WindowBounds {
                 origin_x: 100.0,
@@ -170,6 +208,7 @@ mod tests {
         assert_eq!(reloaded.folder_filter, original.folder_filter);
         assert_eq!(reloaded.project_widths, original.project_widths);
         assert_eq!(reloaded.project_layout, original.project_layout);
+        assert_eq!(reloaded.project_sort_mode, original.project_sort_mode);
         assert_eq!(reloaded.folder_collapsed, original.folder_collapsed);
         assert_eq!(reloaded.os_bounds, original.os_bounds);
         assert_eq!(reloaded.sidebar_open, original.sidebar_open);
@@ -220,5 +259,6 @@ mod tests {
         assert!(s.os_bounds.is_none());
         assert_eq!(s.sidebar_open, None);
         assert_eq!(s.project_layout, ProjectLayoutMode::Columns);
+        assert_eq!(s.project_sort_mode, ProjectSortMode::Manual);
     }
 }

--- a/crates/okena-state/src/window_state.rs
+++ b/crates/okena-state/src/window_state.rs
@@ -127,6 +127,14 @@ pub struct WindowState {
     /// How the sidebar orders projects in this window (manual vs activity).
     #[serde(default)]
     pub project_sort_mode: ProjectSortMode,
+    /// Opt-in: in the manual (`ProjectSortMode::Manual`) view, surface a
+    /// "needs attention" section at the top of the sidebar that *duplicates*
+    /// the projects with an unseen bell/notification, so they're reachable
+    /// without losing the hand-arranged folder layout below. Default off.
+    /// Irrelevant in the activity view, which already has a NEEDS ATTENTION
+    /// tier. Per-window so each window opts in independently.
+    #[serde(default)]
+    pub show_attention_section: bool,
     /// Per-folder collapsed state in this window's sidebar.
     #[serde(default)]
     pub folder_collapsed: HashMap<String, bool>,
@@ -150,6 +158,7 @@ impl Default for WindowState {
             project_widths: HashMap::new(),
             project_layout: ProjectLayoutMode::default(),
             project_sort_mode: ProjectSortMode::default(),
+            show_attention_section: false,
             folder_collapsed: HashMap::new(),
             os_bounds: None,
             sidebar_open: None,
@@ -190,6 +199,7 @@ mod tests {
             project_widths: widths,
             project_layout: ProjectLayoutMode::Rows,
             project_sort_mode: ProjectSortMode::Activity,
+            show_attention_section: true,
             folder_collapsed: collapsed,
             os_bounds: Some(WindowBounds {
                 origin_x: 100.0,
@@ -209,6 +219,7 @@ mod tests {
         assert_eq!(reloaded.project_widths, original.project_widths);
         assert_eq!(reloaded.project_layout, original.project_layout);
         assert_eq!(reloaded.project_sort_mode, original.project_sort_mode);
+        assert_eq!(reloaded.show_attention_section, original.show_attention_section);
         assert_eq!(reloaded.folder_collapsed, original.folder_collapsed);
         assert_eq!(reloaded.os_bounds, original.os_bounds);
         assert_eq!(reloaded.sidebar_open, original.sidebar_open);
@@ -260,5 +271,6 @@ mod tests {
         assert_eq!(s.sidebar_open, None);
         assert_eq!(s.project_layout, ProjectLayoutMode::Columns);
         assert_eq!(s.project_sort_mode, ProjectSortMode::Manual);
+        assert!(!s.show_attention_section);
     }
 }

--- a/crates/okena-state/src/windows.rs
+++ b/crates/okena-state/src/windows.rs
@@ -232,6 +232,14 @@ impl WorkspaceData {
         Some(w.project_sort_mode)
     }
 
+    /// Flip the "needs attention" section opt-in on the targeted window and
+    /// return the new value. Unknown extra ids are a silent no-op (`None`).
+    pub fn toggle_show_attention_section(&mut self, id: WindowId) -> Option<bool> {
+        let w = self.window_mut(id)?;
+        w.show_attention_section = !w.show_attention_section;
+        Some(w.show_attention_section)
+    }
+
     /// Append a fresh extra window onto `extra_windows` and return its id.
     ///
     /// Snapshots the current set of project IDs into the new window's

--- a/crates/okena-state/src/windows.rs
+++ b/crates/okena-state/src/windows.rs
@@ -15,7 +15,7 @@
 //! not prescriptive of where they live.
 
 use crate::window_id::WindowId;
-use crate::window_state::{WindowBounds, WindowState};
+use crate::window_state::{ProjectSortMode, WindowBounds, WindowState};
 use crate::workspace_data::WorkspaceData;
 
 impl WorkspaceData {
@@ -214,6 +214,22 @@ impl WorkspaceData {
         if let Some(w) = self.window_mut(id) {
             w.sidebar_open = Some(open);
         }
+    }
+
+    /// Set the project sort mode (manual vs activity) on the targeted window.
+    /// Unknown extra ids are a silent no-op, matching the `window_mut` contract.
+    pub fn set_project_sort_mode(&mut self, id: WindowId, mode: ProjectSortMode) {
+        if let Some(w) = self.window_mut(id) {
+            w.project_sort_mode = mode;
+        }
+    }
+
+    /// Flip the project sort mode on the targeted window and return the new
+    /// value. Unknown extra ids are a silent no-op and return `None`.
+    pub fn toggle_project_sort_mode(&mut self, id: WindowId) -> Option<ProjectSortMode> {
+        let w = self.window_mut(id)?;
+        w.project_sort_mode = w.project_sort_mode.toggled();
+        Some(w.project_sort_mode)
     }
 
     /// Append a fresh extra window onto `extra_windows` and return its id.

--- a/crates/okena-state/src/workspace_data.rs
+++ b/crates/okena-state/src/workspace_data.rs
@@ -176,6 +176,20 @@ pub struct ProjectData {
     /// Hook terminals displayed in the service panel (persisted across restarts)
     #[serde(default)]
     pub hook_terminals: HashMap<String, HookTerminalEntry>,
+    /// Whether this project is pinned to the top of the activity-sorted view.
+    /// Pinned projects keep their stable manual order; only non-pinned projects
+    /// are reordered by activity. See [`crate::window_state::ProjectSortMode`].
+    #[serde(default)]
+    pub pinned: bool,
+    /// Unix-millis timestamp of the project's last meaningful activity
+    /// (focus, a finished command, or a bell/notification from one of its
+    /// terminals). Drives the ordering of the activity-sorted view. `None`
+    /// means no activity has been recorded yet (e.g. a freshly loaded
+    /// workspace). Persisted so the activity view is sensible right after a
+    /// restart rather than all-equal. NOT bumped on raw terminal output —
+    /// output volume is deliberately not treated as activity.
+    #[serde(default)]
+    pub last_activity_at: Option<u64>,
 }
 
 impl ProjectData {
@@ -250,6 +264,8 @@ mod tests {
             service_terminals: HashMap::new(),
             default_shell: None,
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         }
     }
 

--- a/crates/okena-terminal/src/terminal/io.rs
+++ b/crates/okena-terminal/src/terminal/io.rs
@@ -30,13 +30,16 @@ impl Terminal {
         // byte where each mark arrives. `advance_until_terminated` stops
         // the prompt sidecar at every OSC 133 so the main processor can
         // catch up before we read `grid.cursor.point`.
-        advance_with_prompt_marks(
+        let command_finished = advance_with_prompt_marks(
             &mut *term,
             &mut processor,
             &mut prompt_sidecar,
             &mut prompt_tracker,
             data,
         );
+        if command_finished {
+            self.command_finished_pending.store(true, Ordering::Relaxed);
+        }
 
         let history_after = term.grid().history_size();
         prompt_tracker.on_history_changed(
@@ -104,13 +107,16 @@ impl Terminal {
 
         let history_before = term.grid().history_size();
         sidecar.advance(&data);
-        advance_with_prompt_marks(
+        let command_finished = advance_with_prompt_marks(
             &mut *term,
             &mut processor,
             &mut prompt_sidecar,
             &mut prompt_tracker,
             &data,
         );
+        if command_finished {
+            self.command_finished_pending.store(true, Ordering::Relaxed);
+        }
         let history_after = term.grid().history_size();
         prompt_tracker.on_history_changed(
             history_before,

--- a/crates/okena-terminal/src/terminal/meta.rs
+++ b/crates/okena-terminal/src/terminal/meta.rs
@@ -59,6 +59,16 @@ impl Terminal {
             .swap(false, std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// Consume the one-shot "a command finished (OSC 133 ;D) since last drain"
+    /// edge. Returns true if a command completed since the previous call, then
+    /// resets it. The PTY event loop uses this to bump the owning project's
+    /// activity timestamp once per finished command (drives the activity-sorted
+    /// sidebar view). Shells without OSC 133 shell integration never raise it.
+    pub fn take_pending_command_finished(&self) -> bool {
+        self.command_finished_pending
+            .swap(false, std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// Mark that this pane raised an OSC 9/777 desktop notification. Drives the
     /// pane's attention border until focus clears it. Set by the app when it
     /// actually fires a notification, so it inherits the user's settings and

--- a/crates/okena-terminal/src/terminal/mod.rs
+++ b/crates/okena-terminal/src/terminal/mod.rs
@@ -203,6 +203,14 @@ pub struct Terminal {
     /// GPUI thread only.
     pub(super) prompt_tracker: Mutex<PromptTracker>,
 
+    /// One-shot "a command finished (OSC 133 ;D) since last drain" edge.
+    /// Set in `process_output` when the prompt sidecar records a
+    /// `CommandFinished` mark, consumed (swapped to false) by the PTY event
+    /// loop so a finished command bumps the owning project's activity
+    /// timestamp exactly once. Mirrors `bell_pending`; not Arc-shared since it
+    /// is only ever set on the GPUI thread. GPUI thread only.
+    pub(super) command_finished_pending: AtomicBool,
+
     /// Reverse index into the current list of `PromptStart` marks (0 =
     /// newest). `Some` while the user is walking through prompts with
     /// `jump_to_prompt_above/below`; reset to `None` on any output or
@@ -351,6 +359,7 @@ impl Terminal {
             osc_sidecar,
             prompt_sidecar: Mutex::new(PromptSidecar::new()),
             prompt_tracker: Mutex::new(PromptTracker::new()),
+            command_finished_pending: AtomicBool::new(false),
             prompt_jump_index: Mutex::new(None),
             last_output_time: Arc::new(Mutex::new(Instant::now())),
             shell_pid: Mutex::new(None),

--- a/crates/okena-terminal/src/terminal/prompt_marks.rs
+++ b/crates/okena-terminal/src/terminal/prompt_marks.rs
@@ -134,13 +134,18 @@ impl Perform for PromptSidecarPerform {
 /// itself as terminated; we advance the main processor up to the same byte
 /// offset (so the cursor is at its post-OSC position, which is unchanged
 /// since OSC sequences are zero-width) and then record the mark.
+///
+/// Returns `true` if at least one `CommandFinished` (OSC 133 ;D) mark was
+/// recorded in this chunk, so the caller can raise the per-terminal
+/// command-finished activity edge exactly once per drain.
 pub(super) fn advance_with_prompt_marks<L: EventListener>(
     term: &mut Term<L>,
     processor: &mut Processor,
     sidecar: &mut PromptSidecar,
     tracker: &mut PromptTracker,
     data: &[u8],
-) {
+) -> bool {
+    let mut command_finished = false;
     let mut pos = 0;
     while pos < data.len() {
         let consumed = sidecar
@@ -148,6 +153,9 @@ pub(super) fn advance_with_prompt_marks<L: EventListener>(
             .advance_until_terminated(&mut sidecar.perform, &data[pos..]);
         processor.advance(term, &data[pos..pos + consumed]);
         if let Some(kind) = sidecar.perform.pending.take() {
+            if matches!(kind, PromptMarkKind::CommandFinished { .. }) {
+                command_finished = true;
+            }
             let point = term.grid().cursor.point;
             tracker.record(kind, point);
         }
@@ -160,4 +168,5 @@ pub(super) fn advance_with_prompt_marks<L: EventListener>(
         }
         pos += consumed;
     }
+    command_finished
 }

--- a/crates/okena-views-sidebar/src/activity_order.rs
+++ b/crates/okena-views-sidebar/src/activity_order.rs
@@ -1,0 +1,226 @@
+//! Tiered, activity-based ordering for the sidebar's `ProjectSortMode::Activity`
+//! view.
+//!
+//! Pure ordering logic, decoupled from GPUI so it can be unit-tested. The
+//! render path gathers one [`ActivityEntry`] per project (resolving live
+//! terminal state from the registry) and calls [`order_by_activity`], which
+//! splits projects into fixed tiers and sorts each tier.
+//!
+//! ## Tiers (top to bottom)
+//!
+//! 1. **Pinned** — projects the user pinned. Kept in their stable manual order
+//!    (ascending `manual_index`), never reordered by activity, so they stay a
+//!    fixed anchor for muscle memory. A pinned project stays pinned even if it
+//!    also has attention/running state.
+//! 2. **Attention** — non-pinned projects with an unseen bell/notification.
+//!    These are what the user most needs to look at, so they sit just under the
+//!    pins. Sorted by most-recent activity first.
+//! 3. **Running** — non-pinned projects with a live foreground process but no
+//!    unseen alert. Sorted by most-recent activity first.
+//! 4. **Rest** — everything else, sorted by most-recent activity first.
+//!
+//! Within the three non-pinned tiers, ties (equal or both-`None`
+//! `last_activity_at`) break by ascending `manual_index` so ordering is stable
+//! and deterministic rather than hash-order noise.
+
+/// One project's inputs to the activity ordering. Built per render from
+/// persisted data (`pinned`, `last_activity_at`) plus live terminal state
+/// aggregated over the project's terminals (`has_attention`, `is_running`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ActivityEntry {
+    pub id: String,
+    /// Whether the project is pinned (top tier, stable order).
+    pub pinned: bool,
+    /// Stable manual position used for the pinned tier order and as the
+    /// tiebreaker within non-pinned tiers. Lower sorts first.
+    pub manual_index: usize,
+    /// Persisted unix-millis of last meaningful activity; `None` = never.
+    pub last_activity_at: Option<u64>,
+    /// Any of the project's terminals has an unseen bell or OSC notification.
+    pub has_attention: bool,
+    /// Any of the project's terminals has a running foreground child process.
+    pub is_running: bool,
+}
+
+/// Which tier a project landed in, for rendering section headers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActivityTier {
+    Pinned,
+    Attention,
+    Running,
+    Rest,
+}
+
+impl ActivityTier {
+    /// Human-readable section header label.
+    pub fn label(self) -> &'static str {
+        match self {
+            ActivityTier::Pinned => "PINNED",
+            ActivityTier::Attention => "NEEDS ATTENTION",
+            ActivityTier::Running => "RUNNING",
+            ActivityTier::Rest => "RECENT",
+        }
+    }
+}
+
+/// Order `entries` into the four tiers. Returns one `(tier, entry)` pair per
+/// input entry, in final render order (pinned first, then attention, running,
+/// rest). The caller renders a section header whenever the tier changes.
+pub fn order_by_activity(mut entries: Vec<ActivityEntry>) -> Vec<(ActivityTier, ActivityEntry)> {
+    // Stable manual order is the baseline; tier sorts refine it.
+    entries.sort_by_key(|e| e.manual_index);
+
+    let tier_of = |e: &ActivityEntry| -> ActivityTier {
+        if e.pinned {
+            ActivityTier::Pinned
+        } else if e.has_attention {
+            ActivityTier::Attention
+        } else if e.is_running {
+            ActivityTier::Running
+        } else {
+            ActivityTier::Rest
+        }
+    };
+
+    let mut pinned = Vec::new();
+    let mut attention = Vec::new();
+    let mut running = Vec::new();
+    let mut rest = Vec::new();
+    for e in entries {
+        match tier_of(&e) {
+            ActivityTier::Pinned => pinned.push(e),
+            ActivityTier::Attention => attention.push(e),
+            ActivityTier::Running => running.push(e),
+            ActivityTier::Rest => rest.push(e),
+        }
+    }
+
+    // Most-recent activity first; `None` (never active) sorts last; ties break
+    // by ascending manual_index (the Vec is already in manual order, so a
+    // stable sort on the activity key preserves that for equal keys).
+    let by_recency = |group: &mut Vec<ActivityEntry>| {
+        group.sort_by(|a, b| {
+            // Reverse so larger timestamp (more recent) comes first; `None`
+            // becomes the smallest, landing at the end after reversal.
+            b.last_activity_at.cmp(&a.last_activity_at)
+        });
+    };
+    by_recency(&mut attention);
+    by_recency(&mut running);
+    by_recency(&mut rest);
+
+    let mut out = Vec::new();
+    out.extend(pinned.into_iter().map(|e| (ActivityTier::Pinned, e)));
+    out.extend(attention.into_iter().map(|e| (ActivityTier::Attention, e)));
+    out.extend(running.into_iter().map(|e| (ActivityTier::Running, e)));
+    out.extend(rest.into_iter().map(|e| (ActivityTier::Rest, e)));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: &str, manual_index: usize) -> ActivityEntry {
+        ActivityEntry {
+            id: id.to_string(),
+            pinned: false,
+            manual_index,
+            last_activity_at: None,
+            has_attention: false,
+            is_running: false,
+        }
+    }
+
+    fn ids(ordered: &[(ActivityTier, ActivityEntry)]) -> Vec<String> {
+        ordered.iter().map(|(_, e)| e.id.clone()).collect()
+    }
+
+    #[test]
+    fn pinned_come_first_in_manual_order_regardless_of_activity() {
+        // Two pinned projects keep their manual order even though the second
+        // has more recent activity than the first. Pins are an anchor, not
+        // activity-sorted.
+        let mut a = entry("a", 0);
+        a.pinned = true;
+        a.last_activity_at = Some(10);
+        let mut b = entry("b", 1);
+        b.pinned = true;
+        b.last_activity_at = Some(999);
+        let out = order_by_activity(vec![b.clone(), a.clone()]);
+        assert_eq!(ids(&out), vec!["a", "b"]);
+        assert!(out.iter().all(|(t, _)| *t == ActivityTier::Pinned));
+    }
+
+    #[test]
+    fn attention_outranks_running_outranks_rest() {
+        let mut att = entry("att", 2);
+        att.has_attention = true;
+        let mut run = entry("run", 1);
+        run.is_running = true;
+        let rest = entry("rest", 0);
+        let out = order_by_activity(vec![rest, run, att]);
+        assert_eq!(ids(&out), vec!["att", "run", "rest"]);
+        assert_eq!(
+            out.iter().map(|(t, _)| *t).collect::<Vec<_>>(),
+            vec![ActivityTier::Attention, ActivityTier::Running, ActivityTier::Rest],
+        );
+    }
+
+    #[test]
+    fn pinned_wins_even_with_attention_elsewhere() {
+        // A pinned project sits above a non-pinned attention project.
+        let mut pinned = entry("p", 5);
+        pinned.pinned = true;
+        let mut att = entry("a", 0);
+        att.has_attention = true;
+        let out = order_by_activity(vec![att, pinned]);
+        assert_eq!(ids(&out), vec!["p", "a"]);
+    }
+
+    #[test]
+    fn within_tier_most_recent_activity_first() {
+        let mut older = entry("older", 0);
+        older.last_activity_at = Some(100);
+        let mut newer = entry("newer", 1);
+        newer.last_activity_at = Some(200);
+        let never = entry("never", 2); // None -> last
+        let out = order_by_activity(vec![older, never, newer]);
+        assert_eq!(ids(&out), vec!["newer", "older", "never"]);
+    }
+
+    #[test]
+    fn ties_break_by_manual_index() {
+        // Equal timestamps -> stable ascending manual_index.
+        let mut x = entry("x", 3);
+        x.last_activity_at = Some(50);
+        let mut y = entry("y", 1);
+        y.last_activity_at = Some(50);
+        let out = order_by_activity(vec![x, y]);
+        assert_eq!(ids(&out), vec!["y", "x"]);
+    }
+
+    #[test]
+    fn pinned_attention_running_rest_full_interleave() {
+        let mut pin = entry("pin", 9);
+        pin.pinned = true;
+        let mut att1 = entry("att1", 0);
+        att1.has_attention = true;
+        att1.last_activity_at = Some(10);
+        let mut att2 = entry("att2", 1);
+        att2.has_attention = true;
+        att2.last_activity_at = Some(20);
+        let mut run = entry("run", 2);
+        run.is_running = true;
+        let mut rest = entry("rest", 3);
+        rest.last_activity_at = Some(5);
+        let out = order_by_activity(vec![rest, run, att1, att2, pin]);
+        // pin (pinned) -> att2,att1 (attention by recency) -> run -> rest
+        assert_eq!(ids(&out), vec!["pin", "att2", "att1", "run", "rest"]);
+    }
+
+    #[test]
+    fn empty_input_yields_empty() {
+        assert!(order_by_activity(vec![]).is_empty());
+    }
+}

--- a/crates/okena-views-sidebar/src/context_menu.rs
+++ b/crates/okena-views-sidebar/src/context_menu.rs
@@ -153,6 +153,17 @@ impl ContextMenu {
         });
     }
 
+    /// Toggle the project's pinned state directly on the workspace, then close.
+    /// Self-contained (no event round-trip) since pinning is a single persisted
+    /// bool flip — see [`okena_workspace::state::Workspace::toggle_project_pinned`].
+    fn toggle_pinned(&self, cx: &mut Context<Self>) {
+        let project_id = self.request.project_id.clone();
+        self.workspace.update(cx, |ws, cx| {
+            ws.toggle_project_pinned(&project_id, cx);
+        });
+        self.close(cx);
+    }
+
     fn configure_hooks(&self, cx: &mut Context<Self>) {
         cx.emit(ContextMenuEvent::ConfigureHooks {
             project_id: self.request.project_id.clone(),
@@ -231,6 +242,7 @@ impl Render for ContextMenu {
         let project_name = project.map(|p| p.name.clone()).unwrap_or_default();
         let project_path = project.map(|p| p.path.clone()).unwrap_or_default();
         let is_worktree = project.map(|p| p.worktree_info.is_some()).unwrap_or(false);
+        let is_pinned = project.map(|p| p.pinned).unwrap_or(false);
         let is_git_repo = okena_git::is_git_repo(std::path::Path::new(&project_path));
         let project_path_for_worktree = project_path.clone();
         let project_path_for_rename_dir = project_path.clone();
@@ -313,6 +325,19 @@ impl Render for ContextMenu {
                             .on_click(cx.listener(|this, _, _window, cx| {
                                 this.focus_project(cx);
                             })),
+                    )
+                    // Pin / Unpin (anchors the project to the top of the
+                    // activity-sorted view; harmless in manual mode)
+                    .child(
+                        menu_item(
+                            "context-menu-toggle-pinned",
+                            "icons/bookmark.svg",
+                            if is_pinned { "Unpin" } else { "Pin to top" },
+                            &t,
+                        )
+                        .on_click(cx.listener(|this, _, _window, cx| {
+                            this.toggle_pinned(cx);
+                        })),
                     )
                     // Hide / Show Project (label + icon depend on extras presence and per-window hidden state)
                     .child(

--- a/crates/okena-views-sidebar/src/lib.rs
+++ b/crates/okena-views-sidebar/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 
+pub mod activity_order;
 pub mod sidebar;
 pub mod project_list;
 pub mod folder_list;

--- a/crates/okena-views-sidebar/src/project_list.rs
+++ b/crates/okena-views-sidebar/src/project_list.rs
@@ -166,6 +166,15 @@ impl Sidebar {
                 }));
                 sidebar_name_or_badge(name_label, &project_name, hide_terminal_badge, project.terminal_ids.len(), &t, cx)
             })
+            // 3b. Pin marker
+            .when(project.pinned, |d| {
+                d.child(
+                    svg()
+                        .path("icons/bookmark.svg")
+                        .size(px(11.0))
+                        .text_color(rgb(t.text_secondary)),
+                )
+            })
             // 4. Idle dot
             .when(idle_count > 0 && !is_busy, |d| d.child(sidebar_idle_dot(&t)))
             // 5. Worktree badge (Project style only)

--- a/crates/okena-views-sidebar/src/sidebar/cursor.rs
+++ b/crates/okena-views-sidebar/src/sidebar/cursor.rs
@@ -247,8 +247,24 @@ impl Sidebar {
             || self.folder_rename.is_some()
     }
 
+    /// True when this window's sidebar is in the activity-sorted view, where
+    /// the cursor-key handlers below no-op. The keyboard cursor list is built
+    /// from the manual `project_order`+folder ordering (`build_cursor_items`),
+    /// which does not line up with the activity view's tiered, activity-sorted
+    /// rows — acting on it would scroll to and confirm rows the user sees no
+    /// highlight on. `Escape` is intentionally left active (it just clears the
+    /// cursor and restores focus, which is harmless in either mode).
+    fn is_activity_sort_mode(&self, cx: &App) -> bool {
+        self.workspace
+            .read(cx)
+            .data()
+            .window(self.window_id)
+            .map(|w| w.project_sort_mode.is_activity())
+            .unwrap_or(false)
+    }
+
     pub(super) fn handle_sidebar_up(&mut self, _: &SidebarUp, _window: &mut Window, cx: &mut Context<Self>) {
-        if self.is_interactive_mode_active() { return; }
+        if self.is_interactive_mode_active() || self.is_activity_sort_mode(cx) { return; }
         let items = self.build_cursor_items(cx);
         if items.is_empty() { return; }
         match self.cursor_index {
@@ -261,7 +277,7 @@ impl Sidebar {
     }
 
     pub(super) fn handle_sidebar_down(&mut self, _: &SidebarDown, _window: &mut Window, cx: &mut Context<Self>) {
-        if self.is_interactive_mode_active() { return; }
+        if self.is_interactive_mode_active() || self.is_activity_sort_mode(cx) { return; }
         let items = self.build_cursor_items(cx);
         if items.is_empty() { return; }
         match self.cursor_index {
@@ -286,7 +302,7 @@ impl Sidebar {
             self.finish_rename(cx);
             return;
         }
-        if self.is_interactive_mode_active() { return; }
+        if self.is_interactive_mode_active() || self.is_activity_sort_mode(cx) { return; }
         let items = self.build_cursor_items(cx);
         let Some(idx) = self.cursor_index else { return };
         let Some(item) = items.get(idx) else { return };
@@ -414,7 +430,7 @@ impl Sidebar {
     }
 
     pub(super) fn handle_sidebar_toggle_expand(&mut self, _: &SidebarToggleExpand, _window: &mut Window, cx: &mut Context<Self>) {
-        if self.is_interactive_mode_active() { return; }
+        if self.is_interactive_mode_active() || self.is_activity_sort_mode(cx) { return; }
         let items = self.build_cursor_items(cx);
         let Some(idx) = self.cursor_index else { return };
         let Some(item) = items.get(idx) else { return };

--- a/crates/okena-views-sidebar/src/sidebar/cursor.rs
+++ b/crates/okena-views-sidebar/src/sidebar/cursor.rs
@@ -31,8 +31,16 @@ impl Sidebar {
         cx.notify();
     }
 
-    /// Build a flat list of cursor items matching the visual render order
+    /// Build a flat list of cursor items matching the visual render order.
+    ///
+    /// In the activity view the rendered order is tiered and activity-sorted,
+    /// not the manual `project_order`+folder walk below, so we return the list
+    /// the render path already built (`activity_cursor_items`) verbatim — it is
+    /// kept 1:1 with the rows on screen.
     pub(super) fn build_cursor_items(&self, cx: &mut Context<Self>) -> Vec<SidebarCursorItem> {
+        if self.is_activity_sort_mode(cx) {
+            return self.activity_cursor_items.clone();
+        }
         let workspace = self.workspace.read(cx);
         let all_projects: HashMap<&str, &ProjectData> = workspace.data().projects.iter()
             .map(|p| (p.id.as_str(), p))
@@ -247,13 +255,10 @@ impl Sidebar {
             || self.folder_rename.is_some()
     }
 
-    /// True when this window's sidebar is in the activity-sorted view, where
-    /// the cursor-key handlers below no-op. The keyboard cursor list is built
-    /// from the manual `project_order`+folder ordering (`build_cursor_items`),
-    /// which does not line up with the activity view's tiered, activity-sorted
-    /// rows — acting on it would scroll to and confirm rows the user sees no
-    /// highlight on. `Escape` is intentionally left active (it just clears the
-    /// cursor and restores focus, which is harmless in either mode).
+    /// True when this window's sidebar is in the activity-sorted view. Used to
+    /// dispatch `build_cursor_items` to the activity cursor list (built by the
+    /// render path to match the tiered rows 1:1) instead of the manual
+    /// `project_order`+folder walk.
     fn is_activity_sort_mode(&self, cx: &App) -> bool {
         self.workspace
             .read(cx)
@@ -264,7 +269,7 @@ impl Sidebar {
     }
 
     pub(super) fn handle_sidebar_up(&mut self, _: &SidebarUp, _window: &mut Window, cx: &mut Context<Self>) {
-        if self.is_interactive_mode_active() || self.is_activity_sort_mode(cx) { return; }
+        if self.is_interactive_mode_active() { return; }
         let items = self.build_cursor_items(cx);
         if items.is_empty() { return; }
         match self.cursor_index {
@@ -272,12 +277,12 @@ impl Sidebar {
             None => self.cursor_index = Some(items.len() - 1),
             _ => {}
         }
-        self.scroll_to_cursor(items.len());
+        self.scroll_to_cursor();
         cx.notify();
     }
 
     pub(super) fn handle_sidebar_down(&mut self, _: &SidebarDown, _window: &mut Window, cx: &mut Context<Self>) {
-        if self.is_interactive_mode_active() || self.is_activity_sort_mode(cx) { return; }
+        if self.is_interactive_mode_active() { return; }
         let items = self.build_cursor_items(cx);
         if items.is_empty() { return; }
         match self.cursor_index {
@@ -285,7 +290,7 @@ impl Sidebar {
             None => self.cursor_index = Some(0),
             _ => {}
         }
-        self.scroll_to_cursor(items.len());
+        self.scroll_to_cursor();
         cx.notify();
     }
 
@@ -302,7 +307,7 @@ impl Sidebar {
             self.finish_rename(cx);
             return;
         }
-        if self.is_interactive_mode_active() || self.is_activity_sort_mode(cx) { return; }
+        if self.is_interactive_mode_active() { return; }
         let items = self.build_cursor_items(cx);
         let Some(idx) = self.cursor_index else { return };
         let Some(item) = items.get(idx) else { return };
@@ -430,7 +435,7 @@ impl Sidebar {
     }
 
     pub(super) fn handle_sidebar_toggle_expand(&mut self, _: &SidebarToggleExpand, _window: &mut Window, cx: &mut Context<Self>) {
-        if self.is_interactive_mode_active() || self.is_activity_sort_mode(cx) { return; }
+        if self.is_interactive_mode_active() { return; }
         let items = self.build_cursor_items(cx);
         let Some(idx) = self.cursor_index else { return };
         let Some(item) = items.get(idx) else { return };
@@ -490,11 +495,18 @@ impl Sidebar {
         cx.notify();
     }
 
-    /// Scroll the sidebar to keep the cursor item visible
-    fn scroll_to_cursor(&self, item_count: usize) {
+    /// Scroll the sidebar to keep the cursor item visible.
+    ///
+    /// `cursor_index` counts cursor-navigable rows, but the scroll container
+    /// also holds non-navigable children (the leading drop zone, the opt-in
+    /// attention section, and — in the activity view — tier headers between
+    /// rows). `cursor_scroll_indices`, populated by the render path, maps the
+    /// cursor index to the actual scroll-child index for the current view.
+    fn scroll_to_cursor(&self) {
         if let Some(idx) = self.cursor_index
-            && item_count > 0 {
-                self.scroll_handle.scroll_to_item(idx);
-            }
+            && let Some(&target) = self.cursor_scroll_indices.get(idx)
+        {
+            self.scroll_handle.scroll_to_item(target);
+        }
     }
 }

--- a/crates/okena-views-sidebar/src/sidebar/from_project_test.rs
+++ b/crates/okena-views-sidebar/src/sidebar/from_project_test.rs
@@ -27,6 +27,8 @@ fn make_project(id: &str) -> ProjectData {
         service_terminals: HashMap::new(),
         default_shell: None,
         hook_terminals: HashMap::new(),
+        pinned: false,
+        last_activity_at: None,
     }
 }
 

--- a/crates/okena-views-sidebar/src/sidebar/mod.rs
+++ b/crates/okena-views-sidebar/src/sidebar/mod.rs
@@ -23,11 +23,13 @@ use okena_terminal::TerminalsRegistry;
 use okena_ui::click_detector::ClickDetector;
 use okena_ui::rename_state::RenameState;
 use okena_ui::theme::theme;
-use okena_ui::tokens::{ui_text_ms, ui_text_xl};
+use okena_ui::tokens::{ui_text_ms, ui_text_xl, ui_text_xs};
 use okena_workspace::request_broker::RequestBroker;
 use okena_workspace::state::{FolderData, ProjectData, WindowId, Workspace};
 use gpui::*;
+use gpui::prelude::FluentBuilder;
 use gpui_component::h_flex;
+use gpui_component::tooltip::Tooltip;
 use std::collections::{HashMap, HashSet};
 
 /// Callback for dispatching actions for a given project.
@@ -166,6 +168,19 @@ pub struct Sidebar {
     /// activity-view ordering so a finishing command / bell doesn't reshuffle
     /// rows mid-interaction.
     pub(crate) activity_pointer_inside: bool,
+    /// Cursor-navigable items for the activity view, in exact rendered order
+    /// (project rows + their expanded group/terminal children; tier headers
+    /// and the attention mirror are not navigable). Rebuilt every render of the
+    /// activity path; `build_cursor_items` returns this verbatim in activity
+    /// mode so keyboard nav lines up 1:1 with what's on screen. Empty in manual
+    /// mode.
+    pub(crate) activity_cursor_items: Vec<SidebarCursorItem>,
+    /// Scroll-child index for each `cursor_index`, populated every render by
+    /// both paths. The scroll container interleaves non-navigable children
+    /// (the leading drop zone and attention section in the manual view; tier
+    /// headers in the activity view) with the navigable rows, so `cursor_index`
+    /// is not the scroll-child index — this maps one to the other.
+    pub(crate) cursor_scroll_indices: Vec<usize>,
 }
 
 impl Sidebar {
@@ -217,6 +232,8 @@ impl Sidebar {
             get_remote_folder: None,
             activity_order_cache: Vec::new(),
             activity_pointer_inside: false,
+            activity_cursor_items: Vec::new(),
+            cursor_scroll_indices: Vec::new(),
         }
     }
 
@@ -439,14 +456,13 @@ impl Sidebar {
         let focus_manager = self.focus_manager.clone();
         let window_id = self.window_id;
 
-        let activity_mode = self
+        let (activity_mode, show_attention) = self
             .workspace
             .read(cx)
             .data()
             .window(window_id)
-            .map(|w| w.project_sort_mode.is_activity())
-            .unwrap_or(false);
-        let toggle_color = if activity_mode { t.border_active } else { t.text_secondary };
+            .map(|w| (w.project_sort_mode.is_activity(), w.show_attention_section))
+            .unwrap_or((false, false));
 
         div()
             .h(px(28.0))
@@ -474,29 +490,93 @@ impl Sidebar {
                     .child("PROJECTS"),
             )
             .child(
-                // Sort-by-activity toggle. Highlighted when active. Stops click
-                // propagation so flipping the mode doesn't also clear focus via
-                // the header's on_click above.
-                div()
-                    .id("sort-mode-toggle")
-                    .cursor_pointer()
-                    .px(px(4.0))
-                    .py(px(2.0))
-                    .rounded(px(4.0))
-                    .hover(|s| s.bg(rgb(t.bg_hover)))
-                    .child(
-                        svg()
-                            .path("icons/focus.svg")
-                            .size(px(14.0))
-                            .text_color(rgb(toggle_color)),
-                    )
-                    .on_click(cx.listener(move |this, _, _window, cx| {
-                        cx.stop_propagation();
-                        this.workspace.update(cx, |ws, cx| {
-                            ws.toggle_project_sort_mode(window_id, cx);
-                        });
-                    })),
+                h_flex()
+                    .gap(px(4.0))
+                    .items_center()
+                    // "Needs attention" opt-in. Only relevant in the manual
+                    // (Custom) view — the Activity view already has a NEEDS
+                    // ATTENTION tier — so it's hidden in activity mode.
+                    .when(!activity_mode, |row| {
+                        let attn_color = if show_attention { t.border_active } else { t.text_secondary };
+                        row.child(
+                            div()
+                                .id("attention-toggle")
+                                .cursor_pointer()
+                                .flex()
+                                .items_center()
+                                .px(px(4.0))
+                                .py(px(2.0))
+                                .rounded(px(4.0))
+                                .hover(|s| s.bg(rgb(t.bg_hover)))
+                                .child(
+                                    svg()
+                                        .path("icons/bell.svg")
+                                        .size(px(13.0))
+                                        .text_color(rgb(attn_color)),
+                                )
+                                .tooltip(|_window, cx| {
+                                    Tooltip::new("Show a \"needs attention\" section at the top")
+                                        .build(_window, cx)
+                                })
+                                .on_click(cx.listener(move |this, _, _window, cx| {
+                                    cx.stop_propagation();
+                                    this.workspace.update(cx, |ws, cx| {
+                                        ws.toggle_show_attention_section(window_id, cx);
+                                    });
+                                })),
+                        )
+                    })
+                    // Sort-order toggle: Custom (hand-arranged folders) vs
+                    // Activity (tiered, activity-sorted). Segmented so both
+                    // states are visible and labeled. Stops click propagation
+                    // so flipping the mode doesn't clear focus via the header.
+                    .child(self.render_sort_mode_toggle(activity_mode, cx)),
             )
+    }
+
+    /// Segmented `Custom | Activity` control for the projects header.
+    fn render_sort_mode_toggle(&self, activity_mode: bool, cx: &mut Context<Self>) -> impl IntoElement {
+        let t = theme(cx);
+        let window_id = self.window_id;
+
+        let segment = |label: &'static str, id: &'static str, active: bool, cx: &mut Context<Self>| {
+            let mut seg = div()
+                .id(id)
+                .px(px(8.0))
+                .py(px(1.0))
+                .rounded(px(4.0))
+                .text_size(ui_text_xs(cx))
+                .cursor_pointer();
+            if active {
+                seg = seg
+                    .bg(rgb(t.bg_primary))
+                    .text_color(rgb(t.text_primary))
+                    .shadow_sm();
+            } else {
+                seg = seg
+                    .text_color(rgb(t.text_muted))
+                    .hover(|s| s.text_color(rgb(t.text_secondary)));
+            }
+            seg.child(label).on_click(cx.listener(move |this, _, _window, cx| {
+                cx.stop_propagation();
+                // Only flip when switching to the other mode; clicking the
+                // already-active segment is a no-op.
+                if active {
+                    return;
+                }
+                this.workspace.update(cx, |ws, cx| {
+                    ws.toggle_project_sort_mode(window_id, cx);
+                });
+            }))
+        };
+
+        h_flex()
+            .gap(px(2.0))
+            .rounded(px(6.0))
+            .bg(rgb(t.bg_secondary))
+            .p(px(2.0))
+            .child(segment("Custom", "sort-seg-custom", !activity_mode, cx))
+            .child(segment("Activity", "sort-seg-activity", activity_mode, cx))
     }
 }
 

--- a/crates/okena-views-sidebar/src/sidebar/mod.rs
+++ b/crates/okena-views-sidebar/src/sidebar/mod.rs
@@ -158,6 +158,14 @@ pub struct Sidebar {
     pub(crate) send_remote_action: Option<SendRemoteActionFn>,
     /// Callback to get remote folder ID for reordering
     pub(crate) get_remote_folder: Option<GetRemoteFolderFn>,
+    /// Last computed activity-view ordering `(tier, project_id)`. Reused while
+    /// the pointer is inside the sidebar (hover-freeze) so rows don't reshuffle
+    /// out from under the cursor; recomputed once the pointer leaves.
+    pub(crate) activity_order_cache: Vec<(crate::activity_order::ActivityTier, String)>,
+    /// True while the pointer is hovering the sidebar scroll area. Freezes the
+    /// activity-view ordering so a finishing command / bell doesn't reshuffle
+    /// rows mid-interaction.
+    pub(crate) activity_pointer_inside: bool,
 }
 
 impl Sidebar {
@@ -207,6 +215,8 @@ impl Sidebar {
             get_remote_connections: None,
             send_remote_action: None,
             get_remote_folder: None,
+            activity_order_cache: Vec::new(),
+            activity_pointer_inside: false,
         }
     }
 
@@ -429,6 +439,15 @@ impl Sidebar {
         let focus_manager = self.focus_manager.clone();
         let window_id = self.window_id;
 
+        let activity_mode = self
+            .workspace
+            .read(cx)
+            .data()
+            .window(window_id)
+            .map(|w| w.project_sort_mode.is_activity())
+            .unwrap_or(false);
+        let toggle_color = if activity_mode { t.border_active } else { t.text_secondary };
+
         div()
             .h(px(28.0))
             .px(px(12.0))
@@ -453,6 +472,30 @@ impl Sidebar {
                     .font_weight(FontWeight::SEMIBOLD)
                     .text_color(rgb(t.text_secondary))
                     .child("PROJECTS"),
+            )
+            .child(
+                // Sort-by-activity toggle. Highlighted when active. Stops click
+                // propagation so flipping the mode doesn't also clear focus via
+                // the header's on_click above.
+                div()
+                    .id("sort-mode-toggle")
+                    .cursor_pointer()
+                    .px(px(4.0))
+                    .py(px(2.0))
+                    .rounded(px(4.0))
+                    .hover(|s| s.bg(rgb(t.bg_hover)))
+                    .child(
+                        svg()
+                            .path("icons/focus.svg")
+                            .size(px(14.0))
+                            .text_color(rgb(toggle_color)),
+                    )
+                    .on_click(cx.listener(move |this, _, _window, cx| {
+                        cx.stop_propagation();
+                        this.workspace.update(cx, |ws, cx| {
+                            ws.toggle_project_sort_mode(window_id, cx);
+                        });
+                    })),
             )
     }
 }
@@ -510,6 +553,9 @@ pub struct SidebarProjectInfo {
     pub is_creating: bool,
     /// Whether this project is itself a worktree
     pub is_worktree: bool,
+    /// Whether this project is pinned (shows a pin marker; drives the pinned
+    /// tier in the activity-sorted view).
+    pub pinned: bool,
 }
 
 impl SidebarProjectInfo {
@@ -567,6 +613,7 @@ impl SidebarProjectInfo {
             is_closing: false,
             is_creating: false,
             is_worktree: project.worktree_info.is_some(),
+            pinned: project.pinned,
         }
     }
 }

--- a/crates/okena-views-sidebar/src/sidebar/render.rs
+++ b/crates/okena-views-sidebar/src/sidebar/render.rs
@@ -1,10 +1,11 @@
 //! Top-level `Render` impl for the sidebar and the `render_expanded_children`
 //! helper that lays out per-project terminal / service / hook groups.
 
-use super::{GroupKind, Sidebar, SidebarItem, SidebarProjectInfo, SidebarServiceInfo};
+use super::{GroupKind, Sidebar, SidebarCursorItem, SidebarItem, SidebarProjectInfo, SidebarServiceInfo};
 use crate::activity_order::{order_by_activity, ActivityEntry, ActivityTier};
 use crate::drag::{FolderDrag, ProjectDrag};
 use gpui::*;
+use okena_ui::color_dot::color_dot;
 use okena_ui::theme::theme;
 use okena_ui::tokens::ui_text_ms;
 use okena_workspace::requests::SidebarRequest;
@@ -255,12 +256,43 @@ impl Sidebar {
                 ord
             };
 
+        // Phase 2b — build the cursor-navigable item list + its scroll-index map
+        // in the exact order the rows render below. `build_cursor_items` returns
+        // this list verbatim in activity mode so keyboard nav lines up 1:1 with
+        // the screen. Every cursor item maps to exactly one flat element and the
+        // only non-navigable flat elements are tier headers, so a cursor item's
+        // scroll-child index is its own index plus the headers emitted before it.
+        let mut cursor_items: Vec<SidebarCursorItem> = Vec::new();
+        let mut scroll_indices: Vec<usize> = Vec::new();
+        {
+            let mut headers_before = 0usize;
+            let mut last_tier: Option<ActivityTier> = None;
+            for (tier, id) in &ordering {
+                if last_tier != Some(*tier) {
+                    headers_before += 1;
+                    last_tier = Some(*tier);
+                }
+                let Some(info) = infos.get(id) else { continue };
+                let first = cursor_items.len();
+                cursor_items.push(SidebarCursorItem::Project { project_id: id.clone() });
+                if self.expanded_projects.contains(id) {
+                    self.push_activity_group_cursor_items(info, &mut cursor_items);
+                }
+                // No tier header falls between a project and its children, so
+                // `headers_before` is constant across this project's run.
+                scroll_indices.extend((first..cursor_items.len()).map(|i| i + headers_before));
+            }
+        }
+        self.validate_cursor(cursor_items.len());
+        let cursor_index = self.cursor_index;
+        self.activity_cursor_items = cursor_items;
+        self.cursor_scroll_indices = scroll_indices;
+
         // Phase 3 — render rows with a section header whenever the tier changes.
         let focused_project_id = self.focus_manager.read(cx).focused_project_id().cloned();
         let mut flat_elements: Vec<AnyElement> = Vec::new();
-        // Cursor-key navigation is not wired for the activity view yet; rows
-        // render without the keyboard cursor highlight. `flat_idx` is still
-        // threaded for render_expanded_children's internal accounting.
+        // `flat_idx` counts cursor-navigable rows (not tier headers), matching
+        // the index space of `cursor_items` built above so `is_cursor` lines up.
         let mut flat_idx: usize = 0;
         let mut last_tier: Option<ActivityTier> = None;
         for (tier, id) in ordering {
@@ -269,18 +301,141 @@ impl Sidebar {
                 last_tier = Some(tier);
             }
             let Some(info) = infos.get(&id) else { continue };
+            let is_cursor = cursor_index == Some(flat_idx);
             let is_focused_project = focused_project_id.as_ref() == Some(&id);
             let idx = manual_index.get(&id).copied().unwrap_or(0);
             flat_elements.push(
-                self.render_project_item(info, idx, false, is_focused_project, window, cx)
+                self.render_project_item(info, idx, is_cursor, is_focused_project, window, cx)
                     .into_any_element(),
             );
             flat_idx += 1;
             if self.expanded_projects.contains(&id) {
-                self.render_expanded_children(info, 20.0, 34.0, "", None, &mut flat_idx, &mut flat_elements, cx);
+                self.render_expanded_children(info, 20.0, 34.0, "", cursor_index, &mut flat_idx, &mut flat_elements, cx);
             }
         }
         flat_elements
+    }
+
+    /// Append the cursor-navigable rows of an expanded project (group headers +
+    /// their children) for the activity view's cursor list.
+    ///
+    /// Reads the same `SidebarProjectInfo` fields `render_expanded_children`
+    /// renders from, so the two stay aligned by construction; it MUST keep
+    /// emitting one entry per element that function pushes, in the same order
+    /// and under the same collapse conditions. (It can't reuse
+    /// `push_group_cursor_items`, which derives terminals from the raw layout
+    /// without filtering hook terminals and so diverges from the rendered rows.)
+    fn push_activity_group_cursor_items(
+        &self,
+        info: &SidebarProjectInfo,
+        cursor_items: &mut Vec<SidebarCursorItem>,
+    ) {
+        // Terminals group
+        if !info.terminal_ids.is_empty() {
+            cursor_items.push(SidebarCursorItem::GroupHeader { project_id: info.id.clone(), group: GroupKind::Terminals });
+            if !self.is_group_collapsed(&info.id, &GroupKind::Terminals) {
+                for tid in &info.terminal_ids {
+                    cursor_items.push(SidebarCursorItem::Terminal { project_id: info.id.clone(), terminal_id: tid.clone() });
+                }
+            }
+        }
+        // Services group
+        if !info.services.is_empty() {
+            cursor_items.push(SidebarCursorItem::GroupHeader { project_id: info.id.clone(), group: GroupKind::Services });
+            if !self.is_group_collapsed(&info.id, &GroupKind::Services) {
+                for service in &info.services {
+                    cursor_items.push(SidebarCursorItem::Service { project_id: info.id.clone(), service_name: service.name.clone() });
+                }
+            }
+        }
+        // Hooks group
+        if !info.hook_terminals.is_empty() {
+            cursor_items.push(SidebarCursorItem::GroupHeader { project_id: info.id.clone(), group: GroupKind::Hooks });
+            if !self.is_group_collapsed(&info.id, &GroupKind::Hooks) {
+                for hook in &info.hook_terminals {
+                    cursor_items.push(SidebarCursorItem::Hook { project_id: info.id.clone(), terminal_id: hook.terminal_id.clone() });
+                }
+            }
+        }
+    }
+
+    /// Collect, in most-recent-activity-first order, the projects with an
+    /// unseen bell/notification on any of their terminals — the source for the
+    /// opt-in "needs attention" section in the manual view. Owned infos so the
+    /// caller can render after releasing the workspace borrow.
+    fn collect_attention_infos(&self, workspace: &Workspace) -> Vec<SidebarProjectInfo> {
+        let terminals = self.terminals.lock();
+        // Determine attention cheaply from raw layout + terminal state first;
+        // only build the (potentially git-touching) `SidebarProjectInfo` for the
+        // few projects that actually qualify. Hook terminals are excluded to
+        // match the activity view's `terminal_ids` (which filters them out).
+        let mut hits: Vec<(Option<u64>, &ProjectData)> = Vec::new();
+        for project in &workspace.data().projects {
+            let has_attention = project
+                .layout
+                .as_ref()
+                .map(|l| l.collect_terminal_ids())
+                .unwrap_or_default()
+                .iter()
+                .any(|tid| {
+                    !project.hook_terminals.contains_key(tid)
+                        && terminals
+                            .get(tid.as_str())
+                            .is_some_and(|t| t.has_bell() || t.has_notification())
+                });
+            if has_attention {
+                hits.push((project.last_activity_at, project));
+            }
+        }
+        drop(terminals);
+        // Most-recent activity first; `None` (never active) sorts last.
+        hits.sort_by_key(|h| std::cmp::Reverse(h.0));
+        hits.into_iter()
+            .map(|(_, project)| SidebarProjectInfo::from_project(project, workspace, self.window_id))
+            .collect()
+    }
+
+    /// One compact, non-draggable "mirror" row for the manual view's needs-
+    /// attention section. Clicking focuses the canonical project (the same
+    /// action as its real row below); it is not a second entity and is not part
+    /// of keyboard cursor navigation.
+    fn render_attention_mirror_row(&self, info: &SidebarProjectInfo, cx: &mut Context<Self>) -> impl IntoElement {
+        let t = theme(cx);
+        let project_id = info.id.clone();
+        let dot_color = t.get_folder_color(info.folder_color);
+        div()
+            .id(ElementId::Name(format!("attention-mirror-{}", info.id).into()))
+            .h(px(24.0))
+            .pl(px(12.0))
+            .pr(px(8.0))
+            .flex()
+            .items_center()
+            .gap(px(6.0))
+            .cursor_pointer()
+            .hover(|s| s.bg(rgb(t.bg_hover)))
+            .child(color_dot(dot_color, info.is_worktree))
+            .child(crate::item_widgets::sidebar_name_label(
+                ElementId::Name(format!("attention-mirror-name-{}", info.id).into()),
+                info.name.clone(),
+                &t,
+                cx,
+            ))
+            .child(
+                svg()
+                    .path("icons/bell.svg")
+                    .size(px(12.0))
+                    .text_color(rgb(t.border_active)),
+            )
+            .on_click(cx.listener(move |this, _, _window, cx| {
+                this.cursor_index = None;
+                let workspace = this.workspace.clone();
+                this.focus_manager.update(cx, |fm, cx| {
+                    workspace.update(cx, |ws, cx| {
+                        ws.set_focused_project_individual(fm, Some(project_id.clone()), cx);
+                    });
+                    cx.notify();
+                });
+            }))
     }
 
     /// Render expanded children (terminals group + services group) for a project.
@@ -435,7 +590,25 @@ impl Render for Sidebar {
             return self.render_sidebar_container(flat_elements, cx);
         }
 
+        // Manual path: cursor nav uses `build_cursor_items` (manual order), so
+        // drop the activity-view cursor list from a previous render.
+        self.activity_cursor_items.clear();
+
         let workspace = self.workspace.read(cx);
+
+        // Opt-in "needs attention" section: collect (owned) the attention
+        // projects to mirror at the top, in most-recent-first order. Computed
+        // under the workspace borrow; rendered after it is released.
+        let show_attention = workspace
+            .data()
+            .window(self.window_id)
+            .map(|w| w.show_attention_section)
+            .unwrap_or(false);
+        let attention_infos = if show_attention {
+            self.collect_attention_infos(workspace)
+        } else {
+            Vec::new()
+        };
 
         // Collect all projects for lookup
         let all_projects: HashMap<&str, &ProjectData> = workspace.data().projects.iter()
@@ -564,6 +737,13 @@ impl Render for Sidebar {
         self.validate_cursor(cursor_items.len());
         let cursor_index = self.cursor_index;
 
+        // Map each cursor index to its scroll-child index. Manual rows are 1:1
+        // with cursor items, offset by the leading drop zone (1) plus the
+        // attention section (header + one row per attention project, when shown).
+        let attention_section_len = if attention_infos.is_empty() { 0 } else { 1 + attention_infos.len() };
+        let cursor_scroll_base = 1 + attention_section_len;
+        self.cursor_scroll_indices = (0..cursor_items.len()).map(|i| cursor_scroll_base + i).collect();
+
         // Determine which project is focused — only highlight when explicitly focused via sidebar click
         let (focused_project_id, focus_individual) = {
             let fm = self.focus_manager.read(cx);
@@ -598,6 +778,19 @@ impl Render for Sidebar {
                 }))
                 .into_any_element()
         );
+
+        // Opt-in "needs attention" section: mirror the attention projects at
+        // the top so they're reachable without leaving the folder layout below.
+        // Self-managing — only shown when something actually needs attention.
+        // The mirror rows are not cursor targets (so not counted in `flat_idx`),
+        // but they occupy scroll children — already accounted for in
+        // `cursor_scroll_indices` above via `attention_section_len`.
+        if !attention_infos.is_empty() {
+            flat_elements.push(self.render_activity_tier_header(ActivityTier::Attention, cx).into_any_element());
+            for info in &attention_infos {
+                flat_elements.push(self.render_attention_mirror_row(info, cx).into_any_element());
+            }
+        }
 
         for item in items {
             match item {

--- a/crates/okena-views-sidebar/src/sidebar/render.rs
+++ b/crates/okena-views-sidebar/src/sidebar/render.rs
@@ -406,25 +406,49 @@ impl Sidebar {
         div()
             .id(ElementId::Name(format!("attention-mirror-{}", info.id).into()))
             .h(px(24.0))
-            .pl(px(12.0))
+            .pl(px(4.0))
             .pr(px(8.0))
             .flex()
             .items_center()
-            .gap(px(6.0))
+            .gap(px(4.0))
             .cursor_pointer()
             .hover(|s| s.bg(rgb(t.bg_hover)))
-            .child(color_dot(dot_color, info.is_worktree))
+            // Match the leading slots of the project rows below so the color
+            // dot lines up: an empty expand-arrow spacer, then the dot inside
+            // the same 14px indicator box (sans the color-picker affordance).
+            .child(crate::item_widgets::sidebar_expand_spacer())
+            .child(
+                div()
+                    .flex_shrink_0()
+                    .w(px(14.0))
+                    .h(px(16.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .child(color_dot(dot_color, info.is_worktree)),
+            )
             .child(crate::item_widgets::sidebar_name_label(
                 ElementId::Name(format!("attention-mirror-name-{}", info.id).into()),
                 info.name.clone(),
                 &t,
                 cx,
             ))
+            // Bell in an 18px box matching the visibility (eye) button so it
+            // lines up with the trailing toggles on the rows below.
             .child(
-                svg()
-                    .path("icons/bell.svg")
-                    .size(px(12.0))
-                    .text_color(rgb(t.border_active)),
+                div()
+                    .flex_shrink_0()
+                    .w(px(18.0))
+                    .h(px(18.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .child(
+                        svg()
+                            .path("icons/bell.svg")
+                            .size(px(12.0))
+                            .text_color(rgb(t.border_active)),
+                    ),
             )
             .on_click(cx.listener(move |this, _, _window, cx| {
                 this.cursor_index = None;
@@ -739,8 +763,9 @@ impl Render for Sidebar {
 
         // Map each cursor index to its scroll-child index. Manual rows are 1:1
         // with cursor items, offset by the leading drop zone (1) plus the
-        // attention section (header + one row per attention project, when shown).
-        let attention_section_len = if attention_infos.is_empty() { 0 } else { 1 + attention_infos.len() };
+        // attention section (header + one row per attention project + a trailing
+        // divider, when shown).
+        let attention_section_len = if attention_infos.is_empty() { 0 } else { 1 + attention_infos.len() + 1 };
         let cursor_scroll_base = 1 + attention_section_len;
         self.cursor_scroll_indices = (0..cursor_items.len()).map(|i| cursor_scroll_base + i).collect();
 
@@ -790,6 +815,16 @@ impl Render for Sidebar {
             for info in &attention_infos {
                 flat_elements.push(self.render_attention_mirror_row(info, cx).into_any_element());
             }
+            // A thin rule sets the mirrored section apart from the structured
+            // folder/project layout that follows.
+            flat_elements.push(
+                div()
+                    .h(px(1.0))
+                    .mx(px(12.0))
+                    .my(px(4.0))
+                    .bg(rgb(t.border))
+                    .into_any_element(),
+            );
         }
 
         for item in items {

--- a/crates/okena-views-sidebar/src/sidebar/render.rs
+++ b/crates/okena-views-sidebar/src/sidebar/render.rs
@@ -159,6 +159,37 @@ impl Sidebar {
         {
             let workspace = self.workspace.read(cx);
             project_services = self.collect_project_services(workspace, cx);
+
+            // Manual display rank: each project's position in the user's
+            // arranged order (`project_order` with folders expanded to their
+            // members), NOT the push order of the `projects` Vec. Drag-reorder
+            // only ever mutates `project_order`, so the Vec order diverges from
+            // the arrangement after any reorder. This rank drives the pinned
+            // tier's stable order and the within-tier tiebreaker so the
+            // activity view honors the same order the manual view shows. Folder
+            // members live in `folder.project_ids` (not `project_order`), so
+            // folders are expanded inline. Projects absent from the walk fall
+            // back after all known ones (deterministic, stable among ties).
+            let manual_rank: HashMap<String, usize> = {
+                let data = workspace.data();
+                let mut rank = HashMap::new();
+                let mut next = 0usize;
+                for id in &data.project_order {
+                    if let Some(folder) = data.folders.iter().find(|f| &f.id == id) {
+                        for pid in &folder.project_ids {
+                            if !rank.contains_key(pid) {
+                                rank.insert(pid.clone(), next);
+                                next += 1;
+                            }
+                        }
+                    } else if !rank.contains_key(id) {
+                        rank.insert(id.clone(), next);
+                        next += 1;
+                    }
+                }
+                rank
+            };
+
             let terminals = self.terminals.lock();
             let mut e = Vec::new();
             let mut m = HashMap::new();
@@ -183,11 +214,15 @@ impl Sidebar {
                 e.push(ActivityEntry {
                     id: project.id.clone(),
                     pinned: project.pinned,
-                    manual_index: idx,
+                    // Order by the user's arrangement, not Vec push order.
+                    manual_index: manual_rank.get(&project.id).copied().unwrap_or(usize::MAX),
                     last_activity_at: project.last_activity_at,
                     has_attention,
                     is_running,
                 });
+                // `idx_map` keeps the `projects` Vec index: it feeds
+                // `render_project_item`'s drag-drop target, which is a separate
+                // concern from activity ordering and unchanged by this view.
                 idx_map.insert(project.id.clone(), idx);
                 m.insert(project.id.clone(), info);
             }

--- a/crates/okena-views-sidebar/src/sidebar/render.rs
+++ b/crates/okena-views-sidebar/src/sidebar/render.rs
@@ -2,14 +2,252 @@
 //! helper that lays out per-project terminal / service / hook groups.
 
 use super::{GroupKind, Sidebar, SidebarItem, SidebarProjectInfo, SidebarServiceInfo};
+use crate::activity_order::{order_by_activity, ActivityEntry, ActivityTier};
 use crate::drag::{FolderDrag, ProjectDrag};
 use gpui::*;
 use okena_ui::theme::theme;
+use okena_ui::tokens::ui_text_ms;
 use okena_workspace::requests::SidebarRequest;
-use okena_workspace::state::ProjectData;
+use okena_workspace::state::{ProjectData, Workspace};
 use std::collections::{HashMap, HashSet};
 
 impl Sidebar {
+    /// Build the `project_id -> services` map from the local `ServiceManager`
+    /// plus remote project snapshots. Shared by the manual and activity render
+    /// paths. Reads only — takes the live `workspace` borrow and a `&App` so it
+    /// composes with the immutable borrows already held during render.
+    pub(crate) fn collect_project_services(
+        &self,
+        workspace: &Workspace,
+        cx: &App,
+    ) -> HashMap<String, Vec<SidebarServiceInfo>> {
+        let mut project_services: HashMap<String, Vec<SidebarServiceInfo>> =
+            if let Some(ref sm) = self.service_manager {
+                let sm = sm.read(cx);
+                workspace.data().projects.iter()
+                    .filter(|p| sm.has_services(&p.id))
+                    .map(|p| {
+                        let services = sm.services_for_project(&p.id)
+                            .into_iter()
+                            .filter(|inst| !inst.is_extra)
+                            .map(|inst| SidebarServiceInfo {
+                                name: inst.definition.name.clone(),
+                                status: inst.status.clone(),
+                                ports: inst.detected_ports.clone(),
+                                port_host: "localhost".to_string(),
+                                is_docker: matches!(inst.kind, okena_services::manager::ServiceKind::DockerCompose { .. }),
+                            })
+                            .collect();
+                        (p.id.clone(), services)
+                    })
+                    .collect()
+            } else {
+                HashMap::new()
+            };
+
+        // Also populate services from remote project data (for projects not covered by local ServiceManager)
+        for project in &workspace.data().projects {
+            let Some(snapshot) = workspace.remote_snapshot(&project.id) else { continue };
+            if !snapshot.services.is_empty() && !project_services.contains_key(&project.id) {
+                let port_host = snapshot.host.clone().unwrap_or_else(|| "localhost".to_string());
+                let services = snapshot.services.iter()
+                    .filter(|api_svc| !api_svc.is_extra)
+                    .map(|api_svc| {
+                        SidebarServiceInfo {
+                            name: api_svc.name.clone(),
+                            status: okena_services::manager::ServiceStatus::from_api(&api_svc.status, api_svc.exit_code),
+                            ports: api_svc.ports.clone(),
+                            port_host: port_host.clone(),
+                            is_docker: api_svc.kind == "docker_compose",
+                        }
+                    }).collect();
+                project_services.insert(project.id.clone(), services);
+            }
+        }
+        project_services
+    }
+
+    /// Outer sidebar chrome shared by the manual and activity render paths:
+    /// header, projects header, and the scrolling body holding `flat_elements`
+    /// plus the remote section. Tracks pointer-inside for the activity view's
+    /// hover-freeze.
+    pub(crate) fn render_sidebar_container(
+        &mut self,
+        flat_elements: Vec<AnyElement>,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let t = theme(cx);
+        div()
+            .relative()
+            .w_full()
+            .h_full()
+            .flex()
+            .flex_col()
+            .bg(rgb(t.bg_secondary))
+            .track_focus(&self.focus_handle)
+            .key_context("Sidebar")
+            .on_action(cx.listener(Self::handle_sidebar_up))
+            .on_action(cx.listener(Self::handle_sidebar_down))
+            .on_action(cx.listener(Self::handle_sidebar_confirm))
+            .on_action(cx.listener(Self::handle_sidebar_toggle_expand))
+            .on_action(cx.listener(Self::handle_sidebar_escape))
+            .child(self.render_header(cx))
+            .child(self.render_projects_header(cx))
+            .child(
+                div()
+                    .id("sidebar-scroll")
+                    .flex_1()
+                    .overflow_y_scroll()
+                    .track_scroll(&self.scroll_handle)
+                    // Freeze the activity ordering while the pointer is over the
+                    // list so a finishing command / bell doesn't reshuffle rows
+                    // under the cursor. Transition-only, so this is cheap.
+                    .on_hover(cx.listener(|this, hovered: &bool, _window, cx| {
+                        if this.activity_pointer_inside != *hovered {
+                            this.activity_pointer_inside = *hovered;
+                            cx.notify();
+                        }
+                    }))
+                    .children(flat_elements)
+                    .child(self.render_remote_section(cx)),
+            )
+    }
+
+    /// A section header for one activity tier (PINNED / NEEDS ATTENTION /
+    /// RUNNING / RECENT). Non-interactive — purely a visual divider.
+    fn render_activity_tier_header(&self, tier: ActivityTier, cx: &mut Context<Self>) -> impl IntoElement {
+        let t = theme(cx);
+        // A small colored dot echoes the per-row indicators for the two
+        // attention-worthy tiers; pinned/recent get none.
+        let dot_color = match tier {
+            ActivityTier::Attention => Some(t.border_active),
+            ActivityTier::Running => Some(t.border_idle),
+            ActivityTier::Pinned | ActivityTier::Rest => None,
+        };
+        div()
+            .h(px(22.0))
+            .px(px(12.0))
+            .flex()
+            .items_center()
+            .gap(px(6.0))
+            .children(dot_color.map(|color| div().size(px(6.0)).rounded_full().bg(rgb(color))))
+            .child(
+                div()
+                    .text_size(ui_text_ms(cx))
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_color(rgb(t.text_secondary))
+                    .child(tier.label()),
+            )
+    }
+
+    /// Build the flat element list for `ProjectSortMode::Activity`: every
+    /// project as a peer (folders and worktree nesting ignored), grouped into
+    /// activity tiers with section headers. Self-contained — reads its own
+    /// workspace borrow and does not touch the manual path's state.
+    fn build_activity_flat_elements(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Vec<AnyElement> {
+        // Phase 1 — gather owned per-project infos + activity inputs while the
+        // workspace borrow and the terminals lock are held, then release both
+        // before the &mut self render calls below.
+        let project_services;
+        let mut infos: HashMap<String, SidebarProjectInfo>;
+        let manual_index: HashMap<String, usize>;
+        let entries: Vec<ActivityEntry>;
+        {
+            let workspace = self.workspace.read(cx);
+            project_services = self.collect_project_services(workspace, cx);
+            let terminals = self.terminals.lock();
+            let mut e = Vec::new();
+            let mut m = HashMap::new();
+            let mut idx_map = HashMap::new();
+            for (idx, project) in workspace.data().projects.iter().enumerate() {
+                let mut info = SidebarProjectInfo::from_project(project, workspace, self.window_id);
+                info.is_closing = workspace.is_project_closing(&project.id);
+                info.is_creating = workspace.is_creating_project(&project.id);
+                let has_attention = info.terminal_ids.iter().any(|tid| {
+                    terminals.get(tid.as_str()).is_some_and(|t| t.has_bell() || t.has_notification())
+                });
+                // "Running" uses cached atomics only (no live /proc read per
+                // render): a terminal the user has driven that is not sitting at
+                // an idle prompt is treated as actively running a command. The
+                // `waiting_for_input` flag is the same background-computed signal
+                // the manual view's idle dot uses.
+                let is_running = info.terminal_ids.iter().any(|tid| {
+                    terminals.get(tid.as_str()).is_some_and(|t| {
+                        t.had_user_input() && !t.is_waiting_for_input()
+                    })
+                });
+                e.push(ActivityEntry {
+                    id: project.id.clone(),
+                    pinned: project.pinned,
+                    manual_index: idx,
+                    last_activity_at: project.last_activity_at,
+                    has_attention,
+                    is_running,
+                });
+                idx_map.insert(project.id.clone(), idx);
+                m.insert(project.id.clone(), info);
+            }
+            entries = e;
+            manual_index = idx_map;
+            infos = m;
+        }
+        for (id, info) in infos.iter_mut() {
+            if let Some(services) = project_services.get(id) {
+                info.services = services.clone();
+            }
+        }
+
+        // Phase 2 — ordering. Reuse the cached order while the pointer is inside
+        // (hover-freeze), dropping any project that has since gone; otherwise
+        // recompute and refresh the cache.
+        let ordering: Vec<(ActivityTier, String)> =
+            if self.activity_pointer_inside && !self.activity_order_cache.is_empty() {
+                self.activity_order_cache
+                    .iter()
+                    .filter(|(_, id)| infos.contains_key(id))
+                    .cloned()
+                    .collect()
+            } else {
+                let ord: Vec<(ActivityTier, String)> = order_by_activity(entries)
+                    .into_iter()
+                    .map(|(tier, entry)| (tier, entry.id))
+                    .collect();
+                self.activity_order_cache = ord.clone();
+                ord
+            };
+
+        // Phase 3 — render rows with a section header whenever the tier changes.
+        let focused_project_id = self.focus_manager.read(cx).focused_project_id().cloned();
+        let mut flat_elements: Vec<AnyElement> = Vec::new();
+        // Cursor-key navigation is not wired for the activity view yet; rows
+        // render without the keyboard cursor highlight. `flat_idx` is still
+        // threaded for render_expanded_children's internal accounting.
+        let mut flat_idx: usize = 0;
+        let mut last_tier: Option<ActivityTier> = None;
+        for (tier, id) in ordering {
+            if last_tier != Some(tier) {
+                flat_elements.push(self.render_activity_tier_header(tier, cx).into_any_element());
+                last_tier = Some(tier);
+            }
+            let Some(info) = infos.get(&id) else { continue };
+            let is_focused_project = focused_project_id.as_ref() == Some(&id);
+            let idx = manual_index.get(&id).copied().unwrap_or(0);
+            flat_elements.push(
+                self.render_project_item(info, idx, false, is_focused_project, window, cx)
+                    .into_any_element(),
+            );
+            flat_idx += 1;
+            if self.expanded_projects.contains(&id) {
+                self.render_expanded_children(info, 20.0, 34.0, "", None, &mut flat_idx, &mut flat_elements, cx);
+            }
+        }
+        flat_elements
+    }
+
     /// Render expanded children (terminals group + services group) for a project.
     /// Returns elements and advances flat_idx.
     // GPUI render helper: params are render inputs and traversal state.
@@ -147,6 +385,21 @@ impl Render for Sidebar {
             self.cursor_index = None;
         }
 
+        // Activity-sorted view is a separate, self-contained build path that
+        // ignores project_order and folders. Branch early so the manual path
+        // below stays untouched.
+        let sort_mode = self
+            .workspace
+            .read(cx)
+            .data()
+            .window(self.window_id)
+            .map(|w| w.project_sort_mode)
+            .unwrap_or_default();
+        if sort_mode.is_activity() {
+            let flat_elements = self.build_activity_flat_elements(window, cx);
+            return self.render_sidebar_container(flat_elements, cx);
+        }
+
         let workspace = self.workspace.read(cx);
 
         // Collect all projects for lookup
@@ -177,49 +430,8 @@ impl Render for Sidebar {
             }
         }
 
-        // Collect services from ServiceManager for all projects
-        let mut project_services: HashMap<String, Vec<SidebarServiceInfo>> = if let Some(ref sm) = self.service_manager {
-            let sm = sm.read(cx);
-            workspace.data().projects.iter()
-                .filter(|p| sm.has_services(&p.id))
-                .map(|p| {
-                    let services = sm.services_for_project(&p.id)
-                        .into_iter()
-                        .filter(|inst| !inst.is_extra)
-                        .map(|inst| SidebarServiceInfo {
-                            name: inst.definition.name.clone(),
-                            status: inst.status.clone(),
-                            ports: inst.detected_ports.clone(),
-                            port_host: "localhost".to_string(),
-                            is_docker: matches!(inst.kind, okena_services::manager::ServiceKind::DockerCompose { .. }),
-                        })
-                        .collect();
-                    (p.id.clone(), services)
-                })
-                .collect()
-        } else {
-            HashMap::new()
-        };
-
-        // Also populate services from remote project data (for projects not covered by local ServiceManager)
-        for project in &workspace.data().projects {
-            let Some(snapshot) = workspace.remote_snapshot(&project.id) else { continue };
-            if !snapshot.services.is_empty() && !project_services.contains_key(&project.id) {
-                let port_host = snapshot.host.clone().unwrap_or_else(|| "localhost".to_string());
-                let services = snapshot.services.iter()
-                    .filter(|api_svc| !api_svc.is_extra)
-                    .map(|api_svc| {
-                        SidebarServiceInfo {
-                            name: api_svc.name.clone(),
-                            status: okena_services::manager::ServiceStatus::from_api(&api_svc.status, api_svc.exit_code),
-                            ports: api_svc.ports.clone(),
-                            port_host: port_host.clone(),
-                            is_docker: api_svc.kind == "docker_compose",
-                        }
-                    }).collect();
-                project_services.insert(project.id.clone(), services);
-            }
-        }
+        // Collect services (local ServiceManager + remote snapshots) for all projects
+        let mut project_services = self.collect_project_services(workspace, cx);
 
         // Build sidebar items from project_order
         let mut items: Vec<SidebarItem> = Vec::new();
@@ -538,30 +750,6 @@ impl Render for Sidebar {
                 .into_any_element()
         );
 
-        div()
-            .relative()
-            .w_full()
-            .h_full()
-            .flex()
-            .flex_col()
-            .bg(rgb(t.bg_secondary))
-            .track_focus(&self.focus_handle)
-            .key_context("Sidebar")
-            .on_action(cx.listener(Self::handle_sidebar_up))
-            .on_action(cx.listener(Self::handle_sidebar_down))
-            .on_action(cx.listener(Self::handle_sidebar_confirm))
-            .on_action(cx.listener(Self::handle_sidebar_toggle_expand))
-            .on_action(cx.listener(Self::handle_sidebar_escape))
-            .child(self.render_header(cx))
-            .child(self.render_projects_header(cx))
-            .child(
-                div()
-                    .id("sidebar-scroll")
-                    .flex_1()
-                    .overflow_y_scroll()
-                    .track_scroll(&self.scroll_handle)
-                    .children(flat_elements)
-                    .child(self.render_remote_section(cx)),
-            )
+        self.render_sidebar_container(flat_elements, cx)
     }
 }

--- a/crates/okena-views-sidebar/src/sidebar/render.rs
+++ b/crates/okena-views-sidebar/src/sidebar/render.rs
@@ -363,7 +363,13 @@ impl Sidebar {
     /// unseen bell/notification on any of their terminals — the source for the
     /// opt-in "needs attention" section in the manual view. Owned infos so the
     /// caller can render after releasing the workspace borrow.
-    fn collect_attention_infos(&self, workspace: &Workspace) -> Vec<SidebarProjectInfo> {
+    ///
+    /// `focused_terminal_id` (when set) is the terminal the user is actively
+    /// looking at; it never counts toward attention. A bell raised on the
+    /// focused terminal of the active window is cleared on the very next
+    /// terminal-pane render, so without this it would flicker through the menu
+    /// for a single frame.
+    fn collect_attention_infos(&self, workspace: &Workspace, focused_terminal_id: Option<&str>) -> Vec<SidebarProjectInfo> {
         let terminals = self.terminals.lock();
         // Determine attention cheaply from raw layout + terminal state first;
         // only build the (potentially git-touching) `SidebarProjectInfo` for the
@@ -378,7 +384,8 @@ impl Sidebar {
                 .unwrap_or_default()
                 .iter()
                 .any(|tid| {
-                    !project.hook_terminals.contains_key(tid)
+                    Some(tid.as_str()) != focused_terminal_id
+                        && !project.hook_terminals.contains_key(tid)
                         && terminals
                             .get(tid.as_str())
                             .is_some_and(|t| t.has_bell() || t.has_notification())
@@ -393,6 +400,30 @@ impl Sidebar {
         hits.into_iter()
             .map(|(_, project)| SidebarProjectInfo::from_project(project, workspace, self.window_id))
             .collect()
+    }
+
+    /// The terminal the user is actively looking at — the focused terminal of
+    /// this window, but only while it is the active OS window — resolved to its
+    /// id. `None` when the window is in the background or nothing is focused.
+    /// Used to keep that terminal out of the needs-attention section (see
+    /// `collect_attention_infos`).
+    fn active_focused_terminal_id(&self, workspace: &Workspace, window: &Window, cx: &App) -> Option<String> {
+        if !window.is_window_active() {
+            return None;
+        }
+        let focus = self.focus_manager.read(cx).focused_terminal_state()?;
+        let node = workspace
+            .data()
+            .projects
+            .iter()
+            .find(|p| p.id == focus.project_id)?
+            .layout
+            .as_ref()?
+            .get_at_path(&focus.layout_path)?;
+        match node {
+            okena_workspace::state::LayoutNode::Terminal { terminal_id, .. } => terminal_id.clone(),
+            _ => None,
+        }
     }
 
     /// One compact, non-draggable "mirror" row for the manual view's needs-
@@ -629,7 +660,8 @@ impl Render for Sidebar {
             .map(|w| w.show_attention_section)
             .unwrap_or(false);
         let attention_infos = if show_attention {
-            self.collect_attention_infos(workspace)
+            let focused_terminal_id = self.active_focused_terminal_id(workspace, window, cx);
+            self.collect_attention_infos(workspace, focused_terminal_id.as_deref())
         } else {
             Vec::new()
         };

--- a/crates/okena-workspace/src/actions/focus.rs
+++ b/crates/okena-workspace/src/actions/focus.rs
@@ -159,8 +159,11 @@ impl Workspace {
         // Update FocusManager
         focus_manager.focus_terminal(project_id.clone(), layout_path.clone());
 
-        // Record project access time for recency sorting
+        // Record project access time for recency sorting, and stamp activity
+        // so the activity-sorted sidebar surfaces the project the user just
+        // moved into. `bump_activity` already notifies + persists (debounced).
         self.touch_project(&project_id);
+        self.bump_activity(&project_id, cx);
 
         cx.notify();
     }

--- a/crates/okena-workspace/src/actions/folder.rs
+++ b/crates/okena-workspace/src/actions/folder.rs
@@ -189,6 +189,8 @@ mod tests {
             service_terminals: HashMap::new(),
             default_shell: None,
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         }
     }
 
@@ -299,6 +301,8 @@ mod gpui_tests {
             service_terminals: HashMap::new(),
             default_shell: None,
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         }
     }
 

--- a/crates/okena-workspace/src/actions/layout/tests_gpui.rs
+++ b/crates/okena-workspace/src/actions/layout/tests_gpui.rs
@@ -32,6 +32,8 @@ fn make_project(id: &str) -> ProjectData {
         service_terminals: HashMap::new(),
         default_shell: None,
         hook_terminals: HashMap::new(),
+        pinned: false,
+        last_activity_at: None,
     }
 }
 
@@ -397,6 +399,8 @@ fn make_project_with_layout(id: &str, layout: LayoutNode) -> ProjectData {
         service_terminals: HashMap::new(),
         default_shell: None,
         hook_terminals: HashMap::new(),
+        pinned: false,
+        last_activity_at: None,
     }
 }
 

--- a/crates/okena-workspace/src/actions/project.rs
+++ b/crates/okena-workspace/src/actions/project.rs
@@ -176,6 +176,8 @@ impl Workspace {
             service_terminals: HashMap::new(),
             default_shell,
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         };
         let project_hooks = project.hooks.clone();
         self.data.projects.push(project);
@@ -508,6 +510,8 @@ mod tests {
             service_terminals: HashMap::new(),
             default_shell: None,
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         }
     }
 
@@ -725,6 +729,8 @@ mod gpui_tests {
             service_terminals: HashMap::new(),
             default_shell: None,
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         }
     }
 

--- a/crates/okena-workspace/src/actions/soft_close.rs
+++ b/crates/okena-workspace/src/actions/soft_close.rs
@@ -253,6 +253,8 @@ mod tests {
             service_terminals: HashMap::new(),
             default_shell: None,
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         }
     }
 

--- a/crates/okena-workspace/src/actions/worktree.rs
+++ b/crates/okena-workspace/src/actions/worktree.rs
@@ -193,6 +193,8 @@ impl Workspace {
             service_terminals: HashMap::new(),
             default_shell: None,
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         };
 
         let new_project_hooks = project.hooks.clone();
@@ -336,6 +338,8 @@ impl Workspace {
             connection_id: None,
             service_terminals: HashMap::new(),
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         };
 
         // Multi-window new-project visibility rule (PRD user story 14):

--- a/crates/okena-workspace/src/persistence.rs
+++ b/crates/okena-workspace/src/persistence.rs
@@ -645,6 +645,8 @@ pub fn default_workspace() -> WorkspaceData {
             service_terminals: HashMap::new(),
             default_shell: None,
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         }],
         project_order: vec![project_id],
         service_panel_heights: HashMap::new(),
@@ -677,6 +679,8 @@ mod tests {
             service_terminals: HashMap::new(),
             default_shell: None,
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         }
     }
 

--- a/crates/okena-workspace/src/remote_apply.rs
+++ b/crates/okena-workspace/src/remote_apply.rs
@@ -192,6 +192,8 @@ pub fn apply_remote_snapshot(
                         service_terminals: HashMap::new(),
                         default_shell: None,
                         hook_terminals: HashMap::new(),
+                        pinned: false,
+                        last_activity_at: None,
                     });
                 }
                 // Update the transient remote snapshot regardless of create/update path.

--- a/crates/okena-workspace/src/state.rs
+++ b/crates/okena-workspace/src/state.rs
@@ -359,6 +359,14 @@ impl Workspace {
         }
     }
 
+    /// Flip the "needs attention" section opt-in for a window's manual view.
+    /// Persisted via `notify_data`.
+    pub fn toggle_show_attention_section(&mut self, window_id: WindowId, cx: &mut Context<Self>) {
+        if self.data.toggle_show_attention_section(window_id).is_some() {
+            self.notify_data(cx);
+        }
+    }
+
     /// Toggle whether a project is pinned to the top of the activity-sorted
     /// view. No-op for an unknown project id. Persisted via `notify_data`.
     pub fn toggle_project_pinned(&mut self, project_id: &str, cx: &mut Context<Self>) {

--- a/crates/okena-workspace/src/state.rs
+++ b/crates/okena-workspace/src/state.rs
@@ -149,6 +149,24 @@ impl Workspace {
         self.access_history.touch(project_id);
     }
 
+    /// Record meaningful activity for a project: stamp `last_activity_at` with
+    /// the current unix-millis and persist it (drives the activity-sorted
+    /// sidebar view). Called on focus, a finished command (OSC 133 ;D), and a
+    /// bell/notification from one of the project's terminals — deliberately NOT
+    /// on raw terminal output, since output volume is not "activity". A no-op
+    /// for an unknown project id. Uses `notify_data` so the change is persisted
+    /// (debounced) and the sidebar re-renders to reorder.
+    pub fn bump_activity(&mut self, project_id: &str, cx: &mut Context<Self>) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        if let Some(project) = self.project_mut(project_id) {
+            project.last_activity_at = Some(now);
+            self.notify_data(cx);
+        }
+    }
+
     /// Get projects sorted by last access time (most recent first)
     pub fn projects_by_recency(&self) -> Vec<&ProjectData> {
         let mut projects: Vec<&ProjectData> = self.data.projects.iter().collect();
@@ -331,6 +349,23 @@ impl Workspace {
             w.project_layout = w.project_layout.toggled();
         }
         self.notify_data(cx);
+    }
+
+    /// Flip the sidebar project sort mode (manual ↔ activity) for a window.
+    /// Persisted via `notify_data`.
+    pub fn toggle_project_sort_mode(&mut self, window_id: WindowId, cx: &mut Context<Self>) {
+        if self.data.toggle_project_sort_mode(window_id).is_some() {
+            self.notify_data(cx);
+        }
+    }
+
+    /// Toggle whether a project is pinned to the top of the activity-sorted
+    /// view. No-op for an unknown project id. Persisted via `notify_data`.
+    pub fn toggle_project_pinned(&mut self, project_id: &str, cx: &mut Context<Self>) {
+        if let Some(project) = self.project_mut(project_id) {
+            project.pinned = !project.pinned;
+            self.notify_data(cx);
+        }
     }
 
     /// Spawn a fresh extra window onto `extra_windows` and return its id.
@@ -905,6 +940,8 @@ mod workspace_tests {
             service_terminals: HashMap::new(),
             default_shell: None,
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         }
     }
 
@@ -1666,6 +1703,8 @@ mod gpui_tests {
             service_terminals: HashMap::new(),
             default_shell: None,
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         }
     }
 

--- a/crates/okena-workspace/src/visibility.rs
+++ b/crates/okena-workspace/src/visibility.rs
@@ -235,6 +235,8 @@ mod tests {
             service_terminals: HashMap::new(),
             default_shell: None,
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -919,6 +919,9 @@ impl Okena {
                     // so background tabs and detached windows are covered too.
                     if !dirty_terminal_ids.is_empty() {
                         this.process_terminal_notifications(&dirty_terminal_ids, cx);
+                        // Stamp project activity for any command that finished
+                        // this batch (OSC 133 ;D), independent of bell/OSC alerts.
+                        this.process_command_finished_activity(&dirty_terminal_ids, cx);
                     }
 
                     if !exit_events.is_empty() {

--- a/src/app/notifications.rs
+++ b/src/app/notifications.rs
@@ -124,6 +124,12 @@ impl Okena {
             return;
         }
 
+        // A bell or OSC alert is "activity" for the owning project regardless
+        // of the notification settings below — stamp it before any settings
+        // bail so the activity-sorted sidebar surfaces the project even when
+        // desktop notifications are disabled.
+        self.bump_activity_for_terminals(drained.iter().map(|(tid, _, _)| tid.as_str()), cx);
+
         // Read the (small) notification settings; bail if the feature is off.
         // Draining above already cleared the queues, so nothing accumulates
         // while disabled.
@@ -193,6 +199,58 @@ impl Okena {
                 );
             }
         }
+    }
+
+    /// Drain the one-shot command-finished (OSC 133 ;D) edge for each dirty
+    /// terminal and stamp activity on the owning project. Called from the PTY
+    /// event loop alongside notification draining so a finished command floats
+    /// its project up in the activity-sorted sidebar — even with no bell.
+    pub(super) fn process_command_finished_activity(
+        &mut self,
+        dirty_terminal_ids: &[String],
+        cx: &mut Context<Self>,
+    ) {
+        // Drain edges first (cheap atomic swap); collect the terminals that
+        // actually saw a command finish. Almost every batch drains nothing.
+        let finished: Vec<String> = {
+            let reg = self.terminals.lock();
+            dirty_terminal_ids
+                .iter()
+                .filter(|tid| {
+                    reg.get(*tid)
+                        .is_some_and(|t| t.take_pending_command_finished())
+                })
+                .cloned()
+                .collect()
+        };
+        if finished.is_empty() {
+            return;
+        }
+        self.bump_activity_for_terminals(finished.iter().map(|s| s.as_str()), cx);
+    }
+
+    /// Resolve each terminal id to its owning project and bump that project's
+    /// activity timestamp once. Deduplicates projects so a batch touching
+    /// several terminals of the same project only notifies/persists once.
+    fn bump_activity_for_terminals<'a>(
+        &mut self,
+        terminal_ids: impl Iterator<Item = &'a str>,
+        cx: &mut Context<Self>,
+    ) {
+        let project_ids: std::collections::HashSet<String> = {
+            let ws = self.workspace.read(cx);
+            terminal_ids
+                .filter_map(|tid| ws.find_project_for_terminal(tid).map(|p| p.id.clone()))
+                .collect()
+        };
+        if project_ids.is_empty() {
+            return;
+        }
+        self.workspace.update(cx, |ws, cx| {
+            for pid in project_ids {
+                ws.bump_activity(&pid, cx);
+            }
+        });
     }
 
     /// True when `(project_id, path)` is the focused pane in a window that

--- a/src/views/overlays/project_switcher.rs
+++ b/src/views/overlays/project_switcher.rs
@@ -584,6 +584,8 @@ mod tests {
             service_terminals: HashMap::new(),
             default_shell: None::<ShellType>,
             hook_terminals: HashMap::<String, HookTerminalEntry>::new(),
+            pinned: false,
+            last_activity_at: None,
         }
     }
 

--- a/src/workspace/actions/execute/project.rs
+++ b/src/workspace/actions/execute/project.rs
@@ -312,6 +312,8 @@ mod set_show_in_overview_tests {
             service_terminals: HashMap::new(),
             default_shell: None,
             hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
         }
     }
 


### PR DESCRIPTION
Addresses #120 — surfacing active/attention-worthy projects in the sidebar.

Instead of auto-moving projects between ACTIVE/RECENT/ARCHIVED sections (which would fight the existing manual `project_order` + folders + drag-and-drop model), this adds an **opt-in, per-window "sort by activity" view** that leaves the manual model completely untouched. Toggle it from the PROJECTS header (`focus` icon, highlighted when active).

## Behaviour

In Activity mode the sidebar ignores `project_order` and folders and shows a flat, tiered list:

1. **Pinned** — kept in stable manual order (an anchor for muscle memory; never reordered by activity)
2. **Needs attention** — a terminal has an unseen bell / OSC notification
3. **Running** — a terminal is actively running a command
4. **Recent** — everything else

Non-pinned tiers sort by most-recent activity first.

### What counts as "activity"
Deliberately **discrete attention events**, not raw output volume (a `tail -f` / dev server must not pin itself to the top):
- focus
- a finished command (OSC 133 ;D — new one-shot edge on `Terminal`)
- a bell / OSC 9/777/99 notification

`last_activity_at` is persisted (unix-millis) so the view is sensible right after a restart.

### Anti-jumping
- Re-sort is driven by these discrete events, not per-output ticks
- **Hover-freeze**: ordering is cached and not recomputed while the pointer is over the sidebar, so rows don't shuffle out from under the cursor
- Attention state is sticky until the pane is focused
- The "running" tier reads cached atomics only — no per-render `/proc` scans

### Pinning
Pin/unpin from the project context menu; a pin marker shows in the row.

## Commits (each independently buildable)
1. `feat(state)` — `pinned`, `last_activity_at`, `ProjectSortMode` (serde-default, backward compatible)
2. `feat(terminal)` — OSC 133 command-finished edge
3. `feat(workspace)` — `bump_activity`, sort-mode + pin toggles
4. `feat(app)` — bump activity on bell / notification / command-finish in the PTY loop
5. `feat(sidebar)` — the activity view, tier headers, hover-freeze, pin UI

## Tests
`order_by_activity` has unit coverage for tier precedence, pinned anchoring, recency sorting, and tiebreaks. All touched crates' test suites pass.

## Known limitations / follow-ups
- No keybind for the toggle yet (header button + context menu cover it)
- Keyboard cursor-nav (arrow keys) isn't wired for the activity view
- No move animations (event-driven re-sort + hover-freeze already keep it calm)
- Dragging a row in Activity mode still mutates the manual order invisibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)