### PR TITLE
feat(terminal): grace-period soft close with undo

### DIFF
--- a/crates/okena-layout/src/lib.rs
+++ b/crates/okena-layout/src/lib.rs
@@ -18,7 +18,7 @@ fn default_zoom_level() -> f32 {
 }
 
 /// Recursive layout tree node
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum LayoutNode {
     Terminal {
@@ -224,6 +224,58 @@ impl LayoutNode {
                     }
                 }
                 None
+            }
+        }
+    }
+
+    /// Find the `Terminal` node with the given id, returning a reference to it.
+    /// Unlike `find_terminal_path`, this hands back the node itself so callers
+    /// can clone its visual state (shell_type, zoom_level) — used by soft-close
+    /// undo to reconstruct a closed pane.
+    pub fn find_terminal_node(&self, target_id: &str) -> Option<&LayoutNode> {
+        match self {
+            LayoutNode::Terminal { terminal_id, .. } => {
+                if terminal_id.as_deref() == Some(target_id) {
+                    Some(self)
+                } else {
+                    None
+                }
+            }
+            LayoutNode::Split { children, .. } | LayoutNode::Tabs { children, .. } => {
+                children.iter().find_map(|c| c.find_terminal_node(target_id))
+            }
+        }
+    }
+
+    /// Append a node as a sibling at the root of this layout.
+    ///
+    /// Used by soft-close undo when the original position can no longer be
+    /// restored (the tree changed during the grace window): rather than guess a
+    /// merge, the recovered terminal is dropped into the top-level group.
+    /// - Split: pushed as a new child, sizes rebalanced equally.
+    /// - Tabs: pushed as a new tab and activated.
+    /// - bare Terminal: wrapped together with `node` into a horizontal Split.
+    pub fn append_to_root(&mut self, node: LayoutNode) {
+        match self {
+            LayoutNode::Split { children, sizes, .. } => {
+                children.push(node);
+                let n = children.len();
+                *sizes = vec![1.0 / n as f32; n];
+            }
+            LayoutNode::Tabs { children, active_tab } => {
+                children.push(node);
+                *active_tab = children.len() - 1;
+            }
+            LayoutNode::Terminal { .. } => {
+                let existing = std::mem::replace(
+                    self,
+                    LayoutNode::Tabs { children: Vec::new(), active_tab: 0 },
+                );
+                *self = LayoutNode::Split {
+                    direction: SplitDirection::Horizontal,
+                    sizes: vec![0.5, 0.5],
+                    children: vec![existing, node],
+                };
             }
         }
     }
@@ -843,6 +895,68 @@ mod tests {
             panic!("expected nested split inside tabs");
         };
         assert_eq!(*inner, SplitDirection::Horizontal, "nested split flipped");
+    }
+
+    #[test]
+    fn find_terminal_node_returns_node_with_visual_state() {
+        let tree = hsplit(vec![
+            terminal("a"),
+            LayoutNode::Terminal {
+                terminal_id: Some("b".to_string()),
+                minimized: false,
+                detached: false,
+                shell_type: ShellType::Default,
+                zoom_level: 2.5,
+            },
+        ]);
+        let node = tree.find_terminal_node("b").expect("b present");
+        let LayoutNode::Terminal { zoom_level, .. } = node else {
+            panic!("expected terminal");
+        };
+        assert_eq!(*zoom_level, 2.5);
+        assert!(tree.find_terminal_node("missing").is_none());
+    }
+
+    #[test]
+    fn append_to_root_split_pushes_and_rebalances() {
+        let mut tree = hsplit(vec![terminal("a"), terminal("b")]);
+        tree.append_to_root(terminal("c"));
+        let LayoutNode::Split { children, sizes, .. } = &tree else {
+            panic!("expected split");
+        };
+        assert_eq!(children.len(), 3);
+        assert_eq!(sizes.len(), 3);
+        for s in sizes {
+            assert!((s - 1.0 / 3.0).abs() < 1e-6, "sizes rebalanced equally");
+        }
+        assert_eq!(tree.find_terminal_path("c"), Some(vec![2]));
+    }
+
+    #[test]
+    fn append_to_root_tabs_pushes_and_activates() {
+        let mut tree = LayoutNode::Tabs {
+            children: vec![terminal("a"), terminal("b")],
+            active_tab: 0,
+        };
+        tree.append_to_root(terminal("c"));
+        let LayoutNode::Tabs { children, active_tab } = &tree else {
+            panic!("expected tabs");
+        };
+        assert_eq!(children.len(), 3);
+        assert_eq!(*active_tab, 2, "new tab activated");
+    }
+
+    #[test]
+    fn append_to_root_bare_terminal_wraps_in_split() {
+        let mut tree = terminal("a");
+        tree.append_to_root(terminal("b"));
+        let LayoutNode::Split { children, sizes, .. } = &tree else {
+            panic!("expected split after wrapping a bare terminal");
+        };
+        assert_eq!(children.len(), 2);
+        assert_eq!(sizes.len(), 2);
+        assert_eq!(tree.find_terminal_path("a"), Some(vec![0]));
+        assert_eq!(tree.find_terminal_path("b"), Some(vec![1]));
     }
 
     fn hsplit(children: Vec<LayoutNode>) -> LayoutNode {

--- a/crates/okena-state/src/lib.rs
+++ b/crates/okena-state/src/lib.rs
@@ -17,7 +17,7 @@ mod workspace_data;
 
 pub use hooks_config::{HooksConfig, ProjectHooks, TerminalHooks, WorktreeHooks};
 pub use okena_layout::{LayoutNode, SplitDirection};
-pub use toast::{Toast, ToastLevel};
+pub use toast::{Toast, ToastAction, ToastActionStyle, ToastLevel};
 pub use transient::{DropZone, FocusedTerminalState, PendingWorktreeClose};
 pub use window_id::WindowId;
 pub use window_state::{ProjectLayoutMode, WindowBounds, WindowState};

--- a/crates/okena-state/src/toast.rs
+++ b/crates/okena-state/src/toast.rs
@@ -16,6 +16,39 @@ pub enum ToastLevel {
     Info,
 }
 
+/// Visual emphasis for a clickable toast action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToastActionStyle {
+    /// Neutral / secondary action.
+    Default,
+    /// Emphasized primary action (e.g. "Undo").
+    Primary,
+    /// Destructive action (e.g. "Close now").
+    Danger,
+}
+
+/// A clickable button rendered inside a toast.
+///
+/// `id` is opaque to this crate — the view layer that posted the toast is
+/// responsible for interpreting it (e.g. `"soft_close_undo:<project>:<terminal>"`).
+/// This keeps `okena-state` free of any GPUI / action-routing knowledge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToastAction {
+    pub id: String,
+    pub label: String,
+    pub style: ToastActionStyle,
+}
+
+impl ToastAction {
+    pub fn new(id: impl Into<String>, label: impl Into<String>, style: ToastActionStyle) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+            style,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Toast {
     pub id: String,
@@ -23,6 +56,9 @@ pub struct Toast {
     pub message: String,
     pub created: Instant,
     pub ttl: Duration,
+    /// Optional clickable actions. When non-empty the overlay also renders a
+    /// countdown indicator driven by `created` + `ttl`.
+    pub actions: Vec<ToastAction>,
 }
 
 impl Toast {
@@ -33,6 +69,7 @@ impl Toast {
             message: message.into(),
             created: Instant::now(),
             ttl: DEFAULT_TTL,
+            actions: Vec::new(),
         }
     }
 
@@ -53,10 +90,25 @@ impl Toast {
         Self::new(ToastLevel::Info, message)
     }
 
-    #[allow(dead_code)]
     pub fn with_ttl(mut self, ttl: Duration) -> Self {
         self.ttl = ttl;
         self
+    }
+
+    /// Attach clickable actions (rendered as buttons, with a countdown).
+    pub fn with_actions(mut self, actions: Vec<ToastAction>) -> Self {
+        self.actions = actions;
+        self
+    }
+
+    /// Remaining lifetime as a 0.0..=1.0 fraction of the TTL
+    /// (1.0 = just created, 0.0 = expired). Drives the countdown indicator.
+    pub fn remaining_fraction(&self) -> f32 {
+        let ttl = self.ttl.as_secs_f32();
+        if ttl <= 0.0 {
+            return 0.0;
+        }
+        (1.0 - self.created.elapsed().as_secs_f32() / ttl).clamp(0.0, 1.0)
     }
 
     /// True when the toast has lived past its TTL.

--- a/crates/okena-state/src/toast.rs
+++ b/crates/okena-state/src/toast.rs
@@ -54,6 +54,9 @@ pub struct Toast {
     pub id: String,
     pub level: ToastLevel,
     pub message: String,
+    /// Optional secondary line rendered smaller + muted under `message`
+    /// (e.g. the project / cwd context for a soft-close toast).
+    pub detail: Option<String>,
     pub created: Instant,
     pub ttl: Duration,
     /// Optional clickable actions. When non-empty the overlay also renders a
@@ -67,6 +70,7 @@ impl Toast {
             id: uuid::Uuid::new_v4().to_string(),
             level,
             message: message.into(),
+            detail: None,
             created: Instant::now(),
             ttl: DEFAULT_TTL,
             actions: Vec::new(),
@@ -98,6 +102,12 @@ impl Toast {
     /// Attach clickable actions (rendered as buttons, with a countdown).
     pub fn with_actions(mut self, actions: Vec<ToastAction>) -> Self {
         self.actions = actions;
+        self
+    }
+
+    /// Attach a secondary line rendered smaller + muted under the message.
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
         self
     }
 

--- a/crates/okena-terminal/src/terminal/child_processes.rs
+++ b/crates/okena-terminal/src/terminal/child_processes.rs
@@ -36,3 +36,34 @@ pub fn has_child_processes(pid: u32) -> bool {
 pub fn has_child_processes(_pid: u32) -> bool {
     false
 }
+
+/// Best-effort name of the foreground command running under `pid` (the shell):
+/// the first child process's `comm` (e.g. "make", "vim", "cargo"). Linux only —
+/// reads `/proc/<child>/comm`; returns `None` elsewhere or when the shell has no
+/// child. Used to give the soft-close toast a "what am I killing" hint.
+#[cfg(target_os = "linux")]
+pub fn foreground_command(pid: u32) -> Option<String> {
+    let task_dir = format!("/proc/{pid}/task");
+    for entry in std::fs::read_dir(&task_dir).ok()?.flatten() {
+        let file_name = entry.file_name();
+        let Some(tid) = file_name.to_str() else { continue };
+        let Ok(children) = std::fs::read_to_string(format!("/proc/{pid}/task/{tid}/children"))
+        else {
+            continue;
+        };
+        let Some(child_pid) = children.split_whitespace().next() else { continue };
+        let Ok(comm) = std::fs::read_to_string(format!("/proc/{child_pid}/comm")) else {
+            continue;
+        };
+        let name = comm.trim();
+        if !name.is_empty() {
+            return Some(name.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn foreground_command(_pid: u32) -> Option<String> {
+    None
+}

--- a/crates/okena-terminal/src/terminal/mod.rs
+++ b/crates/okena-terminal/src/terminal/mod.rs
@@ -33,7 +33,7 @@ mod url_detect;
 mod tests;
 
 pub use app_version::set_app_version;
-pub use child_processes::has_child_processes;
+pub use child_processes::{foreground_command, has_child_processes};
 pub use resize_authority::{
     claim_resize_authority_local, claim_resize_authority_remote, is_resize_authority_local,
 };

--- a/crates/okena-workspace/src/actions/mod.rs
+++ b/crates/okena-workspace/src/actions/mod.rs
@@ -11,6 +11,7 @@ pub mod focus;
 pub mod folder;
 pub mod layout;
 pub mod project;
+pub mod soft_close;
 pub mod terminal;
 pub mod worktree;
 

--- a/crates/okena-workspace/src/actions/project.rs
+++ b/crates/okena-workspace/src/actions/project.rs
@@ -308,6 +308,14 @@ impl Workspace {
             self.queue_terminal_kills(kill_ids);
         }
 
+        // Soft-closed terminals are no longer in the layout but their PTY is
+        // still alive waiting out the grace window — kill them too and drop the
+        // pending records so the grace timer can't fire against a deleted project.
+        let soft_closed = self.drain_pending_closes_for_project(project_id);
+        if !soft_closed.is_empty() {
+            self.queue_terminal_kills(soft_closed);
+        }
+
         // Capture project info before removal for the hook
         let folder = self.folder_for_project_or_parent(project_id);
         let hook_folder_id = folder.map(|f| f.id.clone());

--- a/crates/okena-workspace/src/actions/soft_close.rs
+++ b/crates/okena-workspace/src/actions/soft_close.rs
@@ -6,7 +6,7 @@
 //! bookkeeping: recording the close, restoring it, and finalizing the kill.
 
 use crate::focus::FocusManager;
-use crate::state::{LayoutNode, PendingClose, Workspace};
+use crate::state::{LayoutNode, PendingClose, RestoredClose, Workspace};
 use gpui::*;
 
 impl Workspace {
@@ -39,6 +39,10 @@ impl Workspace {
             pre_close_layout,
             post_close_layout,
         });
+
+        // A fresh close supersedes any earlier restore-race breadcrumb for this
+        // terminal (e.g. close → undo → close again).
+        self.restored_closes.retain(|r| r.terminal_id != terminal_id);
     }
 
     /// True if the terminal is currently waiting out its grace period.
@@ -132,10 +136,46 @@ impl Workspace {
             .and_then(|p| p.layout.as_ref())
             .and_then(|l| l.find_terminal_path(terminal_id))
         {
-            self.set_focused_terminal(focus_manager, project_id, path, cx);
+            self.set_focused_terminal(focus_manager, project_id.clone(), path, cx);
         }
 
+        // Leave a breadcrumb: the `alive` check is registry-based and lags the
+        // real process exit, so the PTY we just restored might already be dead
+        // (its exit event still queued). If that exit lands, the exit handler
+        // calls `reap_restored_close` to tear this pane back out — see
+        // [`RestoredClose`].
+        self.restored_closes.retain(|r| r.terminal_id != terminal_id);
+        self.restored_closes.push(RestoredClose {
+            terminal_id: terminal_id.to_string(),
+            project_id,
+        });
+
         self.notify_data(cx);
+        true
+    }
+
+    /// A soft-close-restored terminal's shell exited — it was racing the undo and
+    /// the PTY is now dead. Consume the breadcrumb and, if the dead terminal is
+    /// still sitting in the layout, remove that pane (it can't be reconnected, and
+    /// a lingering layout node would respawn a fresh shell on the next render).
+    /// Returns true if a breadcrumb was consumed. Idempotent.
+    pub fn reap_restored_close(&mut self, terminal_id: &str, cx: &mut Context<Self>) -> bool {
+        let Some(idx) = self
+            .restored_closes
+            .iter()
+            .position(|r| r.terminal_id == terminal_id)
+        else {
+            return false;
+        };
+        let restored = self.restored_closes.remove(idx);
+
+        if let Some(path) = self
+            .project(&restored.project_id)
+            .and_then(|p| p.layout.as_ref())
+            .and_then(|l| l.find_terminal_path(terminal_id))
+        {
+            self.close_terminal(&restored.project_id, &path, cx);
+        }
         true
     }
 
@@ -317,6 +357,56 @@ mod tests {
             let layout = ws.project("p1").unwrap().layout.as_ref().unwrap();
             assert!(layout.find_terminal_path("a").is_some(), "a is back in the tree");
             assert!(layout.find_terminal_path("b").is_some(), "b retained");
+        });
+    }
+
+    #[gpui::test]
+    fn reap_restored_close_removes_dead_pane_after_undo(cx: &mut gpui::TestAppContext) {
+        let data = workspace_data(hsplit(vec![term("a"), term("b")]));
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            let mut fm = FocusManager::new();
+            ws.begin_soft_close(&mut fm, "p1", &[0], "a", "toast-a", cx);
+            // Undo with the PTY reading as alive — restored into the layout.
+            assert!(ws.undo_soft_close(&mut fm, "a", true, cx));
+            assert_eq!(
+                ws.project("p1")
+                    .unwrap()
+                    .layout
+                    .as_ref()
+                    .unwrap()
+                    .find_terminal_path("a"),
+                Some(vec![0]),
+                "restored into the split"
+            );
+
+            // The PTY actually died (it was racing the undo). Reaping tears the
+            // dead pane back out instead of leaving it to linger / respawn.
+            assert!(ws.reap_restored_close("a", cx));
+            let layout = ws.project("p1").unwrap().layout.as_ref().unwrap();
+            assert!(layout.find_terminal_path("a").is_none(), "dead pane removed");
+            assert!(layout.find_terminal_path("b").is_some(), "sibling retained");
+
+            // Idempotent — nothing left to reap.
+            assert!(!ws.reap_restored_close("a", cx));
+        });
+    }
+
+    #[gpui::test]
+    fn re_closing_clears_stale_restore_breadcrumb(cx: &mut gpui::TestAppContext) {
+        let data = workspace_data(hsplit(vec![term("a"), term("b")]));
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            let mut fm = FocusManager::new();
+            ws.begin_soft_close(&mut fm, "p1", &[0], "a", "toast-a", cx);
+            assert!(ws.undo_soft_close(&mut fm, "a", true, cx));
+
+            // Soft-closing "a" again supersedes the earlier restore breadcrumb,
+            // so a later stray exit can't reap the freshly-closed pane.
+            ws.begin_soft_close(&mut fm, "p1", &[0], "a", "toast-a2", cx);
+            assert!(!ws.reap_restored_close("a", cx), "breadcrumb cleared by re-close");
         });
     }
 

--- a/crates/okena-workspace/src/actions/soft_close.rs
+++ b/crates/okena-workspace/src/actions/soft_close.rs
@@ -1,0 +1,311 @@
+//! Soft-close (grace-period) workspace actions.
+//!
+//! A "soft close" removes a busy terminal from the layout but keeps its PTY
+//! alive for a grace period so the user can undo an accidental close. The
+//! desktop layer drives the timer + toast; this module owns the layout
+//! bookkeeping: recording the close, restoring it, and finalizing the kill.
+
+use crate::focus::FocusManager;
+use crate::state::{LayoutNode, PendingClose, Workspace};
+use gpui::*;
+
+impl Workspace {
+    /// Begin a soft close: snapshot the project's layout, remove the terminal
+    /// from the tree (focusing a sibling, exactly like a normal close), and
+    /// record the pending close so it can be undone or finalized later.
+    ///
+    /// The PTY is **not** killed and the terminal is **not** removed from the
+    /// registry — that happens in `finalize_soft_close`.
+    pub fn begin_soft_close(
+        &mut self,
+        focus_manager: &mut FocusManager,
+        project_id: &str,
+        path: &[usize],
+        terminal_id: &str,
+        toast_id: &str,
+        cx: &mut Context<Self>,
+    ) {
+        let pre_close_layout = self.project(project_id).and_then(|p| p.layout.clone());
+
+        // Remove from the layout + focus a sibling (same as a hard close).
+        self.close_terminal_and_focus_sibling(focus_manager, project_id, path, cx);
+
+        let post_close_layout = self.project(project_id).and_then(|p| p.layout.clone());
+
+        self.pending_closes.push(PendingClose {
+            terminal_id: terminal_id.to_string(),
+            project_id: project_id.to_string(),
+            toast_id: toast_id.to_string(),
+            pre_close_layout,
+            post_close_layout,
+        });
+    }
+
+    /// True if the terminal is currently waiting out its grace period.
+    pub fn has_pending_close(&self, terminal_id: &str) -> bool {
+        self.pending_closes
+            .iter()
+            .any(|p| p.terminal_id == terminal_id)
+    }
+
+    fn take_pending_close(&mut self, terminal_id: &str) -> Option<PendingClose> {
+        let idx = self
+            .pending_closes
+            .iter()
+            .position(|p| p.terminal_id == terminal_id)?;
+        Some(self.pending_closes.remove(idx))
+    }
+
+    /// Finalize a soft close: drop the pending record and queue the PTY for the
+    /// real teardown (the Okena observer drains `pending_terminal_kills` and
+    /// calls `pty_manager.kill` + removes it from the registry). Idempotent —
+    /// returns false if there was no pending close for this terminal.
+    pub fn finalize_soft_close(&mut self, terminal_id: &str, cx: &mut Context<Self>) -> bool {
+        if self.take_pending_close(terminal_id).is_none() {
+            return false;
+        }
+        self.queue_terminal_kills([terminal_id.to_string()]);
+        // Plain notify (not notify_data): queuing a kill is transient state, it
+        // must not bump data_version / trigger an auto-save. The workspace
+        // observer drains the kill queue on this notification.
+        cx.notify();
+        true
+    }
+
+    /// Undo a soft close, bringing the terminal back into the layout.
+    ///
+    /// `alive` reflects whether the PTY is still in the registry — if the shell
+    /// exited on its own during the grace window there is nothing to restore, so
+    /// the pending record is simply dropped. Returns true if the terminal was
+    /// actually restored.
+    pub fn undo_soft_close(
+        &mut self,
+        focus_manager: &mut FocusManager,
+        terminal_id: &str,
+        alive: bool,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let pending = match self.take_pending_close(terminal_id) {
+            Some(p) => p,
+            None => return false,
+        };
+
+        if !alive {
+            // The shell exited during the grace window — nothing to bring back.
+            // The normal exit path has already reaped it.
+            return false;
+        }
+
+        let project_id = pending.project_id.clone();
+        let current = self.project(&project_id).and_then(|p| p.layout.clone());
+
+        if current == pending.post_close_layout {
+            // Nothing else touched the tree since the close — restore it exactly.
+            if let Some(project) = self.project_mut(&project_id) {
+                project.layout = pending.pre_close_layout;
+            }
+        } else {
+            // The tree changed during the grace window. Don't guess a merge —
+            // drop the recovered pane into the top-level group.
+            let node = pending
+                .pre_close_layout
+                .as_ref()
+                .and_then(|l| l.find_terminal_node(terminal_id))
+                .cloned();
+            if let Some(mut node) = node {
+                if let LayoutNode::Terminal { minimized, detached, .. } = &mut node {
+                    *minimized = false;
+                    *detached = false;
+                }
+                if let Some(project) = self.project_mut(&project_id) {
+                    match &mut project.layout {
+                        Some(root) => root.append_to_root(node),
+                        None => project.layout = Some(node),
+                    }
+                }
+            }
+        }
+
+        // Focus the restored terminal.
+        if let Some(path) = self
+            .project(&project_id)
+            .and_then(|p| p.layout.as_ref())
+            .and_then(|l| l.find_terminal_path(terminal_id))
+        {
+            self.set_focused_terminal(focus_manager, project_id, path, cx);
+        }
+
+        self.notify_data(cx);
+        true
+    }
+
+    /// Drain all pending soft-closes, returning their terminal ids. Used on
+    /// quit to make sure soft-closed PTYs are actually torn down (and don't
+    /// leak as orphaned session-backend sessions).
+    pub fn drain_pending_closes(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.pending_closes)
+            .into_iter()
+            .map(|p| p.terminal_id)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gpui::AppContext as _;
+
+    use crate::focus::FocusManager;
+    use crate::settings::HooksConfig;
+    use crate::state::{LayoutNode, ProjectData, SplitDirection, Workspace, WorkspaceData};
+    use okena_core::theme::FolderColor;
+    use okena_terminal::shell_config::ShellType;
+    use std::collections::HashMap;
+
+    fn term(id: &str) -> LayoutNode {
+        LayoutNode::Terminal {
+            terminal_id: Some(id.to_string()),
+            minimized: false,
+            detached: false,
+            shell_type: ShellType::Default,
+            zoom_level: 1.0,
+        }
+    }
+
+    fn project_with(layout: LayoutNode) -> ProjectData {
+        ProjectData {
+            id: "p1".to_string(),
+            name: "Project p1".to_string(),
+            path: "/tmp/test".to_string(),
+            layout: Some(layout),
+            terminal_names: HashMap::new(),
+            hidden_terminals: HashMap::new(),
+            worktree_info: None,
+            worktree_ids: Vec::new(),
+            folder_color: FolderColor::default(),
+            hooks: HooksConfig::default(),
+            is_remote: false,
+            connection_id: None,
+            service_terminals: HashMap::new(),
+            default_shell: None,
+            hook_terminals: HashMap::new(),
+        }
+    }
+
+    fn workspace_data(layout: LayoutNode) -> WorkspaceData {
+        WorkspaceData {
+            version: 1,
+            projects: vec![project_with(layout)],
+            project_order: vec!["p1".to_string()],
+            service_panel_heights: HashMap::new(),
+            hook_panel_heights: HashMap::new(),
+            folders: vec![],
+            main_window: crate::state::WindowState::default(),
+            extra_windows: Vec::new(),
+        }
+    }
+
+    fn hsplit(children: Vec<LayoutNode>) -> LayoutNode {
+        let n = children.len();
+        LayoutNode::Split {
+            direction: SplitDirection::Horizontal,
+            sizes: vec![1.0 / n as f32; n],
+            children,
+        }
+    }
+
+    #[gpui::test]
+    fn undo_restores_exact_tree_when_unchanged(cx: &mut gpui::TestAppContext) {
+        let data = workspace_data(hsplit(vec![term("a"), term("b")]));
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            let mut fm = FocusManager::new();
+            // Close "a" (path [0]) softly. The split collapses to just "b".
+            ws.begin_soft_close(&mut fm, "p1", &[0], "a", "toast-a", cx);
+            assert!(ws.has_pending_close("a"));
+            assert_eq!(
+                ws.project("p1").unwrap().layout,
+                Some(term("b")),
+                "split collapses to the sibling after close"
+            );
+
+            // Undo with the PTY still alive — exact restore.
+            assert!(ws.undo_soft_close(&mut fm, "a", true, cx));
+            assert!(!ws.has_pending_close("a"));
+            let layout = ws.project("p1").unwrap().layout.as_ref().unwrap();
+            assert_eq!(layout.find_terminal_path("a"), Some(vec![0]));
+            assert_eq!(layout.find_terminal_path("b"), Some(vec![1]));
+        });
+    }
+
+    #[gpui::test]
+    fn undo_with_dead_pty_drops_pending_without_restoring(cx: &mut gpui::TestAppContext) {
+        let data = workspace_data(hsplit(vec![term("a"), term("b")]));
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            let mut fm = FocusManager::new();
+            ws.begin_soft_close(&mut fm, "p1", &[0], "a", "toast-a", cx);
+
+            // PTY exited during the grace window (alive = false) — nothing to bring back.
+            assert!(!ws.undo_soft_close(&mut fm, "a", false, cx));
+            assert!(!ws.has_pending_close("a"), "pending record is dropped");
+            assert_eq!(
+                ws.project("p1").unwrap().layout,
+                Some(term("b")),
+                "layout stays collapsed — not restored"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn finalize_queues_kill_and_drops_pending(cx: &mut gpui::TestAppContext) {
+        let data = workspace_data(hsplit(vec![term("a"), term("b")]));
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            let mut fm = FocusManager::new();
+            ws.begin_soft_close(&mut fm, "p1", &[0], "a", "toast-a", cx);
+
+            assert!(ws.finalize_soft_close("a", cx));
+            assert!(!ws.has_pending_close("a"));
+            assert_eq!(ws.drain_pending_terminal_kills(), vec!["a".to_string()]);
+
+            // Idempotent — second finalize is a no-op.
+            assert!(!ws.finalize_soft_close("a", cx));
+        });
+    }
+
+    #[gpui::test]
+    fn undo_appends_to_root_when_layout_changed(cx: &mut gpui::TestAppContext) {
+        let data = workspace_data(hsplit(vec![term("a"), term("b")]));
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            let mut fm = FocusManager::new();
+            ws.begin_soft_close(&mut fm, "p1", &[0], "a", "toast-a", cx);
+            // Tree now changed since the close: wrap the survivor in a tab group.
+            ws.add_tab(&mut fm, "p1", &[], cx);
+
+            // Undo can't restore the exact spot — it appends "a" to the root group.
+            assert!(ws.undo_soft_close(&mut fm, "a", true, cx));
+            let layout = ws.project("p1").unwrap().layout.as_ref().unwrap();
+            assert!(layout.find_terminal_path("a").is_some(), "a is back in the tree");
+            assert!(layout.find_terminal_path("b").is_some(), "b retained");
+        });
+    }
+
+    #[gpui::test]
+    fn drain_pending_closes_returns_all_ids(cx: &mut gpui::TestAppContext) {
+        let data = workspace_data(hsplit(vec![term("a"), term("b")]));
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            let mut fm = FocusManager::new();
+            ws.begin_soft_close(&mut fm, "p1", &[0], "a", "toast-a", cx);
+            let drained = ws.drain_pending_closes();
+            assert_eq!(drained, vec!["a".to_string()]);
+            assert!(!ws.has_pending_close("a"));
+        });
+    }
+}

--- a/crates/okena-workspace/src/actions/soft_close.rs
+++ b/crates/okena-workspace/src/actions/soft_close.rs
@@ -148,6 +148,31 @@ impl Workspace {
             .map(|p| p.terminal_id)
             .collect()
     }
+
+    /// Drain pending soft-closes belonging to `project_id`, returning their
+    /// terminal ids. Used when a project is deleted mid-grace: the soft-closed
+    /// panes are gone from the layout, so the normal teardown wouldn't see them
+    /// — kill those PTYs explicitly and drop the now-orphaned pending records.
+    pub fn drain_pending_closes_for_project(&mut self, project_id: &str) -> Vec<String> {
+        let mut ids = Vec::new();
+        self.pending_closes.retain(|p| {
+            if p.project_id == project_id {
+                ids.push(p.terminal_id.clone());
+                false
+            } else {
+                true
+            }
+        });
+        ids
+    }
+
+    /// A soft-closed terminal's shell exited on its own during the grace window.
+    /// Drop the pending record (the normal exit path is already reaping the PTY)
+    /// and return its toast id so the caller can dismiss the now-useless undo
+    /// toast. Returns `None` if the terminal wasn't mid soft-close.
+    pub fn cancel_pending_close(&mut self, terminal_id: &str) -> Option<String> {
+        self.take_pending_close(terminal_id).map(|p| p.toast_id)
+    }
 }
 
 #[cfg(test)]
@@ -305,6 +330,44 @@ mod tests {
             ws.begin_soft_close(&mut fm, "p1", &[0], "a", "toast-a", cx);
             let drained = ws.drain_pending_closes();
             assert_eq!(drained, vec!["a".to_string()]);
+            assert!(!ws.has_pending_close("a"));
+        });
+    }
+
+    #[gpui::test]
+    fn cancel_pending_close_returns_toast_and_drops_record(cx: &mut gpui::TestAppContext) {
+        let data = workspace_data(hsplit(vec![term("a"), term("b")]));
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            let mut fm = FocusManager::new();
+            ws.begin_soft_close(&mut fm, "p1", &[0], "a", "toast-a", cx);
+
+            // Shell exited on its own → cancel returns the toast id to dismiss.
+            assert_eq!(ws.cancel_pending_close("a"), Some("toast-a".to_string()));
+            assert!(!ws.has_pending_close("a"));
+            // Idempotent — nothing left to cancel.
+            assert_eq!(ws.cancel_pending_close("a"), None);
+        });
+    }
+
+    #[gpui::test]
+    fn drain_pending_closes_for_project_filters_by_project(cx: &mut gpui::TestAppContext) {
+        let data = workspace_data(hsplit(vec![term("a"), term("b")]));
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            let mut fm = FocusManager::new();
+            ws.begin_soft_close(&mut fm, "p1", &[0], "a", "toast-a", cx);
+
+            // A different project's pending close must be left untouched.
+            assert!(ws.drain_pending_closes_for_project("other").is_empty());
+            assert!(ws.has_pending_close("a"));
+
+            assert_eq!(
+                ws.drain_pending_closes_for_project("p1"),
+                vec!["a".to_string()]
+            );
             assert!(!ws.has_pending_close("a"));
         });
     }

--- a/crates/okena-workspace/src/settings.rs
+++ b/crates/okena-workspace/src/settings.rs
@@ -262,6 +262,12 @@ pub struct AppSettings {
     /// Number of scrollback lines (default: 10000)
     #[serde(default = "default_scrollback_lines")]
     pub scrollback_lines: u32,
+    /// Grace period, in seconds, before a *busy* terminal (one with a running
+    /// foreground process) is actually killed when closed. During this window
+    /// the pane is removed but the PTY keeps running and a toast offers "Undo".
+    /// `0` disables the feature entirely (close kills immediately, as before).
+    #[serde(default = "default_terminal_close_grace_secs")]
+    pub terminal_close_grace_secs: u32,
 
     // Shell settings
     /// Default shell type for new terminals
@@ -394,6 +400,7 @@ impl Default for AppSettings {
             cursor_style: CursorShape::default(),
             cursor_blink: default_cursor_blink(),
             scrollback_lines: default_scrollback_lines(),
+            terminal_close_grace_secs: default_terminal_close_grace_secs(),
             default_shell: ShellType::default(),
             show_shell_selector: false,
             session_backend: SessionBackend::default(),
@@ -462,6 +469,10 @@ fn default_cursor_blink() -> bool {
 
 fn default_scrollback_lines() -> u32 {
     10000
+}
+
+fn default_terminal_close_grace_secs() -> u32 {
+    5
 }
 
 fn default_file_opener() -> String {
@@ -602,6 +613,8 @@ fn clamp_settings(settings: &mut AppSettings) {
     settings.ui_font_size = settings.ui_font_size.clamp(8.0, 24.0);
     settings.file_font_size = settings.file_font_size.clamp(8.0, 24.0);
     settings.scrollback_lines = settings.scrollback_lines.clamp(100, 100_000);
+    // 0 = disabled; otherwise cap the grace window at a sane upper bound.
+    settings.terminal_close_grace_secs = settings.terminal_close_grace_secs.min(60);
 }
 
 /// Migrate settings from older versions to the current version

--- a/crates/okena-workspace/src/state.rs
+++ b/crates/okena-workspace/src/state.rs
@@ -51,6 +51,25 @@ pub struct Workspace {
     data_replacement_epoch: u64,
     /// Terminal IDs queued for killing by the app layer (drained by Okena observer).
     pending_terminal_kills: Vec<String>,
+    /// Terminals closed with the grace-period "soft close": removed from the
+    /// layout but their PTY is kept alive until the grace timer fires (or the
+    /// user undoes / force-closes). Holds the snapshots needed to restore.
+    pub(crate) pending_closes: Vec<PendingClose>,
+}
+
+/// A terminal that was soft-closed and is waiting out its grace period.
+///
+/// The PTY is still alive in the registry; only the layout entry was removed.
+/// `pre_close_layout` / `post_close_layout` snapshot the owning project's tree
+/// before and right after the close so undo can either restore the exact prior
+/// tree (when nothing else changed) or fall back to re-appending the pane.
+#[derive(Clone, Debug)]
+pub struct PendingClose {
+    pub terminal_id: String,
+    pub project_id: String,
+    pub toast_id: String,
+    pub pre_close_layout: Option<LayoutNode>,
+    pub post_close_layout: Option<LayoutNode>,
 }
 
 impl Workspace {
@@ -63,6 +82,7 @@ impl Workspace {
             data_version: 0,
             data_replacement_epoch: 0,
             pending_terminal_kills: Vec::new(),
+            pending_closes: Vec::new(),
         }
     }
 
@@ -95,6 +115,9 @@ impl Workspace {
     pub fn replace_data(&mut self, focus_manager: &mut FocusManager, data: WorkspaceData, cx: &mut Context<Self>) {
         self.data = data;
         self.data_replacement_epoch += 1;
+        // Snapshots in pending_closes refer to the old data — drop them so an
+        // undo can't restore into a wholesale-replaced workspace.
+        self.pending_closes.clear();
         focus_manager.clear_all();
         cx.notify();
         cx.refresh_windows();

--- a/crates/okena-workspace/src/state.rs
+++ b/crates/okena-workspace/src/state.rs
@@ -55,6 +55,9 @@ pub struct Workspace {
     /// layout but their PTY is kept alive until the grace timer fires (or the
     /// user undoes / force-closes). Holds the snapshots needed to restore.
     pub(crate) pending_closes: Vec<PendingClose>,
+    /// Terminals just brought back by an undo whose PTY might still be racing an
+    /// in-flight exit event — see [`RestoredClose`].
+    pub(crate) restored_closes: Vec<RestoredClose>,
 }
 
 /// A terminal that was soft-closed and is waiting out its grace period.
@@ -72,6 +75,21 @@ pub struct PendingClose {
     pub post_close_layout: Option<LayoutNode>,
 }
 
+/// A terminal brought back by `undo_soft_close` whose PTY may still be racing an
+/// in-flight exit event.
+///
+/// The `alive` check the undo path uses is registry-based, and the registry only
+/// drops a terminal once the app *processes* its exit event — so a shell that has
+/// already exited can still read as "alive", letting undo restore a doomed pane.
+/// If that exit then lands, `reap_restored_close` tears the now-dead pane back out
+/// of the layout (it can't be reconnected) instead of leaving it to linger — or to
+/// silently respawn a fresh shell on the next render.
+#[derive(Clone, Debug)]
+pub struct RestoredClose {
+    pub terminal_id: String,
+    pub project_id: String,
+}
+
 impl Workspace {
     pub fn new(data: WorkspaceData) -> Self {
         Self {
@@ -83,6 +101,7 @@ impl Workspace {
             data_replacement_epoch: 0,
             pending_terminal_kills: Vec::new(),
             pending_closes: Vec::new(),
+            restored_closes: Vec::new(),
         }
     }
 
@@ -116,8 +135,10 @@ impl Workspace {
         self.data = data;
         self.data_replacement_epoch += 1;
         // Snapshots in pending_closes refer to the old data — drop them so an
-        // undo can't restore into a wholesale-replaced workspace.
+        // undo can't restore into a wholesale-replaced workspace. The
+        // restore-race breadcrumbs refer to the old layout too.
         self.pending_closes.clear();
+        self.restored_closes.clear();
         focus_manager.clear_all();
         cx.notify();
         cx.refresh_windows();

--- a/crates/okena-workspace/src/toast.rs
+++ b/crates/okena-workspace/src/toast.rs
@@ -1,6 +1,6 @@
 //! ToastManager — GPUI Global wrapper around the `Toast` data type from `okena-state`.
 
-pub use okena_state::{Toast, ToastLevel};
+pub use okena_state::{Toast, ToastAction, ToastActionStyle, ToastLevel};
 
 use gpui::{App, Global};
 use parking_lot::Mutex;

--- a/crates/okena-workspace/src/toast.rs
+++ b/crates/okena-workspace/src/toast.rs
@@ -11,6 +11,22 @@ use std::sync::Arc;
 /// Maximum number of visible toasts
 const MAX_VISIBLE_TOASTS: usize = 5;
 
+/// Trim the queue to `MAX_VISIBLE_TOASTS`, preferring to drop the oldest toast
+/// that has **no** actions. Toasts with actions (e.g. the soft-close "Undo"
+/// toast) carry a pending operation that only resolves when the toast lives out
+/// its TTL — evicting one early would silently strip the user's undo affordance
+/// while the underlying close still goes through. Falls back to the oldest toast
+/// when every toast has actions, so the hard cap is always honoured.
+fn trim_to_cap(queue: &mut Vec<Toast>) {
+    while queue.len() > MAX_VISIBLE_TOASTS {
+        let idx = queue
+            .iter()
+            .position(|t| t.actions.is_empty())
+            .unwrap_or(0);
+        queue.remove(idx);
+    }
+}
+
 #[derive(Clone)]
 pub struct ToastManager(pub Arc<Mutex<Vec<Toast>>>);
 
@@ -43,10 +59,7 @@ impl ToastManager {
         if let Some(tm) = cx.try_global::<ToastManager>() {
             let mut queue = tm.0.lock();
             queue.push(toast);
-            // Drop oldest if over cap
-            while queue.len() > MAX_VISIBLE_TOASTS {
-                queue.remove(0);
-            }
+            trim_to_cap(&mut queue);
         }
     }
 
@@ -78,9 +91,7 @@ impl ToastManager {
                 log::debug!("[hook toast] {}", toast.message);
                 queue.push(toast);
             }
-            while queue.len() > MAX_VISIBLE_TOASTS {
-                queue.remove(0);
-            }
+            trim_to_cap(&mut queue);
         }
     }
 
@@ -96,5 +107,39 @@ impl ToastManager {
         let mut queue = self.0.lock();
         queue.retain(|t| !t.is_expired());
         queue.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{trim_to_cap, Toast, ToastAction, ToastActionStyle, MAX_VISIBLE_TOASTS};
+
+    fn action_toast(msg: &str) -> Toast {
+        Toast::info(msg)
+            .with_actions(vec![ToastAction::new("undo", "Undo", ToastActionStyle::Primary)])
+    }
+
+    #[test]
+    fn trim_keeps_action_toast_and_drops_oldest_plain() {
+        // Oldest entry is the undo toast, followed by enough plain toasts to
+        // overflow the cap by one.
+        let mut q = vec![action_toast("undo")];
+        for i in 0..MAX_VISIBLE_TOASTS {
+            q.push(Toast::info(format!("plain {i}")));
+        }
+        trim_to_cap(&mut q);
+        assert_eq!(q.len(), MAX_VISIBLE_TOASTS);
+        assert_eq!(q[0].message, "undo", "undo toast survives eviction");
+        assert!(!q[0].actions.is_empty());
+    }
+
+    #[test]
+    fn trim_falls_back_to_oldest_when_all_have_actions() {
+        let mut q: Vec<Toast> = (0..MAX_VISIBLE_TOASTS + 1)
+            .map(|i| action_toast(&format!("a{i}")))
+            .collect();
+        trim_to_cap(&mut q);
+        assert_eq!(q.len(), MAX_VISIBLE_TOASTS);
+        assert_eq!(q[0].message, "a1", "oldest action toast dropped as fallback");
     }
 }

--- a/src/action_dispatch.rs
+++ b/src/action_dispatch.rs
@@ -170,6 +170,16 @@ impl ActionDispatcher {
                 let window_id = *window_id;
                 focus_manager.update(cx, |fm, cx| {
                     workspace.update(cx, |ws, cx| {
+                        // Interactive close of a busy terminal goes through the
+                        // grace-period soft close (undo toast); if it doesn't
+                        // apply, fall through to the immediate close.
+                        if let ActionRequest::CloseTerminal { project_id, terminal_id } = &action
+                            && crate::soft_close::try_begin(
+                                ws, fm, &*backend, project_id, terminal_id, cx,
+                            )
+                        {
+                            return;
+                        }
                         execute_action(action, ws, window_id, fm, &*backend, &terminals, cx);
                     });
                     cx.notify();

--- a/src/action_dispatch.rs
+++ b/src/action_dispatch.rs
@@ -177,7 +177,7 @@ impl ActionDispatcher {
                         match &action {
                             ActionRequest::CloseTerminal { project_id, terminal_id } => {
                                 if crate::soft_close::try_begin(
-                                    ws, fm, &*backend, project_id, terminal_id, cx,
+                                    ws, fm, &*backend, &terminals, project_id, terminal_id, cx,
                                 ) {
                                     return;
                                 }
@@ -188,7 +188,7 @@ impl ActionDispatcher {
                                 let mut remaining = Vec::new();
                                 for terminal_id in terminal_ids {
                                     if !crate::soft_close::try_begin(
-                                        ws, fm, &*backend, project_id, terminal_id, cx,
+                                        ws, fm, &*backend, &terminals, project_id, terminal_id, cx,
                                     ) {
                                         remaining.push(terminal_id.clone());
                                     }

--- a/src/action_dispatch.rs
+++ b/src/action_dispatch.rs
@@ -171,14 +171,41 @@ impl ActionDispatcher {
                 focus_manager.update(cx, |fm, cx| {
                     workspace.update(cx, |ws, cx| {
                         // Interactive close of a busy terminal goes through the
-                        // grace-period soft close (undo toast); if it doesn't
-                        // apply, fall through to the immediate close.
-                        if let ActionRequest::CloseTerminal { project_id, terminal_id } = &action
-                            && crate::soft_close::try_begin(
-                                ws, fm, &*backend, project_id, terminal_id, cx,
-                            )
-                        {
-                            return;
+                        // grace-period soft close (undo toast). Both the single
+                        // and multi-terminal close actions are gated; whatever
+                        // isn't soft-closed falls through to the immediate close.
+                        match &action {
+                            ActionRequest::CloseTerminal { project_id, terminal_id } => {
+                                if crate::soft_close::try_begin(
+                                    ws, fm, &*backend, project_id, terminal_id, cx,
+                                ) {
+                                    return;
+                                }
+                            }
+                            ActionRequest::CloseTerminals { project_id, terminal_ids } => {
+                                // Soft-close each busy terminal; hard-close the
+                                // rest in a single batched action.
+                                let mut remaining = Vec::new();
+                                for terminal_id in terminal_ids {
+                                    if !crate::soft_close::try_begin(
+                                        ws, fm, &*backend, project_id, terminal_id, cx,
+                                    ) {
+                                        remaining.push(terminal_id.clone());
+                                    }
+                                }
+                                if remaining.is_empty() {
+                                    return;
+                                }
+                                execute_action(
+                                    ActionRequest::CloseTerminals {
+                                        project_id: project_id.clone(),
+                                        terminal_ids: remaining,
+                                    },
+                                    ws, window_id, fm, &*backend, &terminals, cx,
+                                );
+                                return;
+                            }
+                            _ => {}
                         }
                         execute_action(action, ws, window_id, fm, &*backend, &terminals, cx);
                     });

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -786,6 +786,17 @@ impl Okena {
                         for toast_id in &stale_toasts {
                             crate::workspace::toast::ToastManager::dismiss(toast_id, cx);
                         }
+
+                        // If an exited terminal had just been *restored* by a
+                        // soft-close undo that raced this exit, its PTY is dead
+                        // now — the registry-based `alive` check let undo bring
+                        // back a doomed pane. Tear it back out so it doesn't
+                        // linger (and respawn a fresh shell on next render).
+                        this.workspace.update(cx, |ws, cx| {
+                            for (tid, _) in &exit_events {
+                                ws.reap_restored_close(tid, cx);
+                            }
+                        });
                     }
                     // Notify dirty terminal content panes directly (batched in one update).
                     // All notifications happen in the same GPUI update → single layout pass.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -447,6 +447,25 @@ impl Okena {
         })
         .detach();
 
+        // Flush soft-closed terminals on quit. Their grace timer can't fire once
+        // the app is gone, so tear the PTYs down here — otherwise a terminal
+        // closed seconds before quitting would leak its persistent (dtach/tmux)
+        // session. on_app_quit fires for every exit path.
+        cx.on_app_quit(move |this: &mut Self, cx| {
+            let ids = this
+                .workspace
+                .update(cx, |ws, _| ws.drain_pending_closes());
+            if !ids.is_empty() {
+                let mut reg = this.terminals.lock();
+                for tid in &ids {
+                    this.pty_manager.kill(tid);
+                    reg.remove(tid);
+                }
+            }
+            async {}
+        })
+        .detach();
+
         // Set up observer for detached terminals
         cx.observe(&workspace, move |this, workspace, cx| {
             this.handle_detached_terminals_changed(workspace, cx);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -772,6 +772,20 @@ impl Okena {
                                 }
                             }
                         }
+
+                        // If any exited terminal was mid soft-close, its undo toast
+                        // is now useless (the PTY is gone) and the pending record
+                        // would otherwise linger until the grace timer fired a
+                        // redundant kill — drop both now.
+                        let stale_toasts: Vec<String> = this.workspace.update(cx, |ws, _| {
+                            exit_events
+                                .iter()
+                                .filter_map(|(tid, _)| ws.cancel_pending_close(tid))
+                                .collect()
+                        });
+                        for toast_id in &stale_toasts {
+                            crate::workspace::toast::ToastManager::dismiss(toast_id, cx);
+                        }
                     }
                     // Notify dirty terminal content panes directly (batched in one update).
                     // All notifications happen in the same GPUI update → single layout pass.

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod remote;
 mod remote_client;
 mod services;
 mod settings;
+mod soft_close;
 #[cfg(target_os = "linux")]
 mod simple_root;
 mod terminal;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -96,6 +96,7 @@ impl SettingsState {
 
     setting_setter!(set_cursor_blink, cursor_blink, bool);
     setting_setter!(set_scrollback_lines, scrollback_lines, u32, 100, 100000);
+    setting_setter!(set_terminal_close_grace_secs, terminal_close_grace_secs, u32, 0, 60);
     setting_setter!(set_show_focused_border, show_focused_border, bool);
     setting_setter!(set_color_tinted_background, color_tinted_background, bool);
     setting_setter!(set_detached_overlays_by_default, detached_overlays_by_default, bool);

--- a/src/soft_close.rs
+++ b/src/soft_close.rs
@@ -1,0 +1,135 @@
+//! Desktop orchestration for the grace-period "soft close".
+//!
+//! When the user closes a *busy* terminal (one with a running foreground
+//! process), instead of killing it immediately we:
+//!   1. remove the pane from the layout but keep the PTY alive,
+//!   2. show a toast with "Undo" / "Close now" and a countdown,
+//!   3. schedule the real teardown after the grace period.
+//!
+//! The layout bookkeeping + restore live on `Workspace` (`begin_soft_close`,
+//! `undo_soft_close`, `finalize_soft_close`); this module wires the busy check,
+//! the toast, and the timer. Only the interactive desktop close path goes
+//! through here — the remote API keeps immediate-close semantics.
+
+use crate::terminal::backend::TerminalBackend;
+use crate::workspace::focus::FocusManager;
+use crate::workspace::state::Workspace;
+use crate::workspace::toast::{Toast, ToastAction, ToastActionStyle, ToastManager};
+use gpui::*;
+use std::time::Duration;
+
+/// Prefix for the "undo" toast action id; payload is `:<project_id>:<terminal_id>`.
+pub const UNDO_PREFIX: &str = "soft_close_undo";
+/// Prefix for the "close now" toast action id; payload is `:<project_id>:<terminal_id>`.
+pub const KILL_PREFIX: &str = "soft_close_kill";
+
+/// Decode a toast action id of the form `<prefix>:<project_id>:<terminal_id>`.
+/// Returns `(project_id, terminal_id)` when the prefix matches.
+pub fn decode_action(id: &str, prefix: &str) -> Option<(String, String)> {
+    let rest = id.strip_prefix(prefix)?.strip_prefix(':')?;
+    let (project_id, terminal_id) = rest.split_once(':')?;
+    Some((project_id.to_string(), terminal_id.to_string()))
+}
+
+/// Attempt to soft-close a terminal. Returns `true` if the close was handled as
+/// a soft close (caller must NOT also run the immediate close); `false` if the
+/// feature is off / the terminal is idle / not found, in which case the caller
+/// should fall through to the normal immediate close.
+pub fn try_begin(
+    ws: &mut Workspace,
+    focus_manager: &mut FocusManager,
+    backend: &dyn TerminalBackend,
+    project_id: &str,
+    terminal_id: &str,
+    cx: &mut Context<Workspace>,
+) -> bool {
+    let grace_secs = crate::settings::settings(cx).terminal_close_grace_secs;
+    if grace_secs == 0 {
+        return false; // feature disabled
+    }
+
+    // Only soft-close *busy* terminals. The foreground shell pid resolves
+    // through session backends (dtach / tmux), so "has a child" means the user
+    // actually has a command running — not just the persistence wrapper.
+    let busy = backend
+        .get_foreground_shell_pid(terminal_id)
+        .map(okena_terminal::terminal::has_child_processes)
+        .unwrap_or(false);
+    if !busy {
+        return false;
+    }
+
+    let path = match ws
+        .project(project_id)
+        .and_then(|p| p.layout.as_ref())
+        .and_then(|l| l.find_terminal_path(terminal_id))
+    {
+        Some(p) => p,
+        None => return false,
+    };
+
+    let grace = Duration::from_secs(grace_secs as u64);
+    let actions = vec![
+        ToastAction::new(
+            format!("{UNDO_PREFIX}:{project_id}:{terminal_id}"),
+            "Undo",
+            ToastActionStyle::Primary,
+        ),
+        ToastAction::new(
+            format!("{KILL_PREFIX}:{project_id}:{terminal_id}"),
+            "Close now",
+            ToastActionStyle::Danger,
+        ),
+    ];
+    let toast = Toast::info("Terminal closed")
+        .with_ttl(grace)
+        .with_actions(actions);
+    let toast_id = toast.id.clone();
+
+    // Remove from the layout (PTY stays alive) and record the pending close.
+    ws.begin_soft_close(focus_manager, project_id, &path, terminal_id, &toast_id, cx);
+    ToastManager::post(toast, cx);
+
+    // Schedule the real teardown once the grace period elapses. If the user
+    // already undid or force-closed, `finalize_soft_close` returns false and
+    // the toast was already dismissed by the action handler.
+    let tid = terminal_id.to_string();
+    let toast_id_timer = toast_id;
+    cx.spawn(async move |ws_weak, cx| {
+        smol::Timer::after(grace).await;
+        let _ = ws_weak.update(cx, |ws, cx| {
+            if ws.finalize_soft_close(&tid, cx) {
+                ToastManager::dismiss(&toast_id_timer, cx);
+            }
+        });
+    })
+    .detach();
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode_action, KILL_PREFIX, UNDO_PREFIX};
+
+    #[test]
+    fn decode_action_round_trips() {
+        let id = format!("{UNDO_PREFIX}:proj-1:term-9");
+        assert_eq!(
+            decode_action(&id, UNDO_PREFIX),
+            Some(("proj-1".to_string(), "term-9".to_string()))
+        );
+    }
+
+    #[test]
+    fn decode_action_rejects_wrong_prefix() {
+        let id = format!("{KILL_PREFIX}:proj-1:term-9");
+        assert_eq!(decode_action(&id, UNDO_PREFIX), None);
+    }
+
+    #[test]
+    fn decode_action_rejects_malformed() {
+        assert_eq!(decode_action("soft_close_undo:onlyone", UNDO_PREFIX), None);
+        assert_eq!(decode_action("garbage", UNDO_PREFIX), None);
+    }
+}

--- a/src/soft_close.rs
+++ b/src/soft_close.rs
@@ -44,6 +44,32 @@ fn truncate_label(label: &str) -> String {
     out
 }
 
+/// Home-relative, tail-preserving working directory for the toast detail line.
+/// `~`-collapses the home dir and keeps the *end* of long paths (the directory
+/// the user is actually in), since that's the useful part.
+fn shorten_cwd(path: &str) -> String {
+    let shown = match std::env::var("HOME") {
+        Ok(home) if !home.is_empty() && path == home => return "~".to_string(),
+        Ok(home) if !home.is_empty() && path.starts_with(&format!("{home}/")) => {
+            format!("~{}", &path[home.len()..])
+        }
+        _ => path.to_string(),
+    };
+    const MAX_CHARS: usize = 30;
+    if shown.chars().count() <= MAX_CHARS {
+        return shown;
+    }
+    let tail: String = shown
+        .chars()
+        .rev()
+        .take(MAX_CHARS - 1)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+    format!("\u{2026}{tail}")
+}
+
 /// Attempt to soft-close a terminal. Returns `true` if the close was handled as
 /// a soft close (caller must NOT also run the immediate close); `false` if the
 /// feature is off / the terminal is idle / not found, in which case the caller
@@ -65,8 +91,8 @@ pub fn try_begin(
     // Only soft-close *busy* terminals. The foreground shell pid resolves
     // through session backends (dtach / tmux), so "has a child" means the user
     // actually has a command running — not just the persistence wrapper.
-    let busy = backend
-        .get_foreground_shell_pid(terminal_id)
+    let fg_pid = backend.get_foreground_shell_pid(terminal_id);
+    let busy = fg_pid
         .map(okena_terminal::terminal::has_child_processes)
         .unwrap_or(false);
     if !busy {
@@ -82,22 +108,40 @@ pub fn try_begin(
         None => return false,
     };
 
-    // Build an informative message: which terminal, in which project. The
-    // terminal label follows the same precedence the tabs use — user-set custom
-    // name, else a meaningful OSC title, else the directory fallback (which we
-    // treat as "no specific label" so we don't quote a redundant name).
-    let osc_title = terminals.lock().get(terminal_id).and_then(|t| t.title());
-    let message = ws
+    // Build an informative two-line toast:
+    //
+    //   title:  Closed “make”             — what's closing
+    //   detail: okena · ~/projects/okena  — project · working directory (muted)
+    //
+    // Read the live OSC title + cwd under a single registry lock.
+    let (osc_title, cwd) = {
+        let reg = terminals.lock();
+        let term = reg.get(terminal_id);
+        (term.and_then(|t| t.title()), term.map(|t| t.current_cwd()))
+    };
+    let command = fg_pid.and_then(okena_terminal::terminal::foreground_command);
+
+    let (title, detail) = ws
         .project(project_id)
         .map(|p| {
-            let label = p.terminal_display_name(terminal_id, osc_title);
-            if label == p.directory_name() {
-                format!("Closed terminal in {}", p.name)
-            } else {
-                format!("Closed \u{201c}{}\u{201d} in {}", truncate_label(&label), p.name)
+            // Title label precedence: a meaningful display name (user-set custom
+            // name or non-prompt OSC title) wins; else the live foreground
+            // command; else a generic "Terminal closed".
+            let display = p.terminal_display_name(terminal_id, osc_title);
+            let label = if display == p.directory_name() { command } else { Some(display) };
+            let title = match label {
+                Some(l) => format!("Closed \u{201c}{}\u{201d}", truncate_label(&l)),
+                None => "Terminal closed".to_string(),
+            };
+            // Detail line: project name, plus the cwd when we have one.
+            let mut detail = p.name.clone();
+            if let Some(cwd) = &cwd {
+                detail.push_str(" \u{00b7} ");
+                detail.push_str(&shorten_cwd(cwd));
             }
+            (title, detail)
         })
-        .unwrap_or_else(|| "Terminal closed".to_string());
+        .unwrap_or_else(|| ("Terminal closed".to_string(), String::new()));
 
     let grace = Duration::from_secs(grace_secs as u64);
     let actions = vec![
@@ -112,9 +156,10 @@ pub fn try_begin(
             ToastActionStyle::Danger,
         ),
     ];
-    let toast = Toast::info(message)
-        .with_ttl(grace)
-        .with_actions(actions);
+    let toast = {
+        let base = Toast::info(title).with_ttl(grace).with_actions(actions);
+        if detail.is_empty() { base } else { base.with_detail(detail) }
+    };
     let toast_id = toast.id.clone();
 
     // Remove from the layout (PTY stays alive) and record the pending close.
@@ -141,7 +186,7 @@ pub fn try_begin(
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_action, truncate_label, KILL_PREFIX, UNDO_PREFIX};
+    use super::{decode_action, shorten_cwd, truncate_label, KILL_PREFIX, UNDO_PREFIX};
 
     #[test]
     fn decode_action_round_trips() {
@@ -184,5 +229,20 @@ mod tests {
         let out = truncate_label(&long);
         assert_eq!(out.chars().count(), 42);
         assert!(out.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn shorten_cwd_passes_through_short_paths() {
+        // A path not under $HOME stays as-is when short enough.
+        assert_eq!(shorten_cwd("/opt/app"), "/opt/app");
+    }
+
+    #[test]
+    fn shorten_cwd_keeps_tail_of_long_paths() {
+        let long = format!("/opt/{}/leaf", "deep/".repeat(20));
+        let out = shorten_cwd(&long);
+        assert_eq!(out.chars().count(), 30);
+        assert!(out.starts_with('\u{2026}'), "leading ellipsis");
+        assert!(out.ends_with("leaf"), "tail preserved");
     }
 }

--- a/src/soft_close.rs
+++ b/src/soft_close.rs
@@ -12,6 +12,7 @@
 //! through here — the remote API keeps immediate-close semantics.
 
 use crate::terminal::backend::TerminalBackend;
+use crate::views::window::TerminalsRegistry;
 use crate::workspace::focus::FocusManager;
 use crate::workspace::state::Workspace;
 use crate::workspace::toast::{Toast, ToastAction, ToastActionStyle, ToastManager};
@@ -31,6 +32,18 @@ pub fn decode_action(id: &str, prefix: &str) -> Option<(String, String)> {
     Some((project_id.to_string(), terminal_id.to_string()))
 }
 
+/// Cap a terminal label so the toast stays tidy (TOAST_WIDTH is ~320px). OSC
+/// titles can be arbitrarily long; truncate on a char boundary with an ellipsis.
+fn truncate_label(label: &str) -> String {
+    const MAX_CHARS: usize = 42;
+    if label.chars().count() <= MAX_CHARS {
+        return label.to_string();
+    }
+    let mut out: String = label.chars().take(MAX_CHARS - 1).collect();
+    out.push('\u{2026}');
+    out
+}
+
 /// Attempt to soft-close a terminal. Returns `true` if the close was handled as
 /// a soft close (caller must NOT also run the immediate close); `false` if the
 /// feature is off / the terminal is idle / not found, in which case the caller
@@ -39,6 +52,7 @@ pub fn try_begin(
     ws: &mut Workspace,
     focus_manager: &mut FocusManager,
     backend: &dyn TerminalBackend,
+    terminals: &TerminalsRegistry,
     project_id: &str,
     terminal_id: &str,
     cx: &mut Context<Workspace>,
@@ -68,6 +82,23 @@ pub fn try_begin(
         None => return false,
     };
 
+    // Build an informative message: which terminal, in which project. The
+    // terminal label follows the same precedence the tabs use — user-set custom
+    // name, else a meaningful OSC title, else the directory fallback (which we
+    // treat as "no specific label" so we don't quote a redundant name).
+    let osc_title = terminals.lock().get(terminal_id).and_then(|t| t.title());
+    let message = ws
+        .project(project_id)
+        .map(|p| {
+            let label = p.terminal_display_name(terminal_id, osc_title);
+            if label == p.directory_name() {
+                format!("Closed terminal in {}", p.name)
+            } else {
+                format!("Closed \u{201c}{}\u{201d} in {}", truncate_label(&label), p.name)
+            }
+        })
+        .unwrap_or_else(|| "Terminal closed".to_string());
+
     let grace = Duration::from_secs(grace_secs as u64);
     let actions = vec![
         ToastAction::new(
@@ -81,7 +112,7 @@ pub fn try_begin(
             ToastActionStyle::Danger,
         ),
     ];
-    let toast = Toast::info("Terminal closed")
+    let toast = Toast::info(message)
         .with_ttl(grace)
         .with_actions(actions);
     let toast_id = toast.id.clone();
@@ -110,7 +141,7 @@ pub fn try_begin(
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_action, KILL_PREFIX, UNDO_PREFIX};
+    use super::{decode_action, truncate_label, KILL_PREFIX, UNDO_PREFIX};
 
     #[test]
     fn decode_action_round_trips() {
@@ -131,5 +162,27 @@ mod tests {
     fn decode_action_rejects_malformed() {
         assert_eq!(decode_action("soft_close_undo:onlyone", UNDO_PREFIX), None);
         assert_eq!(decode_action("garbage", UNDO_PREFIX), None);
+    }
+
+    #[test]
+    fn truncate_label_leaves_short_labels_untouched() {
+        assert_eq!(truncate_label("vim main.rs"), "vim main.rs");
+    }
+
+    #[test]
+    fn truncate_label_caps_long_labels_with_ellipsis() {
+        let long = "a".repeat(60);
+        let out = truncate_label(&long);
+        assert_eq!(out.chars().count(), 42);
+        assert!(out.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn truncate_label_respects_char_boundaries() {
+        // Multi-byte chars must not be split mid-codepoint.
+        let long = "é".repeat(60);
+        let out = truncate_label(&long);
+        assert_eq!(out.chars().count(), 42);
+        assert!(out.ends_with('\u{2026}'));
     }
 }

--- a/src/views/overlays/settings_panel/render_terminal.rs
+++ b/src/views/overlays/settings_panel/render_terminal.rs
@@ -46,6 +46,16 @@ impl SettingsPanel {
                             "idle-timeout", "Idle Timeout (seconds)", s.idle_timeout_secs, 1, 50.0, false,
                             |state, val, cx| state.set_idle_timeout_secs(val, cx), cx,
                         ))
+                    })
+                    .child(self.render_toggle(
+                        "close-grace", "Undo Close (busy terminals)", s.terminal_close_grace_secs > 0, true,
+                        |state, val, cx| state.set_terminal_close_grace_secs(if val { 5 } else { 0 }, cx), cx,
+                    ))
+                    .when(s.terminal_close_grace_secs > 0, |el| {
+                        el.child(self.render_integer_stepper(
+                            "close-grace-secs", "Undo Window (seconds)", s.terminal_close_grace_secs, 1, 50.0, false,
+                            |state, val, cx| state.set_terminal_close_grace_secs(val, cx), cx,
+                        ))
                     }),
             )
     }

--- a/src/views/panels/toast.rs
+++ b/src/views/panels/toast.rs
@@ -2,7 +2,7 @@
 pub use crate::workspace::toast::{Toast, ToastAction, ToastActionStyle, ToastLevel, ToastManager};
 
 use crate::theme::theme;
-use crate::ui::tokens::{RADIUS_MD, RADIUS_STD, SPACE_MD, SPACE_SM, SPACE_XS, ICON_SM, ui_text_ms};
+use crate::ui::tokens::{RADIUS_MD, RADIUS_STD, SPACE_MD, SPACE_SM, SPACE_XS, ICON_SM, ui_text_ms, ui_text_xs};
 use gpui::prelude::FluentBuilder;
 use gpui::*;
 use std::time::Duration;
@@ -122,6 +122,7 @@ impl Render for ToastOverlay {
 
         let t = theme(cx);
         let text_size = ui_text_ms(cx);
+        let detail_size = ui_text_xs(cx);
         // Own the toasts so `self` isn't borrowed across the `cx.listener` calls
         // the action buttons need.
         let toasts = self.toasts.clone();
@@ -192,16 +193,34 @@ impl Render for ToastOverlay {
                                                     .mt(px(1.0))
                                                     .child(icon_char),
                                             )
-                                            // Message
+                                            // Message + optional detail line
                                             .child(
                                                 div()
                                                     .flex_1()
                                                     .min_w(px(0.))
                                                     .overflow_x_hidden()
-                                                    .whitespace_normal()
-                                                    .text_size(text_size)
-                                                    .text_color(rgb(t.text_primary))
-                                                    .child(toast.message.clone()),
+                                                    .flex()
+                                                    .flex_col()
+                                                    .gap(px(1.0))
+                                                    .child(
+                                                        div()
+                                                            .whitespace_normal()
+                                                            .text_size(text_size)
+                                                            .text_color(rgb(t.text_primary))
+                                                            .child(toast.message.clone()),
+                                                    )
+                                                    .when_some(
+                                                        toast.detail.clone(),
+                                                        |el, detail| {
+                                                            el.child(
+                                                                div()
+                                                                    .whitespace_normal()
+                                                                    .text_size(detail_size)
+                                                                    .text_color(rgb(t.text_muted))
+                                                                    .child(detail),
+                                                            )
+                                                        },
+                                                    ),
                                             )
                                             // Close (dismiss) button — only for
                                             // plain toasts. Action toasts (undo /

--- a/src/views/panels/toast.rs
+++ b/src/views/panels/toast.rs
@@ -1,10 +1,19 @@
 // Re-export Toast, ToastLevel, and ToastManager from workspace (shared data types)
-pub use crate::workspace::toast::{Toast, ToastLevel, ToastManager};
+pub use crate::workspace::toast::{Toast, ToastAction, ToastActionStyle, ToastLevel, ToastManager};
 
 use crate::theme::theme;
-use crate::ui::tokens::{RADIUS_STD, SPACE_MD, SPACE_SM, SPACE_XS, ICON_SM, ui_text_ms};
+use crate::ui::tokens::{RADIUS_MD, RADIUS_STD, SPACE_MD, SPACE_SM, SPACE_XS, ICON_SM, ui_text_ms};
+use gpui::prelude::FluentBuilder;
 use gpui::*;
 use std::time::Duration;
+
+/// Emitted when a clickable toast action is clicked. The owning view (WindowView)
+/// subscribes and routes it (e.g. soft-close undo / close-now).
+#[derive(Clone, Debug)]
+pub struct ToastActionEvent {
+    pub toast_id: String,
+    pub action_id: String,
+}
 
 /// Tick interval for the overlay's animation/prune loop
 const TICK_INTERVAL: Duration = Duration::from_millis(50);
@@ -80,8 +89,13 @@ impl ToastOverlay {
                             cx.notify();
                         }
                     }
-                    // Also re-render during fade-in animations
-                    if this.toasts.iter().any(|t| toast_opacity(t) < 1.0) {
+                    // Re-render during fade-in animations and while any toast is
+                    // counting down (so its progress bar advances smoothly).
+                    if this
+                        .toasts
+                        .iter()
+                        .any(|t| toast_opacity(t) < 1.0 || !t.actions.is_empty())
+                    {
                         cx.notify();
                     }
                 });
@@ -98,6 +112,8 @@ impl ToastOverlay {
 }
 
 
+impl EventEmitter<ToastActionEvent> for ToastOverlay {}
+
 impl Render for ToastOverlay {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         if self.toasts.is_empty() {
@@ -105,6 +121,10 @@ impl Render for ToastOverlay {
         }
 
         let t = theme(cx);
+        let text_size = ui_text_ms(cx);
+        // Own the toasts so `self` isn't borrowed across the `cx.listener` calls
+        // the action buttons need.
+        let toasts = self.toasts.clone();
 
         div()
             .absolute()
@@ -114,11 +134,13 @@ impl Render for ToastOverlay {
             .flex()
             .flex_col()
             .gap(SPACE_XS)
-            .children(self.toasts.iter().map(|toast| {
+            .children(toasts.into_iter().map(|toast| {
                 let accent_color = toast.level.accent_color(&t);
                 let icon_char = toast.level.icon_char();
-                let opacity = toast_opacity(toast);
+                let opacity = toast_opacity(&toast);
                 let toast_id = toast.id.clone();
+                let has_countdown = !toast.actions.is_empty();
+                let remaining = toast.remaining_fraction();
 
                 div()
                     .id(SharedString::from(format!("toast-{}", toast.id)))
@@ -129,69 +151,155 @@ impl Render for ToastOverlay {
                     .rounded(RADIUS_STD)
                     .shadow_xl()
                     .flex()
+                    .flex_col()
                     .overflow_hidden()
-                    // Accent stripe
-                    .child(
-                        div()
-                            .w(px(ACCENT_WIDTH))
-                            .h_full()
-                            .bg(rgb(accent_color))
-                            .flex_shrink_0(),
-                    )
-                    // Content
+                    // Main row: accent stripe + content column
                     .child(
                         div()
                             .flex()
                             .flex_row()
-                            .items_start()
-                            .flex_1()
-                            .overflow_x_hidden()
-                            .gap(SPACE_SM)
-                            .px(SPACE_MD)
-                            .py(SPACE_SM)
-                            // Icon
+                            // Accent stripe
                             .child(
                                 div()
-                                    .text_color(rgb(accent_color))
-                                    .text_size(ui_text_ms(cx))
-                                    .flex_shrink_0()
-                                    .mt(px(1.0))
-                                    .child(icon_char),
+                                    .w(px(ACCENT_WIDTH))
+                                    .h_full()
+                                    .bg(rgb(accent_color))
+                                    .flex_shrink_0(),
                             )
-                            // Message
+                            // Content column (message row + optional actions row)
                             .child(
                                 div()
+                                    .flex()
+                                    .flex_col()
                                     .flex_1()
-                                    .min_w(px(0.))
                                     .overflow_x_hidden()
-                                    .whitespace_normal()
-                                    .text_size(ui_text_ms(cx))
-                                    .text_color(rgb(t.text_primary))
-                                    .child(toast.message.clone()),
-                            )
-                            // Close button
-                            .child(
-                                div()
-                                    .id(SharedString::from(format!("toast-close-{}", toast.id)))
-                                    .cursor_pointer()
-                                    .flex_shrink_0()
-                                    .rounded(RADIUS_STD)
-                                    .p(px(2.0))
-                                    .hover(|s| s.bg(rgb(t.bg_hover)))
+                                    .gap(SPACE_XS)
+                                    .px(SPACE_MD)
+                                    .py(SPACE_SM)
+                                    // Message row
                                     .child(
-                                        svg()
-                                            .path("icons/close.svg")
-                                            .size(ICON_SM)
-                                            .text_color(rgb(t.text_muted)),
+                                        div()
+                                            .flex()
+                                            .flex_row()
+                                            .items_start()
+                                            .gap(SPACE_SM)
+                                            // Icon
+                                            .child(
+                                                div()
+                                                    .text_color(rgb(accent_color))
+                                                    .text_size(text_size)
+                                                    .flex_shrink_0()
+                                                    .mt(px(1.0))
+                                                    .child(icon_char),
+                                            )
+                                            // Message
+                                            .child(
+                                                div()
+                                                    .flex_1()
+                                                    .min_w(px(0.))
+                                                    .overflow_x_hidden()
+                                                    .whitespace_normal()
+                                                    .text_size(text_size)
+                                                    .text_color(rgb(t.text_primary))
+                                                    .child(toast.message.clone()),
+                                            )
+                                            // Close (dismiss) button
+                                            .child(
+                                                div()
+                                                    .id(SharedString::from(format!(
+                                                        "toast-close-{}",
+                                                        toast.id
+                                                    )))
+                                                    .cursor_pointer()
+                                                    .flex_shrink_0()
+                                                    .rounded(RADIUS_STD)
+                                                    .p(px(2.0))
+                                                    .hover(|s| s.bg(rgb(t.bg_hover)))
+                                                    .child(
+                                                        svg()
+                                                            .path("icons/close.svg")
+                                                            .size(ICON_SM)
+                                                            .text_color(rgb(t.text_muted)),
+                                                    )
+                                                    .on_click(move |_, _window, cx| {
+                                                        ToastManager::dismiss(&toast_id, cx);
+                                                    }),
+                                            ),
                                     )
-                                    .on_click(move |_, _window, cx| {
-                                        ToastManager::dismiss(&toast_id, cx);
+                                    // Actions row (Undo / Close now / …)
+                                    .when(has_countdown, |el| {
+                                        el.child(
+                                            div()
+                                                .flex()
+                                                .flex_row()
+                                                .justify_end()
+                                                .gap(SPACE_XS)
+                                                .children(toast.actions.iter().map(|action| {
+                                                    let toast_id = toast.id.clone();
+                                                    let action_id = action.id.clone();
+                                                    let on_click = cx.listener(
+                                                        move |_this, _ev: &ClickEvent, _window, cx| {
+                                                            cx.emit(ToastActionEvent {
+                                                                toast_id: toast_id.clone(),
+                                                                action_id: action_id.clone(),
+                                                            });
+                                                        },
+                                                    );
+                                                    action_button(
+                                                        &toast.id, action, &t, text_size, on_click,
+                                                    )
+                                                })),
+                                        )
                                     }),
                             ),
                     )
+                    // Countdown progress bar (only for toasts with actions)
+                    .when(has_countdown, |el| {
+                        el.child(
+                            div()
+                                .w_full()
+                                .h(px(2.0))
+                                .bg(rgb(t.border))
+                                .child(
+                                    div()
+                                        .h_full()
+                                        .w(relative(remaining))
+                                        .bg(rgb(accent_color)),
+                                ),
+                        )
+                    })
             }))
             .into_any_element()
     }
+}
+
+/// Render a single clickable toast action button. The `on_click` handler is
+/// built by the caller (via `cx.listener`) so this stays free of the context
+/// lifetime.
+fn action_button(
+    toast_id: &str,
+    action: &ToastAction,
+    t: &crate::theme::ThemeColors,
+    text_size: Pixels,
+    on_click: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+) -> impl IntoElement {
+    let label_color = match action.style {
+        ToastActionStyle::Primary => t.term_blue,
+        ToastActionStyle::Danger => t.error,
+        ToastActionStyle::Default => t.text_secondary,
+    };
+
+    div()
+        .id(SharedString::from(format!("toast-action-{}-{}", toast_id, action.id)))
+        .cursor_pointer()
+        .px(SPACE_SM)
+        .py(px(2.0))
+        .rounded(RADIUS_MD)
+        .text_size(text_size)
+        .text_color(rgb(label_color))
+        .hover(|s| s.bg(rgb(t.bg_hover)))
+        .child(action.label.clone())
+        .on_click(on_click)
 }
 
 #[cfg(test)]

--- a/src/views/panels/toast.rs
+++ b/src/views/panels/toast.rs
@@ -203,28 +203,36 @@ impl Render for ToastOverlay {
                                                     .text_color(rgb(t.text_primary))
                                                     .child(toast.message.clone()),
                                             )
-                                            // Close (dismiss) button
-                                            .child(
-                                                div()
-                                                    .id(SharedString::from(format!(
-                                                        "toast-close-{}",
-                                                        toast.id
-                                                    )))
-                                                    .cursor_pointer()
-                                                    .flex_shrink_0()
-                                                    .rounded(RADIUS_STD)
-                                                    .p(px(2.0))
-                                                    .hover(|s| s.bg(rgb(t.bg_hover)))
-                                                    .child(
-                                                        svg()
-                                                            .path("icons/close.svg")
-                                                            .size(ICON_SM)
-                                                            .text_color(rgb(t.text_muted)),
-                                                    )
-                                                    .on_click(move |_, _window, cx| {
-                                                        ToastManager::dismiss(&toast_id, cx);
-                                                    }),
-                                            ),
+                                            // Close (dismiss) button — only for
+                                            // plain toasts. Action toasts (undo /
+                                            // close-now) are resolved via their
+                                            // buttons or the countdown, so a third
+                                            // "dismiss" affordance would be
+                                            // ambiguous (it would hide the undo but
+                                            // still let the close go through).
+                                            .when(!has_countdown, |el| {
+                                                el.child(
+                                                    div()
+                                                        .id(SharedString::from(format!(
+                                                            "toast-close-{}",
+                                                            toast.id
+                                                        )))
+                                                        .cursor_pointer()
+                                                        .flex_shrink_0()
+                                                        .rounded(RADIUS_STD)
+                                                        .p(px(2.0))
+                                                        .hover(|s| s.bg(rgb(t.bg_hover)))
+                                                        .child(
+                                                            svg()
+                                                                .path("icons/close.svg")
+                                                                .size(ICON_SM)
+                                                                .text_color(rgb(t.text_muted)),
+                                                        )
+                                                        .on_click(move |_, _window, cx| {
+                                                            ToastManager::dismiss(&toast_id, cx);
+                                                        }),
+                                                )
+                                            }),
                                     )
                                     // Actions row (Undo / Close now / …)
                                     .when(has_countdown, |el| {

--- a/src/views/window/handlers.rs
+++ b/src/views/window/handlers.rs
@@ -191,6 +191,41 @@ impl WindowView {
 
 impl WindowView {
     /// Handle events from the OverlayManager that require WindowView access.
+    /// Handle a click on a toast action button (soft-close undo / close-now).
+    pub(super) fn handle_toast_action(
+        &mut self,
+        _: Entity<crate::views::panels::toast::ToastOverlay>,
+        event: &crate::views::panels::toast::ToastActionEvent,
+        cx: &mut Context<Self>,
+    ) {
+        use crate::soft_close::{decode_action, KILL_PREFIX, UNDO_PREFIX};
+        use crate::workspace::toast::ToastManager;
+
+        if let Some((_project_id, terminal_id)) = decode_action(&event.action_id, UNDO_PREFIX) {
+            // The PTY is only restorable if it's still in the registry — if the
+            // shell exited on its own during the grace window there's nothing to
+            // bring back, and `undo_soft_close` just drops the pending record.
+            let alive = self.terminals.lock().contains_key(terminal_id.as_str());
+            let ws = self.workspace.clone();
+            let fm = self.focus_manager.clone();
+            fm.update(cx, |fm, cx| {
+                ws.update(cx, |ws, cx| {
+                    ws.undo_soft_close(fm, &terminal_id, alive, cx);
+                });
+                cx.notify();
+            });
+            ToastManager::dismiss(&event.toast_id, cx);
+        } else if let Some((_project_id, terminal_id)) =
+            decode_action(&event.action_id, KILL_PREFIX)
+        {
+            let ws = self.workspace.clone();
+            ws.update(cx, |ws, cx| {
+                ws.finalize_soft_close(&terminal_id, cx);
+            });
+            ToastManager::dismiss(&event.toast_id, cx);
+        }
+    }
+
     pub(super) fn handle_overlay_manager_event(
         &mut self,
         _: Entity<OverlayManager>,

--- a/src/views/window/mod.rs
+++ b/src/views/window/mod.rs
@@ -228,6 +228,9 @@ impl WindowView {
         // Subscribe to overlay manager events
         cx.subscribe(&overlay_manager, Self::handle_overlay_manager_event).detach();
 
+        // Subscribe to toast action clicks (soft-close undo / close-now).
+        cx.subscribe(&toast_overlay, Self::handle_toast_action).detach();
+
         // Observe RequestBroker to process overlay + terminal-send requests
         // outside of render().
         cx.observe(&request_broker, |this, _broker, cx| {


### PR DESCRIPTION
## Summary

Closing a **busy** terminal (one with a running foreground process) no longer kills it immediately. The pane is removed from the layout, but the PTY keeps running for a grace period while a toast offers **Undo** / **Close now** with a countdown bar. After the window elapses the terminal is torn down exactly as before. Idle shells still close instantly.

Configurable via a new `terminal_close_grace_secs` setting (default `5`, `0` disables the feature).

## How it works

- **`okena-state`** — `Toast` gains optional clickable `ToastAction`s (with `Default`/`Primary`/`Danger` styling) and a `remaining_fraction()` helper that drives the countdown indicator. The action `id` is opaque to the crate — the view layer that posts the toast interprets it — so `okena-state` stays free of GPUI / action-routing knowledge.
- **`okena-layout`** — `LayoutNode::find_terminal_node` / `append_to_root` (+ `PartialEq`) to support restore.
- **`okena-workspace`** — pending-close state on `Workspace` (`begin` / `undo` / `finalize` / `drain`). Undo restores the exact pre-close tree when nothing else changed; otherwise it re-appends the recovered pane to the root group rather than guessing a merge.
- **settings** — `terminal_close_grace_secs` (default 5, 0 = disabled) plus a settings-panel row.
- **desktop** — busy-gated soft close wired into the local dispatch (remote close stays immediate). Foreground-shell pid resolution sees through `dtach`/`tmux`. Toast buttons emit events handled by `WindowView`. Pending closes are flushed on quit so persistent sessions don't leak as orphaned backend sessions.

## Tests

Unit tests cover:
- exact restore when the tree is unchanged,
- append-to-root fallback when the layout changed during the grace window,
- dead-PTY undo (shell exited on its own — pending record dropped, no restore),
- finalize queues the kill and is idempotent,
- `drain_pending_closes` returns all ids,
- toast action-id encoding/decoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
