### PR TITLE
feat(remote): paste clipboard images into remote terminals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ hyper-util = { version = "0.1", features = ["server-auto", "tokio"] }
 tower-service = "0.3"
 
 # Remote control server
-tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros", "time", "fs"] }
 axum = { version = "0.8", features = ["ws"] }
 
 base64 = "0.22"

--- a/crates/okena-files/src/content_search.rs
+++ b/crates/okena-files/src/content_search.rs
@@ -449,7 +449,7 @@ fn search_content_fuzzy(
             }
 
             // Sort by score descending — best matches first
-            scored_matches.sort_by(|a, b| b.0.cmp(&a.0));
+            scored_matches.sort_by_key(|b| std::cmp::Reverse(b.0));
 
             let best_score = scored_matches.first().map(|(s, _)| *s).unwrap_or(0);
             let mut file_matches: Vec<ContentMatch> = scored_matches

--- a/crates/okena-files/src/content_search_dialog/render.rs
+++ b/crates/okena-files/src/content_search_dialog/render.rs
@@ -28,16 +28,14 @@ impl Render for ContentSearchDialog {
         // Shared key handler for both modes
         let key_handler = cx.listener(|this, event: &KeyDownEvent, _window, cx| {
             match event.keystroke.key.as_str() {
-                "up" => {
-                    if this.select_prev() {
+                "up"
+                    if this.select_prev() => {
                         cx.notify();
                     }
-                }
-                "down" => {
-                    if this.select_next() {
+                "down"
+                    if this.select_next() => {
                         cx.notify();
                     }
-                }
                 "enter" => this.open_selected(cx),
                 "tab" if !event.keystroke.modifiers.shift => {
                     this.expanded = !this.expanded;

--- a/crates/okena-files/src/file_search.rs
+++ b/crates/okena-files/src/file_search.rs
@@ -328,7 +328,7 @@ impl FileSearchDialog {
                 })
                 .collect();
 
-            scored.sort_by(|a, b| b.1.cmp(&a.1));
+            scored.sort_by_key(|b| std::cmp::Reverse(b.1));
             self.filtered_files = scored.into_iter().map(|(i, _, pos)| (i, pos)).collect();
         }
 
@@ -594,16 +594,14 @@ impl Render for FileSearchDialog {
             }))
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, _window, cx| {
                 match event.keystroke.key.as_str() {
-                    "up" => {
-                        if this.select_prev() {
+                    "up"
+                        if this.select_prev() => {
                             cx.notify();
                         }
-                    }
-                    "down" => {
-                        if this.select_next() {
+                    "down"
+                        if this.select_next() => {
                             cx.notify();
                         }
-                    }
                     "enter" => this.open_selected(cx),
                     "escape" => this.close(cx),
                     _ => {}

--- a/crates/okena-files/src/file_viewer/render.rs
+++ b/crates/okena-files/src/file_viewer/render.rs
@@ -1311,11 +1311,10 @@ impl Render for FileViewer {
                 let img_zoom_chord = is_img_view;
 
                 match key {
-                    "f" if modifiers.platform || modifiers.control => {
-                        if !is_preview && !is_img_view && !is_font_tab {
+                    "f" if (modifiers.platform || modifiers.control)
+                        && !is_preview && !is_img_view && !is_font_tab => {
                             this.open_search(window, cx);
                         }
-                    }
                     "tab" if (is_md || is_svg_tab) && !modifiers.control && !modifiers.shift => {
                         this.toggle_display_mode(cx);
                     }
@@ -1325,13 +1324,12 @@ impl Render for FileViewer {
                     "tab" if modifiers.control => {
                         this.next_tab(cx);
                     }
-                    "b" if (modifiers.platform || modifiers.control) && modifiers.alt => {
-                        if this.blame_provider.is_some() {
+                    "b" if (modifiers.platform || modifiers.control) && modifiers.alt
+                        && this.blame_provider.is_some() => {
                             this.toggle_blame(cx);
                             let visible = this.blame_visible();
                             cx.emit(super::FileViewerEvent::BlamePreferenceChanged(visible));
                         }
-                    }
                     "b" if !modifiers.platform && !modifiers.control => {
                         this.toggle_sidebar(cx);
                     }

--- a/crates/okena-remote-client/src/manager.rs
+++ b/crates/okena-remote-client/src/manager.rs
@@ -382,6 +382,89 @@ impl RemoteConnectionManager {
         });
     }
 
+    /// Upload a pasted clipboard image to the remote server, which writes it to
+    /// a temp file on its own filesystem and bracketed-pastes that path into the
+    /// terminal (so a server-side TUI like Claude Code can read it).
+    ///
+    /// `terminal_id` is the server-local id (already stripped of the
+    /// `remote:{cid}:` prefix). Mirrors [`send_action`]'s fire-and-forget HTTP
+    /// pattern: spawns on the tokio runtime, logs errors and warns on failure.
+    pub fn upload_paste_image(
+        &self,
+        connection_id: &str,
+        terminal_id: &str,
+        mime: &str,
+        bytes: Vec<u8>,
+        cx: &mut Context<Self>,
+    ) {
+        let config = match self.connections.get(connection_id) {
+            Some(conn) => conn.config().clone(),
+            None => {
+                log::error!("upload_paste_image: connection {} not found", connection_id);
+                return;
+            }
+        };
+        let token = match config.saved_token {
+            Some(ref t) => t.clone(),
+            None => {
+                log::error!(
+                    "upload_paste_image: no auth token for connection {}",
+                    connection_id
+                );
+                ToastManager::error("No auth token for remote connection".to_string(), cx);
+                return;
+            }
+        };
+
+        let host = config.host.clone();
+        let port = config.port;
+        let name = config.name.clone();
+        let event_tx = self.event_tx.clone();
+        let terminal_id = terminal_id.to_string();
+        let mime = mime.to_string();
+
+        self.runtime.spawn(async move {
+            let url = format!(
+                "http://{}:{}/v1/terminals/{}/paste-image",
+                host, port, terminal_id
+            );
+            let client = reqwest::Client::new();
+            let result = client
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", token))
+                .header("Content-Type", mime)
+                .body(bytes)
+                .timeout(std::time::Duration::from_secs(15))
+                .send()
+                .await;
+
+            match result {
+                Ok(resp) if resp.status().is_success() => {
+                    log::debug!("upload_paste_image: success for {}", name);
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    let body = resp.text().await.unwrap_or_default();
+                    log::error!(
+                        "upload_paste_image: failed ({}): {} for {}",
+                        status, body, name
+                    );
+                    let _ = event_tx.try_send(ConnectionEvent::ServerWarning {
+                        connection_id: String::new(),
+                        message: format!("Image paste failed ({}): {}", status, body),
+                    });
+                }
+                Err(e) => {
+                    log::error!("upload_paste_image: request error for {}: {}", name, e);
+                    let _ = event_tx.try_send(ConnectionEvent::ServerWarning {
+                        connection_id: String::new(),
+                        message: format!("Image paste request failed: {}", e),
+                    });
+                }
+            }
+        });
+    }
+
     /// Handle an event from a connection's tokio task.
     fn handle_event(&mut self, event: ConnectionEvent, cx: &mut Context<Self>) {
         let event_label: &'static str = match &event {

--- a/crates/okena-views-git/src/worktree_dialog/view.rs
+++ b/crates/okena-views-git/src/worktree_dialog/view.rs
@@ -212,8 +212,8 @@ impl Render for WorktreeDialog {
                                     cx.notify();
                                 }
                     }
-                    "down" => {
-                        if search_focused {
+                    "down"
+                        if search_focused => {
                             let max = this.filtered_branches.len().saturating_sub(1);
                             if let Some(idx) = this.selected_branch_index {
                                 if idx < max {
@@ -225,7 +225,6 @@ impl Render for WorktreeDialog {
                                 cx.notify();
                             }
                         }
-                    }
                     "enter" => {
                         this.create_worktree(cx);
                     }

--- a/crates/okena-views-terminal/src/layout/terminal_pane/actions.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/actions.rs
@@ -84,6 +84,23 @@ impl<D: ActionDispatch + Send + Sync> TerminalPane<D> {
         });
         let Some(image) = image else { return };
 
+        // Remote terminals: the temp file the terminal's process reads lives on
+        // the *server's* filesystem, not ours. Upload the bytes so the server
+        // writes the file and bracketed-pastes its path; the client-local temp
+        // paths below would hand the server a path that doesn't exist on it.
+        if let Some(ref dispatcher) = self.action_dispatcher
+            && dispatcher.is_remote()
+            && let Some(ref terminal_id) = self.terminal_id
+        {
+            dispatcher.upload_remote_paste_image(
+                terminal_id,
+                image.format.mime_type(),
+                image.bytes.clone(),
+                cx,
+            );
+            return;
+        }
+
         let filename = paste_filename(&image);
 
         // WSL fast path: write the image into the distro's own /tmp via the

--- a/crates/okena-views-terminal/src/lib.rs
+++ b/crates/okena-views-terminal/src/lib.rs
@@ -45,6 +45,23 @@ pub trait ActionDispatch: Clone + 'static {
         in_group: bool,
         cx: &mut gpui::App,
     );
+
+    /// Upload a clipboard image pasted into a remote terminal.
+    ///
+    /// The temp file the terminal's process reads must live on the *server's*
+    /// filesystem, not the client's. Remote dispatchers upload the bytes so the
+    /// server materialises the file and bracketed-pastes its path. Local
+    /// dispatchers don't override this — the caller writes a local temp file
+    /// directly (see `TerminalPane::handle_paste`).
+    fn upload_remote_paste_image(
+        &self,
+        terminal_id: &str,
+        mime: &str,
+        bytes: Vec<u8>,
+        cx: &mut gpui::App,
+    ) {
+        let _ = (terminal_id, mime, bytes, cx);
+    }
 }
 
 /// Settings namespace used in ExtensionSettingsStore.

--- a/src/action_dispatch.rs
+++ b/src/action_dispatch.rs
@@ -175,13 +175,12 @@ impl ActionDispatcher {
                         // and multi-terminal close actions are gated; whatever
                         // isn't soft-closed falls through to the immediate close.
                         match &action {
-                            ActionRequest::CloseTerminal { project_id, terminal_id } => {
+                            ActionRequest::CloseTerminal { project_id, terminal_id }
                                 if crate::soft_close::try_begin(
                                     ws, fm, &*backend, &terminals, project_id, terminal_id, cx,
-                                ) {
+                                ) => {
                                     return;
                                 }
-                            }
                             ActionRequest::CloseTerminals { project_id, terminal_ids } => {
                                 // Soft-close each busy terminal; hard-close the
                                 // rest in a single batched action.

--- a/src/action_dispatch.rs
+++ b/src/action_dispatch.rs
@@ -404,6 +404,32 @@ impl ActionDispatcher {
     }
 }
 
+impl ActionDispatcher {
+    /// Upload a pasted clipboard image to the remote server (no-op for local).
+    ///
+    /// The server writes the bytes to a temp file on its own filesystem and
+    /// bracketed-pastes that path into the terminal, so a server-side TUI like
+    /// Claude Code can read it. `terminal_id` is the local (prefixed) id; the
+    /// `remote:{cid}:` prefix is stripped before upload.
+    pub fn upload_remote_paste_image(
+        &self,
+        terminal_id: &str,
+        mime: &str,
+        bytes: Vec<u8>,
+        cx: &mut impl AppContext,
+    ) {
+        let Self::Remote { connection_id, manager, .. } = self else {
+            return;
+        };
+        let remote_terminal_id = strip_prefix(terminal_id, connection_id);
+        let cid = connection_id.clone();
+        let mime = mime.to_string();
+        manager.update(cx, |rm, cx| {
+            rm.upload_paste_image(&cid, &remote_terminal_id, &mime, bytes, cx);
+        });
+    }
+}
+
 impl okena_views_terminal::ActionDispatch for ActionDispatcher {
     fn dispatch(&self, action: ActionRequest, cx: &mut gpui::App) {
         self.dispatch(action, cx);
@@ -431,6 +457,16 @@ impl okena_views_terminal::ActionDispatch for ActionDispatcher {
         cx: &mut gpui::App,
     ) {
         self.add_tab(project_id, layout_path, in_group, cx);
+    }
+
+    fn upload_remote_paste_image(
+        &self,
+        terminal_id: &str,
+        mime: &str,
+        bytes: Vec<u8>,
+        cx: &mut gpui::App,
+    ) {
+        self.upload_remote_paste_image(terminal_id, mime, bytes, cx);
     }
 }
 

--- a/src/app/remote_commands.rs
+++ b/src/app/remote_commands.rs
@@ -290,6 +290,21 @@ pub(crate) async fn remote_command_loop(
                     }
                 })
             }
+            RemoteCommand::PasteImage { terminal_id, path } => {
+                cx.update(|cx| {
+                    let ws = workspace.read(cx);
+                    match ensure_terminal(&terminal_id, &terminals, &*backend, ws) {
+                        Some(term) => {
+                            // Bracketed paste of the server-local image path —
+                            // same as a local image paste, so the focused TUI's
+                            // own paste handler attaches it.
+                            term.send_paste(&path);
+                            CommandResult::Ok(Some(serde_json::json!({ "path": path })))
+                        }
+                        None => CommandResult::Err(format!("terminal not found: {}", terminal_id)),
+                    }
+                })
+            }
         };
 
         if let Some(reply) = msg.reply {

--- a/src/remote/bridge.rs
+++ b/src/remote/bridge.rs
@@ -20,6 +20,9 @@ pub enum RemoteCommand {
     RenderSnapshot { terminal_id: String },
     /// Get current grid sizes (cols, rows) for multiple terminals.
     GetTerminalSizes { terminal_ids: Vec<String> },
+    /// Bracketed-paste the path of a remote-pasted image (already written to a
+    /// temp file on this host) into the target terminal.
+    PasteImage { terminal_id: String, path: String },
 }
 
 /// Result of processing a RemoteCommand.

--- a/src/remote/routes/mod.rs
+++ b/src/remote/routes/mod.rs
@@ -2,6 +2,7 @@ pub mod actions;
 pub mod auth_reload;
 pub mod health;
 pub mod pair;
+pub mod paste_image;
 pub mod refresh;
 pub mod state;
 pub mod stream;
@@ -70,6 +71,11 @@ pub fn build_router(
     let protected = Router::new()
         .route("/v1/state", axum::routing::get(state::get_state))
         .route("/v1/actions", axum::routing::post(actions::post_actions))
+        .route(
+            "/v1/terminals/{terminal_id}/paste-image",
+            axum::routing::post(paste_image::post_paste_image)
+                .layer(DefaultBodyLimit::max(paste_image::IMAGE_UPLOAD_LIMIT)),
+        )
         .route("/v1/stream", axum::routing::get(stream::ws_handler))
         .route("/v1/refresh", axum::routing::post(refresh::post_refresh))
         .route("/v1/tokens", axum::routing::get(tokens::list_tokens))

--- a/src/remote/routes/paste_image.rs
+++ b/src/remote/routes/paste_image.rs
@@ -1,0 +1,148 @@
+//! `POST /v1/terminals/{terminal_id}/paste-image` — accept a clipboard image
+//! pasted on a remote client, write it to a temp file on *this* (server) host,
+//! and bracketed-paste its path into the target terminal so a TUI like Claude
+//! Code can attach it.
+//!
+//! The image must live where the terminal's process runs: the client's local
+//! clipboard isn't reachable from here, and a client-local path would point at
+//! a file that doesn't exist on the server. So the bytes travel over HTTP and
+//! the file is materialised server-side. This mirrors the desktop's local
+//! image-paste (write temp file → `send_paste(path)`), just across the wire.
+
+use crate::remote::bridge::{BridgeMessage, CommandResult, RemoteCommand};
+use crate::remote::routes::AppState;
+use axum::Json;
+use axum::body::Bytes;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode, header::CONTENT_TYPE};
+use axum::response::IntoResponse;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Max accepted image upload (20 MiB). Clipboard screenshots — especially
+/// retina full-screen PNGs — routinely exceed the global 1 MiB body cap, so
+/// this route raises its own limit (see `build_router`).
+pub const IMAGE_UPLOAD_LIMIT: usize = 20 * 1024 * 1024;
+
+pub async fn post_paste_image(
+    State(state): State<AppState>,
+    Path(terminal_id): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    if body.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "empty image body"})),
+        )
+            .into_response();
+    }
+
+    let mime = headers
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("image/png");
+    let ext = image_ext_for_mime(mime);
+
+    let filename = format!("okena-remote-paste-{}.{}", next_token(), ext);
+    let path = std::env::temp_dir().join(filename);
+
+    if let Err(e) = tokio::fs::write(&path, &body).await {
+        log::error!("paste-image: failed to write {}: {}", path.display(), e);
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("failed to write image: {e}")})),
+        )
+            .into_response();
+    }
+
+    let path_str = path.to_string_lossy().into_owned();
+    let command = RemoteCommand::PasteImage {
+        terminal_id,
+        path: path_str.clone(),
+    };
+
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    let msg = BridgeMessage {
+        command,
+        reply: Some(reply_tx),
+    };
+
+    if state.bridge_tx.send(msg).await.is_err() {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "bridge unavailable"})),
+        )
+            .into_response();
+    }
+
+    match reply_rx.await {
+        Ok(CommandResult::Ok(_)) | Ok(CommandResult::OkBytes(_)) => {
+            (StatusCode::OK, Json(serde_json::json!({"path": path_str}))).into_response()
+        }
+        Ok(CommandResult::Err(e)) => {
+            (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": e}))).into_response()
+        }
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "command processing failed"})),
+        )
+            .into_response(),
+    }
+}
+
+/// File extension for a clipboard image MIME type. Mirrors the desktop
+/// `paste_filename` mapping (GPUI `ImageFormat`), defaulting to `png` for
+/// anything unrecognised. Tolerates parameters (`image/png; charset=…`).
+fn image_ext_for_mime(mime: &str) -> &'static str {
+    let mime = mime.split(';').next().unwrap_or(mime).trim();
+    match mime {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/webp" => "webp",
+        "image/gif" => "gif",
+        "image/svg+xml" => "svg",
+        "image/bmp" | "image/x-bmp" => "bmp",
+        "image/tiff" => "tiff",
+        "image/x-icon" | "image/vnd.microsoft.icon" => "ico",
+        "image/x-portable-anymap" => "pnm",
+        _ => "png",
+    }
+}
+
+/// Per-process token keeping temp filenames unique within a run (monotonic
+/// counter) and across runs (wall clock). Collisions would only overwrite a
+/// sibling paste, but uniqueness is cheap.
+fn next_token() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{nanos:x}-{n:x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::image_ext_for_mime;
+
+    #[test]
+    fn maps_known_mime_types() {
+        assert_eq!(image_ext_for_mime("image/png"), "png");
+        assert_eq!(image_ext_for_mime("image/jpeg"), "jpg");
+        assert_eq!(image_ext_for_mime("image/svg+xml"), "svg");
+        assert_eq!(image_ext_for_mime("image/x-icon"), "ico");
+    }
+
+    #[test]
+    fn tolerates_content_type_parameters() {
+        assert_eq!(image_ext_for_mime("image/png; charset=binary"), "png");
+        assert_eq!(image_ext_for_mime(" image/webp "), "webp");
+    }
+
+    #[test]
+    fn defaults_unknown_to_png() {
+        assert_eq!(image_ext_for_mime("application/octet-stream"), "png");
+        assert_eq!(image_ext_for_mime(""), "png");
+    }
+}

--- a/src/views/components/path_autocomplete.rs
+++ b/src/views/components/path_autocomplete.rs
@@ -357,36 +357,31 @@ impl PathAutoCompleteState {
         let key = event.keystroke.key.as_str();
 
         match key {
-            "tab" => {
-                if self.show_suggestions && !self.suggestions.is_empty() {
+            "tab"
+                if self.show_suggestions && !self.suggestions.is_empty() => {
                     self.complete_selected(cx);
                     return true;
                 }
-            }
-            "up" => {
-                if self.show_suggestions {
+            "up"
+                if self.show_suggestions => {
                     self.select_previous(cx);
                     return true;
                 }
-            }
-            "down" => {
-                if self.show_suggestions {
+            "down"
+                if self.show_suggestions => {
                     self.select_next(cx);
                     return true;
                 }
-            }
-            "escape" => {
-                if self.show_suggestions {
+            "escape"
+                if self.show_suggestions => {
                     self.hide_suggestions(cx);
                     return true;
                 }
-            }
-            "enter" => {
-                if self.show_suggestions && !self.suggestions.is_empty() {
+            "enter"
+                if self.show_suggestions && !self.suggestions.is_empty() => {
                     self.complete_selected(cx);
                     return true;
                 }
-            }
             _ => {}
         }
 

--- a/src/views/overlays/keybindings_help.rs
+++ b/src/views/overlays/keybindings_help.rs
@@ -611,11 +611,10 @@ impl Render for KeybindingsHelp {
                 }
                 let key = event.keystroke.key.as_str();
                 match key {
-                    "backspace" => {
-                        if this.search_query.pop().is_some() {
+                    "backspace"
+                        if this.search_query.pop().is_some() => {
                             cx.notify();
                         }
-                    }
                     k if k.len() == 1 && !event.keystroke.modifiers.modified() => {
                         let Some(ch) = k.chars().next() else {
                             return;


### PR DESCRIPTION
## Problem

Pasting a clipboard image into a **remote-backed** terminal was broken. `TerminalPane::handle_paste` wrote the image to the *client's* temp dir and sent that **client-local path** over the wire to the server's PTY — so the server-side process (e.g. Claude Code) got a path to a file that doesn't exist on it. Claude Code reads images by path, so this silently failed.

Local image paste already worked this way (write temp file → `send_paste(path)`); only the remote case was wrong.

## Approach

Route remote image pastes over HTTP so the file is materialised **where the terminal's process runs**:

1. Client captures the clipboard image (GPUI `ClipboardEntry::Image`) and, when the terminal is remote, uploads the bytes to `POST /v1/terminals/{id}/paste-image` instead of writing a local temp file.
2. The server writes the bytes to **its own** temp dir and bracketed-pastes that path into the terminal — mirroring the local paste path, just across the wire — so the focused TUI's own paste handler attaches it.

Scope: **remote desktop client** (okena desktop connected to a remote okena server). Web/mobile clients are unchanged for now; they'd reuse the same endpoint via an `onPaste` handler.

## Changes

- **okena-views-terminal**: `ActionDispatch::upload_remote_paste_image` (default no-op); `handle_paste` short-circuits to it for remote terminals.
- **action_dispatch**: strip the `remote:{cid}:` prefix and delegate to the connection manager.
- **okena-remote-client**: `RemoteConnectionManager::upload_paste_image` — fire-and-forget HTTP upload, mirrors `send_action`.
- **remote server**: new authenticated `paste-image` route (20 MiB body limit, overriding the global 1 MiB cap; clipboard PNGs routinely exceed 1 MiB) + `RemoteCommand::PasteImage` → `ensure_terminal` + `send_paste` on the GPUI thread.
- enable tokio `fs` feature for the async temp-file write.

## Testing

- `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test` green, CI passing.
- New unit tests for the MIME→extension mapping (param tolerance + default).

## Notes

- **Second commit (`fix(lint)`) is unrelated** to this feature: the `rust-toolchain.toml` bump to 1.95.0 turned new clippy lints (`collapsible_match`, `unnecessary_sort_by`) into CI errors, which had already made `main` red. Mechanical, no behavior change — included here so this branch's CI is green; can be cherry-picked to `main` separately to un-red it sooner.
- **TLS parity caveat**: the upload mirrors `send_action`, which builds an `http://` URL with a plain `reqwest::Client` (no cert pinning). So like every other action, image upload won't work over a TLS connection with a self-signed pinned cert — a pre-existing limitation of the action transport, not a new regression. Happy to fix both in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)