### PR TITLE
feat(usage): unify Claude & Codex widgets, add working-days setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6120,6 +6120,7 @@ dependencies = [
  "okena-core",
  "okena-extensions",
  "okena-ui",
+ "okena-usage",
  "parking_lot",
  "serde_json",
  "sha2",
@@ -6140,6 +6141,7 @@ dependencies = [
  "okena-core",
  "okena-extensions",
  "okena-ui",
+ "okena-usage",
  "parking_lot",
  "serde_json",
  "smol",
@@ -6369,6 +6371,19 @@ dependencies = [
  "okena-core",
  "okena-theme",
  "smol",
+]
+
+[[package]]
+name = "okena-usage"
+version = "0.1.0"
+dependencies = [
+ "gpui",
+ "gpui-component",
+ "jiff",
+ "okena-core",
+ "okena-extensions",
+ "okena-ui",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/okena-mobile-ffi", "crates/okena-core", "crates/okena-git", "crates/okena-views-git", "crates/okena-views-services", "crates/okena-views-sidebar", "crates/okena-views-terminal", "crates/okena-terminal", "crates/okena-layout", "crates/okena-state", "crates/okena-hooks", "crates/okena-workspace", "crates/okena-ui", "crates/okena-files", "crates/okena-markdown", "crates/okena-extensions", "crates/okena-ext-claude", "crates/okena-ext-codex", "crates/okena-ext-github", "crates/okena-ext-updater", "crates/okena-services", "crates/okena-remote-client", "crates/okena-views-remote", "crates/okena-theme"]
+members = [".", "crates/okena-mobile-ffi", "crates/okena-core", "crates/okena-git", "crates/okena-views-git", "crates/okena-views-services", "crates/okena-views-sidebar", "crates/okena-views-terminal", "crates/okena-terminal", "crates/okena-layout", "crates/okena-state", "crates/okena-hooks", "crates/okena-workspace", "crates/okena-ui", "crates/okena-usage", "crates/okena-files", "crates/okena-markdown", "crates/okena-extensions", "crates/okena-ext-claude", "crates/okena-ext-codex", "crates/okena-ext-github", "crates/okena-ext-updater", "crates/okena-services", "crates/okena-remote-client", "crates/okena-views-remote", "crates/okena-theme"]
 resolver = "2"
 
 [package]

--- a/crates/okena-ext-claude/src/settings.rs
+++ b/crates/okena-ext-claude/src/settings.rs
@@ -3,6 +3,7 @@ use okena_extensions::{ExtensionSettingsStore, ThemeColors};
 use okena_ui::settings::{section_container, section_header, settings_row_with_desc};
 use okena_ui::simple_input::{InputChangedEvent, SimpleInput, SimpleInputState};
 use okena_ui::tokens::ui_text_md;
+use okena_usage::WorkingDaysSetting;
 
 fn theme(cx: &App) -> ThemeColors {
     okena_extensions::theme(cx)
@@ -10,6 +11,7 @@ fn theme(cx: &App) -> ThemeColors {
 
 pub struct ClaudeSettingsView {
     config_dir_input: Entity<SimpleInputState>,
+    working_days: Entity<WorkingDaysSetting>,
 }
 
 impl ClaudeSettingsView {
@@ -25,6 +27,8 @@ impl ClaudeSettingsView {
                 .placeholder("e.g. ~/.claude-work")
                 .default_value(current_value)
         });
+
+        let working_days = cx.new(WorkingDaysSetting::new);
 
         cx.observe_global::<ExtensionSettingsStore>(move |this, cx| {
             let next_value = cx
@@ -55,7 +59,10 @@ impl ClaudeSettingsView {
         )
         .detach();
 
-        Self { config_dir_input }
+        Self {
+            config_dir_input,
+            working_days,
+        }
     }
 }
 
@@ -89,5 +96,6 @@ impl Render for ClaudeSettingsView {
                     ),
                 ),
             )
+            .child(self.working_days.clone())
     }
 }

--- a/crates/okena-ext-claude/src/usage.rs
+++ b/crates/okena-ext-claude/src/usage.rs
@@ -1,9 +1,12 @@
-use crate::ui_helpers::open_url;
+use crate::ui_helpers::capitalize_first;
 use okena_extensions::{ExtensionSettingsStore, ThemeColors};
-use okena_ui::tokens::{ui_text_xs, ui_text_ms, ui_text_md};
+use okena_usage::{
+    effective_time_pct, read_working_days, render_simple_bar, render_usage_row,
+    usage_body_container, usage_divider, usage_kv_row, usage_popover_container,
+    usage_popover_header, usage_trigger_items, SegmentUnit, UsageRow,
+};
 use gpui::prelude::FluentBuilder;
 use gpui::*;
-use gpui_component::tooltip::Tooltip;
 use gpui_component::{h_flex, v_flex};
 use parking_lot::Mutex;
 #[cfg(target_os = "macos")]
@@ -29,9 +32,9 @@ const HOVER_REFETCH_THROTTLE: Duration = Duration::from_secs(60);
 #[derive(Clone)]
 struct TierUsage {
     utilization: f64,
-    resets_at: String,
-    /// Raw ISO 8601 reset timestamp, used to anchor the per-day/hour grid.
-    resets_at_raw: Option<String>,
+    /// Reset time as Unix epoch seconds, anchoring the per-day/hour grid and
+    /// the "resets …" label.
+    reset_epoch: Option<f64>,
     /// Length of this rate-limit window in seconds.
     period_secs: f64,
     /// Percentage of the billing period that has elapsed (0.0–100.0)
@@ -50,6 +53,8 @@ struct ExtraUsage {
 /// All fetched usage data
 #[derive(Clone)]
 struct UsageData {
+    /// Subscription plan label (e.g. "Pro", "Max") read from the credentials.
+    plan: Option<String>,
     five_hour: Option<TierUsage>,
     seven_day: Option<TierUsage>,
     seven_day_sonnet: Option<TierUsage>,
@@ -233,11 +238,54 @@ fn read_access_token(claude_dir: &Path) -> Option<String> {
     None
 }
 
+/// Extract the subscription plan label (e.g. "pro", "max") from a Claude
+/// credentials JSON blob.
+fn extract_subscription_type(json_str: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(json_str).ok()?;
+    let plan = v["claudeAiOauth"]["subscriptionType"].as_str()?.trim();
+    if plan.is_empty() {
+        None
+    } else {
+        Some(plan.to_string())
+    }
+}
+
+/// Read the subscription plan label from the credentials file or, on macOS,
+/// the Keychain — mirroring [`read_access_token`]'s lookup.
+fn read_subscription_type(claude_dir: &Path) -> Option<String> {
+    if let Some(plan) = std::fs::read_to_string(claude_dir.join(".credentials.json"))
+        .ok()
+        .and_then(|content| extract_subscription_type(&content))
+    {
+        return Some(plan);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let user = std::env::var("USER").ok()?;
+        for service in keychain_service_names(claude_dir) {
+            let output = okena_core::process::safe_output(
+                okena_core::process::command("security")
+                    .args(["find-generic-password", "-s", &service, "-a", &user, "-w"]),
+            )
+            .ok()?;
+            if output.status.success() {
+                let content = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if let Some(plan) = extract_subscription_type(&content) {
+                    return Some(plan);
+                }
+            }
+        }
+    }
+
+    None
+}
+
 fn parse_usage(resp: &serde_json::Value) -> UsageData {
-    let five_hour = parse_tier(resp, "five_hour", false, FIVE_HOUR_SECS);
-    let seven_day = parse_tier(resp, "seven_day", true, SEVEN_DAY_SECS);
-    let seven_day_sonnet = parse_tier(resp, "seven_day_sonnet", true, SEVEN_DAY_SECS);
-    let seven_day_opus = parse_tier(resp, "seven_day_opus", true, SEVEN_DAY_SECS);
+    let five_hour = parse_tier(resp, "five_hour", FIVE_HOUR_SECS);
+    let seven_day = parse_tier(resp, "seven_day", SEVEN_DAY_SECS);
+    let seven_day_sonnet = parse_tier(resp, "seven_day_sonnet", SEVEN_DAY_SECS);
+    let seven_day_opus = parse_tier(resp, "seven_day_opus", SEVEN_DAY_SECS);
 
     let extra_usage = resp.get("extra_usage").map(|eu| {
         ExtraUsage {
@@ -249,6 +297,7 @@ fn parse_usage(resp: &serde_json::Value) -> UsageData {
     });
 
     UsageData {
+        plan: None,
         five_hour,
         seven_day,
         seven_day_sonnet,
@@ -261,21 +310,14 @@ fn parse_usage(resp: &serde_json::Value) -> UsageData {
 const FIVE_HOUR_SECS: f64 = 5.0 * 3600.0;
 const SEVEN_DAY_SECS: f64 = 7.0 * 86400.0;
 
-fn parse_tier(
-    resp: &serde_json::Value,
-    key: &str,
-    include_date: bool,
-    period_secs: f64,
-) -> Option<TierUsage> {
+fn parse_tier(resp: &serde_json::Value, key: &str, period_secs: f64) -> Option<TierUsage> {
     let tier = resp.get(key)?;
     let resets_at_raw = tier["resets_at"].as_str();
+    let reset_epoch = resets_at_raw.and_then(parse_iso8601_to_epoch);
     let time_elapsed_pct = resets_at_raw.and_then(|ts| compute_time_elapsed_pct(ts, period_secs));
     Some(TierUsage {
         utilization: tier["utilization"].as_f64().unwrap_or(0.0),
-        resets_at: resets_at_raw
-            .map(|ts| format_reset_time(ts, include_date))
-            .unwrap_or_default(),
-        resets_at_raw: resets_at_raw.map(str::to_owned),
+        reset_epoch,
         period_secs,
         time_elapsed_pct,
     })
@@ -304,124 +346,6 @@ fn parse_iso8601_to_epoch(ts: &str) -> Option<f64> {
 pub(crate) fn parse_iso8601_to_local(ts: &str) -> Option<jiff::Zoned> {
     let timestamp: jiff::Timestamp = ts.parse().ok()?;
     Some(timestamp.to_zoned(jiff::tz::TimeZone::system()))
-}
-
-#[derive(Clone, Copy)]
-enum SegmentUnit {
-    Hour,
-    Day,
-}
-
-/// Compute reset-anchored grid boundaries for a usage bar, plus the block that
-/// currently contains "now".
-///
-/// Boundaries land on the user's *actual* reset time-of-day — e.g. a Sunday
-/// 12:00 weekly reset yields noon-to-noon day blocks — computed with calendar
-/// arithmetic so they stay correct across DST and for any reset time, rather
-/// than just evenly dividing the bar. Returns the divider fractions (0..1,
-/// excluding the ends) and the (start, end) fractions of the current block.
-fn reset_aligned_segments(
-    resets_at: Option<&str>,
-    period_secs: f64,
-    unit: SegmentUnit,
-) -> (Vec<f32>, Option<(f32, f32)>) {
-    let reset = match resets_at.and_then(parse_iso8601_to_local) {
-        Some(z) => z,
-        None => return (Vec::new(), None),
-    };
-    let reset_epoch = reset.timestamp().as_millisecond() as f64 / 1_000.0;
-    let start_epoch = reset_epoch - period_secs;
-    let now_epoch = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs_f64())
-        .unwrap_or(start_epoch);
-
-    // Keep the grid legible on a thin bar: if a window spans more units than
-    // this, step by a whole multiple (e.g. every 2 days), which is still
-    // anchored to the reset time-of-day.
-    let (unit_secs, max_blocks) = match unit {
-        SegmentUnit::Hour => (3_600.0, 12.0),
-        SegmentUnit::Day => (86_400.0, 14.0),
-    };
-    let units = (period_secs / unit_secs).round().max(1.0);
-    let multiplier = (units / max_blocks).ceil().max(1.0) as i64;
-    let step = match unit {
-        SegmentUnit::Hour => jiff::Span::new().hours(multiplier),
-        SegmentUnit::Day => jiff::Span::new().days(multiplier),
-    };
-
-    // Walk back from the reset, one block at a time, until the window start is
-    // covered. `bounds` ends up holding boundary epochs in ascending order.
-    let mut bounds = vec![reset_epoch];
-    let mut cursor = reset;
-    for _ in 0..64 {
-        cursor = match cursor.checked_sub(step) {
-            Ok(z) => z,
-            Err(_) => break,
-        };
-        let epoch = cursor.timestamp().as_millisecond() as f64 / 1_000.0;
-        bounds.push(epoch);
-        if epoch <= start_epoch {
-            break;
-        }
-    }
-    bounds.reverse();
-
-    let frac = |epoch: f64| ((epoch - start_epoch) / period_secs) as f32;
-    let dividers = bounds
-        .iter()
-        .map(|&epoch| frac(epoch))
-        .filter(|&f| f > 0.001 && f < 0.999)
-        .collect();
-    let current = bounds.windows(2).find_map(|w| {
-        (now_epoch >= w[0] && now_epoch < w[1])
-            .then(|| (frac(w[0]).max(0.0), frac(w[1]).min(1.0)))
-    });
-
-    (dividers, current)
-}
-
-/// Format ISO 8601 reset time to a human-readable short form in local timezone.
-/// Falls back to UTC if local timezone is unavailable, or returns `ts` as-is if unparseable.
-fn format_reset_time(ts: &str, include_date: bool) -> String {
-    if let Some(zoned) = parse_iso8601_to_local(ts) {
-        if include_date {
-            let today = jiff::Zoned::now().date();
-            let reset_date = zoned.date();
-
-            let diff_days = today.until(reset_date).ok()
-                .map(|span| span.get_days())
-                .unwrap_or(i32::MAX);
-
-            let date_label = match diff_days {
-                0 => Some("today"),
-                1 => Some("tomorrow"),
-                _ => None,
-            };
-
-            return match date_label {
-                Some(label) => format!("{}, {}", label, zoned.strftime("%H:%M %Z")),
-                None if (2..=6).contains(&diff_days) => {
-                    zoned.strftime("%a, %H:%M %Z").to_string()
-                }
-                None => zoned.strftime("%b %-d, %H:%M %Z").to_string(),
-            };
-        }
-
-        return zoned.strftime("%H:%M %Z").to_string();
-    }
-
-    // Fallback: try UTC if the timestamp parses but local timezone failed
-    if let Ok(timestamp) = ts.parse::<jiff::Timestamp>() {
-        let utc = timestamp.to_zoned(jiff::tz::TimeZone::UTC);
-        return if include_date {
-            utc.strftime("%b %-d, %H:%M UTC").to_string()
-        } else {
-            utc.strftime("%H:%M UTC").to_string()
-        };
-    }
-
-    ts.to_string()
 }
 
 impl ClaudeUsageData {
@@ -555,7 +479,9 @@ impl ClaudeUsageData {
                                     Ok(v) => v,
                                     Err(_) => return (None, None),
                                 };
-                            (Some(parse_usage(&parsed)), None)
+                            let mut usage = parse_usage(&parsed);
+                            usage.plan = read_subscription_type(&dir);
+                            (Some(usage), None)
                         }
                         Err(e) => {
                             log::warn!("[claude-usage] request failed: {}", e);
@@ -707,6 +633,8 @@ impl ClaudeUsage {
             _ => return div().size_0().into_any_element(),
         };
 
+        let working = read_working_days(cx);
+        let plan = data.plan.as_deref().map(capitalize_first);
         let bounds = self.trigger_bounds;
         let position = point(bounds.origin.x, bounds.origin.y - px(4.0));
 
@@ -716,16 +644,9 @@ impl ClaudeUsage {
                 .anchor(Anchor::BottomLeft)
                 .snap_to_window()
                 .child(
-                    div()
+                    usage_popover_container(t)
                         .id("claude-usage-popover")
                         .occlude()
-                        .min_w(px(300.0))
-                        .max_w(px(420.0))
-                        .bg(rgb(t.bg_primary))
-                        .border_1()
-                        .border_color(rgb(t.border))
-                        .rounded(px(8.0))
-                        .shadow_lg()
                         .on_hover(cx.listener(|this, hovered: &bool, _window, cx| {
                             if *hovered {
                                 this.hover_token.fetch_add(1, Ordering::SeqCst);
@@ -736,44 +657,65 @@ impl ClaudeUsage {
                         .on_mouse_down(MouseButton::Left, |_, _, cx| {
                             cx.stop_propagation();
                         })
+                        .child(usage_popover_header(
+                            "CLAUDE USAGE",
+                            plan.as_deref(),
+                            "https://claude.ai/settings/usage",
+                            "Open usage settings on claude.ai",
+                            t,
+                            cx,
+                        ))
                         .child(
-                            v_flex()
-                                .child(render_popover_header(t, cx))
-                                .child(
-                                    v_flex()
-                                        .px(px(12.0))
-                                        .py(px(10.0))
-                                        .gap(px(7.0))
-                                        .when_some(data.five_hour.as_ref(), |el, tier| {
-                                            el.child(render_tier_row(t, cx, "Session", "5h", tier, "marker-session", SegmentUnit::Hour))
-                                        })
-                                        .when_some(data.seven_day.as_ref(), |el, tier| {
-                                            el.child(render_tier_row(t, cx, "Weekly", "7d", tier, "marker-weekly", SegmentUnit::Day))
-                                        })
-                                        .when_some(
-                                            data.seven_day_sonnet
-                                                .as_ref()
-                                                .filter(|tier| tier.utilization >= 0.5),
-                                            |el, tier| {
-                                                el.child(render_tier_row(t, cx, "Sonnet", "7d", tier, "marker-sonnet", SegmentUnit::Day))
-                                            },
-                                        )
-                                        .when_some(
-                                            data.seven_day_opus
-                                                .as_ref()
-                                                .filter(|tier| tier.utilization >= 0.5),
-                                            |el, tier| {
-                                                el.child(render_tier_row(t, cx, "Opus", "7d", tier, "marker-opus", SegmentUnit::Day))
-                                            },
-                                        )
-                                        .when_some(data.extra_usage.as_ref(), |el, extra| {
-                                            if !extra.is_enabled {
-                                                return el;
-                                            }
-                                            el.child(render_divider(t))
-                                                .child(render_extra_usage_row(t, cx, extra))
-                                        }),
-                                ),
+                            usage_body_container()
+                                .when_some(data.five_hour.as_ref(), |el, tier| {
+                                    el.child(render_usage_row(
+                                        t,
+                                        cx,
+                                        &tier_row("Session", "5h", tier, "claude-marker-session", SegmentUnit::Hour),
+                                        working,
+                                    ))
+                                })
+                                .when_some(data.seven_day.as_ref(), |el, tier| {
+                                    el.child(render_usage_row(
+                                        t,
+                                        cx,
+                                        &tier_row("Weekly", "7d", tier, "claude-marker-weekly", SegmentUnit::Day),
+                                        working,
+                                    ))
+                                })
+                                .when_some(
+                                    data.seven_day_sonnet
+                                        .as_ref()
+                                        .filter(|tier| tier.utilization >= 0.5),
+                                    |el, tier| {
+                                        el.child(render_usage_row(
+                                            t,
+                                            cx,
+                                            &tier_row("Sonnet", "7d", tier, "claude-marker-sonnet", SegmentUnit::Day),
+                                            working,
+                                        ))
+                                    },
+                                )
+                                .when_some(
+                                    data.seven_day_opus
+                                        .as_ref()
+                                        .filter(|tier| tier.utilization >= 0.5),
+                                    |el, tier| {
+                                        el.child(render_usage_row(
+                                            t,
+                                            cx,
+                                            &tier_row("Opus", "7d", tier, "claude-marker-opus", SegmentUnit::Day),
+                                            working,
+                                        ))
+                                    },
+                                )
+                                .when_some(data.extra_usage.as_ref(), |el, extra| {
+                                    if !extra.is_enabled {
+                                        return el;
+                                    }
+                                    el.child(usage_divider(t))
+                                        .child(render_extra_usage_row(t, cx, extra))
+                                }),
                         ),
                 ),
         )
@@ -782,359 +724,72 @@ impl ClaudeUsage {
     }
 }
 
-fn render_popover_header(t: &ThemeColors, cx: &App) -> impl IntoElement {
-    let muted = t.text_muted;
-    let primary = t.text_primary;
-
-    h_flex()
-        .px(px(12.0))
-        .py(px(7.0))
-        .items_center()
-        .justify_between()
-        .border_b_1()
-        .border_color(rgb(t.border))
-        .child(
-            div()
-                .text_size(ui_text_xs(cx))
-                .font_weight(FontWeight::SEMIBOLD)
-                .text_color(rgb(t.text_secondary))
-                .child("CLAUDE USAGE"),
-        )
-        .child(
-            h_flex()
-                .id("claude-usage-settings")
-                .gap(px(4.0))
-                .items_center()
-                .px(px(4.0))
-                .py(px(1.0))
-                .rounded(px(3.0))
-                .cursor_pointer()
-                .text_color(rgb(muted))
-                .hover(|s| s.text_color(rgb(primary)).bg(rgb(t.bg_hover)))
-                .child(
-                    div()
-                        .text_size(ui_text_xs(cx))
-                        .line_height(px(10.0))
-                        .child("Settings"),
-                )
-                .child(
-                    svg()
-                        .path("icons/external-link.svg")
-                        .size(px(10.0)),
-                )
-                .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                    cx.stop_propagation();
-                })
-                .on_click(|_, _, _cx| {
-                    open_url("https://claude.ai/settings/usage");
-                })
-                .tooltip(|window, cx| {
-                    Tooltip::new("Open usage settings on claude.ai").build(window, cx)
-                }),
-        )
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum Severity {
-    Normal,
-    Warning,
-    Critical,
-}
-
-fn severity_color(t: &ThemeColors, s: Severity) -> u32 {
-    match s {
-        Severity::Normal => t.metric_normal,
-        Severity::Warning => t.metric_warning,
-        Severity::Critical => t.metric_critical,
-    }
-}
-
-/// Severity from absolute utilization — how close to the hard cap.
-fn abs_severity(pct: f64) -> Severity {
-    if pct > 80.0 {
-        Severity::Critical
-    } else if pct > 60.0 {
-        Severity::Warning
-    } else {
-        Severity::Normal
-    }
-}
-
-/// Severity from pace — how far ahead usage is of where it "should" be at this
-/// point in the period. `Critical` means the user is burning budget fast enough
-/// to run out before the period resets unless they slow down.
-fn pace_severity(usage_pct: f64, time_pct: Option<f64>) -> Severity {
-    match time_pct {
-        Some(tp) if usage_pct > tp + 15.0 => Severity::Critical,
-        Some(tp) if usage_pct > tp + 5.0 => Severity::Warning,
-        _ => Severity::Normal,
-    }
-}
-
-fn utilization_color(t: &ThemeColors, pct: f64) -> u32 {
-    severity_color(t, abs_severity(pct))
-}
-
-fn render_tier_row(
-    t: &ThemeColors,
-    cx: &App,
+/// Build a shared [`UsageRow`] from a Claude rate-limit tier.
+fn tier_row(
     label: &str,
     period: &str,
     tier: &TierUsage,
     marker_id: &'static str,
     unit: SegmentUnit,
-) -> impl IntoElement {
-    let pct = tier.utilization;
-    let (dividers, current_seg) =
-        reset_aligned_segments(tier.resets_at_raw.as_deref(), tier.period_secs, unit);
-    let pace = pace_severity(pct, tier.time_elapsed_pct);
-    // % text reflects whichever is worse: nearness to the cap, or burn pace.
-    let pct_color = severity_color(t, abs_severity(pct).max(pace));
-    let pace_msg: Option<(&str, u32)> = match pace {
-        Severity::Critical => Some(("Slow down to last the period", t.metric_critical)),
-        Severity::Warning => Some(("Ahead of pace", t.metric_warning)),
-        Severity::Normal => None,
-    };
+) -> UsageRow {
+    UsageRow {
+        label: label.into(),
+        period: period.into(),
+        pct: tier.utilization,
+        time_pct: tier.time_elapsed_pct,
+        reset_epoch: tier.reset_epoch,
+        period_secs: tier.period_secs,
+        unit: Some(unit),
+        marker_id: marker_id.into(),
+    }
+}
 
+fn render_extra_usage_row(t: &ThemeColors, cx: &App, extra: &ExtraUsage) -> impl IntoElement {
     v_flex()
         .gap(px(5.0))
-        .child(
-            h_flex()
-                .items_baseline()
-                .justify_between()
-                .child(
-                    h_flex()
-                        .gap(px(6.0))
-                        .items_baseline()
-                        .child(
-                            div()
-                                .text_size(ui_text_ms(cx))
-                                .text_color(rgb(t.text_primary))
-                                .child(label.to_string()),
-                        )
-                        .child(
-                            div()
-                                .text_size(ui_text_xs(cx))
-                                .text_color(rgb(t.text_muted))
-                                .child(period.to_string()),
-                        ),
-                )
-                .child(
-                    div()
-                        .text_size(ui_text_md(cx))
-                        .font_weight(FontWeight::SEMIBOLD)
-                        .text_color(rgb(pct_color))
-                        .child(format!("{:.0}%", pct)),
-                ),
-        )
-        .child(render_usage_with_time_bar(
+        .child(usage_kv_row(
             t,
-            pct,
-            tier.time_elapsed_pct,
-            marker_id,
-            dividers,
-            current_seg,
+            cx,
+            "Extra Usage",
+            format!(
+                "${:.2} / ${:.2}",
+                extra.used_credits / 100.0,
+                extra.monthly_limit / 100.0
+            ),
+            t.text_primary,
         ))
-        .when(pace_msg.is_some() || !tier.resets_at.is_empty(), |el| {
-            el.child(
-                h_flex()
-                    .justify_between()
-                    .items_baseline()
-                    .child(
-                        div()
-                            .text_size(ui_text_xs(cx))
-                            .font_weight(FontWeight::MEDIUM)
-                            .when_some(pace_msg, |d, (msg, col)| {
-                                d.text_color(rgb(col)).child(msg)
-                            }),
-                    )
-                    .child(
-                        div()
-                            .text_size(ui_text_xs(cx))
-                            .text_color(rgb(t.text_muted))
-                            .when(!tier.resets_at.is_empty(), |d| {
-                                d.child(format!("resets {}", tier.resets_at))
-                            }),
-                    ),
-            )
-        })
-}
-
-fn render_extra_usage_row(
-    t: &ThemeColors,
-    cx: &App,
-    extra: &ExtraUsage,
-) -> impl IntoElement {
-    v_flex()
-        .gap(px(5.0))
-        .child(
-            h_flex()
-                .items_baseline()
-                .justify_between()
-                .child(
-                    div()
-                        .text_size(ui_text_ms(cx))
-                        .text_color(rgb(t.text_primary))
-                        .child("Extra Usage"),
-                )
-                .child(
-                    div()
-                        .text_size(ui_text_ms(cx))
-                        .font_weight(FontWeight::SEMIBOLD)
-                        .text_color(rgb(t.text_primary))
-                        .child(format!(
-                            "${:.2} / ${:.2}",
-                            extra.used_credits / 100.0,
-                            extra.monthly_limit / 100.0
-                        )),
-                ),
-        )
-        .child(render_progress_bar(t, extra.utilization))
-}
-
-fn render_divider(t: &ThemeColors) -> impl IntoElement {
-    div().h(px(1.0)).w_full().bg(rgb(t.border))
-}
-
-fn render_usage_with_time_bar(
-    t: &ThemeColors,
-    usage_pct: f64,
-    time_pct: Option<f64>,
-    marker_id: &'static str,
-    dividers: Vec<f32>,
-    current_seg: Option<(f32, f32)>,
-) -> impl IntoElement {
-    let clamped_usage = usage_pct.clamp(0.0, 100.0) as f32;
-
-    // Base fill reflects nearness to the hard cap. Any usage *beyond* the pace
-    // marker is overage — drawn on top in warning/critical — so being over the
-    // budget for this point in the period is visible directly on the bar.
-    let base_color = severity_color(t, abs_severity(usage_pct));
-    let overage = time_pct.and_then(|tp| {
-        let start = tp.clamp(0.0, 100.0) as f32;
-        let width = clamped_usage - start;
-        if width <= 0.0 {
-            return None;
-        }
-        let color = if width > 15.0 {
-            t.metric_critical
-        } else {
-            t.metric_warning
-        };
-        Some((start, width, color))
-    });
-
-    // Divider lines at the reset-anchored day/hour boundaries, so the pace
-    // marker can be read against a real time grid.
-    let divider_els = dividers.into_iter().map(move |f| {
-        div()
-            .absolute()
-            .top_0()
-            .h_full()
-            .w(px(1.0))
-            .bg(rgb(t.border))
-            .left(relative(f))
-    });
-
-    // Translucent band over the block the user is currently in (today / this
-    // hour). Derived from text_primary so it lightens on dark themes and darkens
-    // on light ones.
-    let mut highlight = rgb(t.text_primary);
-    highlight.a = 0.14;
-
-    div()
-        .h(px(6.0))
-        .w_full()
-        .rounded_full()
-        .bg(rgb(t.bg_secondary))
-        .relative()
-        .child(
-            div()
-                .h_full()
-                .rounded_full()
-                .bg(rgb(base_color))
-                .w(relative(clamped_usage / 100.0)),
-        )
-        .when_some(overage, |el, (start, width, color)| {
-            el.child(
-                div()
-                    .absolute()
-                    .top_0()
-                    .h_full()
-                    .left(relative(start / 100.0))
-                    .w(relative(width / 100.0))
-                    .rounded_r(px(3.0))
-                    .bg(rgb(color)),
-            )
-        })
-        .children(divider_els)
-        .when_some(current_seg, |el, (start, end)| {
-            el.child(
-                div()
-                    .absolute()
-                    .top_0()
-                    .h_full()
-                    .left(relative(start))
-                    .w(relative((end - start).max(0.0)))
-                    .bg(highlight),
-            )
-        })
-        .when_some(time_pct, |el, tp| {
-            let clamped_time = tp.clamp(0.0, 100.0) as f32;
-            let marker_color = t.text_primary;
-            el.child(
-                div()
-                    .id(marker_id)
-                    .absolute()
-                    .top(px(-4.0))
-                    .left(relative(clamped_time / 100.0))
-                    .w(px(8.0))
-                    .h(px(14.0))
-                    .flex()
-                    .items_center()
-                    .justify_start()
-                    .child(
-                        div()
-                            .w(px(2.0))
-                            .h(px(10.0))
-                            .rounded(px(1.0))
-                            .bg(rgb(marker_color)),
-                    )
-                    .tooltip(|window, cx| {
-                        Tooltip::new("Time elapsed in this period").build(window, cx)
-                    }),
-            )
-        })
-}
-
-fn render_progress_bar(t: &ThemeColors, pct: f64) -> impl IntoElement {
-    let clamped = pct.clamp(0.0, 100.0) as f32;
-    let color = utilization_color(t, pct);
-
-    div()
-        .h(px(6.0))
-        .w_full()
-        .rounded_full()
-        .bg(rgb(t.bg_secondary))
-        .child(
-            div()
-                .h_full()
-                .rounded_full()
-                .bg(rgb(color))
-                .w(relative(clamped / 100.0)),
-        )
+        .child(render_simple_bar(t, extra.utilization))
 }
 
 impl Render for ClaudeUsage {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let t = theme(cx);
 
+        let working = read_working_days(cx);
         let data = self.data.read(cx).data.lock();
-        let (five_h, seven_d) = match data.as_ref() {
+        let mut items: Vec<(SharedString, f64, Option<f64>)> = Vec::new();
+        match data.as_ref() {
             Some(d) => {
-                let fh = d.five_hour.as_ref().map(|t| t.utilization);
-                let sd = d.seven_day.as_ref().map(|t| t.utilization);
-                (fh, sd)
+                if let Some(tier) = d.five_hour.as_ref() {
+                    let et = effective_time_pct(
+                        tier.reset_epoch,
+                        tier.period_secs,
+                        Some(SegmentUnit::Hour),
+                        working,
+                        tier.time_elapsed_pct,
+                    );
+                    items.push(("5h".into(), tier.utilization, et));
+                }
+                if let Some(tier) = d.seven_day.as_ref() {
+                    let et = effective_time_pct(
+                        tier.reset_epoch,
+                        tier.period_secs,
+                        Some(SegmentUnit::Day),
+                        working,
+                        tier.time_elapsed_pct,
+                    );
+                    items.push(("7d".into(), tier.utilization, et));
+                }
             }
             None => {
                 drop(data);
@@ -1143,7 +798,7 @@ impl Render for ClaudeUsage {
                 self.data.read(cx).wake_if_no_data();
                 return div().size_0().into_any_element();
             }
-        };
+        }
         drop(data);
 
         let entity_handle = cx.entity().clone();
@@ -1158,48 +813,7 @@ impl Render for ClaudeUsage {
                     .py(px(1.0))
                     .rounded(px(3.0))
                     .hover(|s| s.bg(rgb(t.bg_hover)))
-                    .when_some(five_h, |el, pct| {
-                        el.child(
-                            h_flex()
-                                .gap(px(3.0))
-                                .child(
-                                    div()
-                                        .text_size(ui_text_ms(cx))
-                                        .text_color(rgb(t.text_muted))
-                                        .child("5h"),
-                                )
-                                .child(
-                                    div()
-                                        .text_size(ui_text_ms(cx))
-                                        .text_color(rgb(utilization_color(&t, pct)))
-                                        .child(format!("{:.0}%", pct)),
-                                ),
-                        )
-                    })
-                    .when_some(seven_d, |el, pct| {
-                        el.child(
-                            div()
-                                .text_size(ui_text_ms(cx))
-                                .text_color(rgb(t.text_muted))
-                                .child("|"),
-                        )
-                        .child(
-                            h_flex()
-                                .gap(px(3.0))
-                                .child(
-                                    div()
-                                        .text_size(ui_text_ms(cx))
-                                        .text_color(rgb(t.text_muted))
-                                        .child("7d"),
-                                )
-                                .child(
-                                    div()
-                                        .text_size(ui_text_ms(cx))
-                                        .text_color(rgb(utilization_color(&t, pct)))
-                                        .child(format!("{:.0}%", pct)),
-                                ),
-                        )
-                    })
+                    .children(usage_trigger_items(&t, cx, &items))
                     .child(
                         canvas(
                             move |bounds, _window, app| {
@@ -1339,36 +953,6 @@ mod tests {
     #[test]
     fn test_parse_iso8601_to_local_invalid() {
         assert!(parse_iso8601_to_local("garbage").is_none());
-    }
-
-    #[test]
-    fn test_format_reset_time_uses_local_tz() {
-        let result = format_reset_time("2025-06-15T14:00:00.000Z", false);
-        // Should contain a colon (HH:MM) and a timezone abbreviation
-        assert!(result.contains(':'), "Expected HH:MM format, got: {}", result);
-        assert!(!result.is_empty());
-    }
-
-    #[test]
-    fn test_format_reset_time_with_date() {
-        let result = format_reset_time("2099-01-15T11:00:00.000Z", true);
-        assert!(result.contains(':'), "Expected time in result, got: {}", result);
-        assert!(result.contains(','), "Expected date label with comma, got: {}", result);
-    }
-
-    #[test]
-    fn test_format_reset_time_invalid_input() {
-        // Invalid input should be returned as-is
-        let result = format_reset_time("garbage", false);
-        assert_eq!(result, "garbage");
-    }
-
-    #[test]
-    fn test_format_reset_time_past_date() {
-        // A reset time in the past should still format with date (no panic, no special label)
-        let result = format_reset_time("2020-01-01T00:00:00.000Z", true);
-        assert!(result.contains(':'), "Expected time in result, got: {}", result);
-        assert!(result.contains(','), "Expected date with comma, got: {}", result);
     }
 
     #[test]

--- a/crates/okena-ext-codex/Cargo.toml
+++ b/crates/okena-ext-codex/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 okena-core = { path = "../okena-core", features = ["blocking-http"] }
 okena-extensions = { path = "../okena-extensions" }
 okena-ui = { path = "../okena-ui" }
+okena-usage = { path = "../okena-usage" }
 gpui = { git = "https://github.com/zed-industries/zed", package = "gpui" }
 gpui-component = { git = "https://github.com/longbridge/gpui-component", package = "gpui-component" }
 serde_json = "1.0"

--- a/crates/okena-ext-codex/src/lib.rs
+++ b/crates/okena-ext-codex/src/lib.rs
@@ -1,10 +1,11 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 
 mod status;
+mod settings;
 mod usage;
 mod ui_helpers;
 
-use gpui::AppContext as _;
+use gpui::{AppContext as _, AnyView};
 use okena_extensions::{ExtensionInstance, ExtensionManifest, ExtensionRegistration};
 use std::sync::Arc;
 
@@ -23,6 +24,8 @@ pub fn register() -> ExtensionRegistration {
                 status_bar_right_widgets: vec![],
             }
         }),
-        settings_view: None,
+        settings_view: Some(Arc::new(|app| {
+            AnyView::from(app.new(settings::CodexSettingsView::new))
+        })),
     }
 }

--- a/crates/okena-ext-codex/src/settings.rs
+++ b/crates/okena-ext-codex/src/settings.rs
@@ -1,0 +1,33 @@
+use gpui::*;
+use okena_extensions::ThemeColors;
+use okena_ui::settings::section_header;
+use okena_usage::WorkingDaysSetting;
+
+fn theme(cx: &App) -> ThemeColors {
+    okena_extensions::theme(cx)
+}
+
+pub struct CodexSettingsView {
+    working_days: Entity<WorkingDaysSetting>,
+}
+
+impl CodexSettingsView {
+    pub fn new(cx: &mut Context<Self>) -> Self {
+        Self {
+            working_days: cx.new(WorkingDaysSetting::new),
+        }
+    }
+}
+
+impl Render for CodexSettingsView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let t = theme(cx);
+
+        div()
+            .flex()
+            .flex_col()
+            .gap(px(8.0))
+            .child(section_header("Codex", &t, cx))
+            .child(self.working_days.clone())
+    }
+}

--- a/crates/okena-ext-codex/src/usage.rs
+++ b/crates/okena-ext-codex/src/usage.rs
@@ -661,7 +661,7 @@ fn format_window_label(window_seconds: u64) -> &'static str {
 /// Build a shared [`UsageRow`] from a Codex rate-limit window.
 fn window_row(label: &str, window: &RateLimitWindow, marker_id: &'static str) -> UsageRow {
     let unit = segment_unit_for_window(window.window_seconds);
-    let reset_epoch = (window.reset_at > 0).then(|| window.reset_at as f64);
+    let reset_epoch = (window.reset_at > 0).then_some(window.reset_at as f64);
     UsageRow {
         label: label.into(),
         period: format_window_label(window.window_seconds).into(),
@@ -688,7 +688,7 @@ impl Render for CodexUsage {
                     .flatten()
                 {
                     let et = effective_time_pct(
-                        (w.reset_at > 0).then(|| w.reset_at as f64),
+                        (w.reset_at > 0).then_some(w.reset_at as f64),
                         w.window_seconds as f64,
                         segment_unit_for_window(w.window_seconds),
                         working,

--- a/crates/okena-ext-codex/src/usage.rs
+++ b/crates/okena-ext-codex/src/usage.rs
@@ -161,7 +161,14 @@ fn parse_window(v: &serde_json::Value) -> Option<RateLimitWindow> {
         .as_u64()
         .or_else(|| v["window_minutes"].as_u64().map(|v| v.saturating_mul(60)))
         .unwrap_or(0);
-    let reset_at = v["reset_at"].as_u64().unwrap_or(0);
+    // The live `/codex/usage` API uses `reset_at`; the local `token_count`
+    // session events use `resets_at` (plural). Accept either — missing it leaves
+    // the bar with no reset anchor, which silently disables the day/hour grid
+    // and the working-days reshape (the bar collapses to a single block).
+    let reset_at = v["reset_at"]
+        .as_u64()
+        .or_else(|| v["resets_at"].as_u64())
+        .unwrap_or(0);
 
     let time_elapsed_pct = if window_seconds > 0 && reset_at > 0 {
         let now = std::time::SystemTime::now()
@@ -770,4 +777,32 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn parse_window_reads_session_field_names() {
+        // Local `token_count` session events use `window_minutes` + `resets_at`
+        // (plural). Both must be picked up; missing the reset anchor used to
+        // collapse the weekly bar to a single block.
+        let v = serde_json::json!({
+            "used_percent": 3.0,
+            "window_minutes": 10080,
+            "resets_at": 1782371508u64,
+        });
+        let w = parse_window(&v).expect("window should parse");
+        assert_eq!(w.used_percent, 3);
+        assert_eq!(w.window_seconds, 10080 * 60, "weekly window = 7 days");
+        assert_eq!(w.reset_at, 1782371508, "must read `resets_at` (plural)");
+    }
+
+    #[test]
+    fn parse_window_reads_live_api_field_names() {
+        // The live `/codex/usage` API uses `limit_window_seconds` + `reset_at`.
+        let v = serde_json::json!({
+            "used_percent": 50,
+            "limit_window_seconds": 604800,
+            "reset_at": 1782371508u64,
+        });
+        let w = parse_window(&v).expect("window should parse");
+        assert_eq!(w.window_seconds, 604800);
+        assert_eq!(w.reset_at, 1782371508);
+    }
 }

--- a/crates/okena-ext-codex/src/usage.rs
+++ b/crates/okena-ext-codex/src/usage.rs
@@ -1,16 +1,20 @@
 use okena_extensions::ThemeColors;
-use okena_ui::tokens::{ui_text_xs, ui_text_sm, ui_text_ms, ui_text_md};
+use okena_usage::{
+    effective_time_pct, read_working_days, render_usage_row, usage_body_container, usage_divider,
+    usage_kv_row, usage_popover_container, usage_popover_header, usage_trigger_items, SegmentUnit,
+    UsageRow,
+};
 use base64::Engine as _;
 use gpui::prelude::FluentBuilder;
 use gpui::*;
-use gpui_component::{h_flex, v_flex};
+use gpui_component::h_flex;
 use parking_lot::Mutex;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Refresh interval for usage data
 const USAGE_INTERVAL: Duration = Duration::from_secs(300);
@@ -20,6 +24,9 @@ const MIN_RETRY_DELAY: Duration = Duration::from_secs(30);
 
 /// Hover delay before showing the popover (ms)
 const HOVER_DELAY_MS: u64 = 300;
+
+/// Minimum interval between hover-triggered re-fetches.
+const HOVER_REFETCH_THROTTLE: Duration = Duration::from_secs(60);
 
 /// Codex OAuth client ID (public, embedded in the Codex CLI binary)
 const CODEX_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
@@ -70,6 +77,12 @@ struct UsageData {
 /// state (popover, hover) lives on [`CodexUsage`] instead.
 struct CodexUsageData {
     data: Arc<Mutex<Option<UsageData>>>,
+    /// Send on this channel to wake up the fetch loop and retry immediately.
+    wake_tx: smol::channel::Sender<()>,
+    /// Whether a wake signal has already been sent (avoids spamming from render).
+    wake_sent: Arc<AtomicBool>,
+    /// Timestamp of the most recent successful fetch — used to throttle hover-triggered refreshes.
+    last_fetch_at: Arc<Mutex<Option<Instant>>>,
     /// Background polling task. Cancelled automatically when this entity is dropped.
     _poll_task: Task<()>,
 }
@@ -377,9 +390,30 @@ impl CodexUsageData {
         entity
     }
 
+    /// Wake the fetch loop, but only if the most recent successful fetch is older
+    /// than [`HOVER_REFETCH_THROTTLE`]. Used to refresh on popover open without
+    /// hammering the API on rapid hover-on/off.
+    fn request_fresh_fetch(&self) {
+        let stale = match *self.last_fetch_at.lock() {
+            None => true,
+            Some(last) => last.elapsed() >= HOVER_REFETCH_THROTTLE,
+        };
+        if !stale {
+            return;
+        }
+        if !self.wake_sent.swap(true, Ordering::SeqCst) {
+            let _ = self.wake_tx.try_send(());
+        }
+    }
+
     fn new(cx: &mut Context<Self>) -> Self {
         let data: Arc<Mutex<Option<UsageData>>> = Arc::new(Mutex::new(None));
         let data_for_task = data.clone();
+        let (wake_tx, wake_rx) = smol::channel::bounded::<()>(1);
+        let wake_sent = Arc::new(AtomicBool::new(false));
+        let wake_sent_for_task = wake_sent.clone();
+        let last_fetch_at: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
+        let last_fetch_at_for_task = last_fetch_at.clone();
 
         let poll_task = cx.spawn(async move |this: WeakEntity<Self>, cx| {
             let mut consecutive_failures: u32 = 0;
@@ -388,7 +422,9 @@ impl CodexUsageData {
 
                 if let Some(fetched) = result {
                     *data_for_task.lock() = Some(fetched);
+                    *last_fetch_at_for_task.lock() = Some(Instant::now());
                     consecutive_failures = 0;
+                    wake_sent_for_task.store(false, Ordering::SeqCst);
                     if this.update(cx, |_this, cx| cx.notify()).is_err() {
                         break;
                     }
@@ -406,12 +442,28 @@ impl CodexUsageData {
                 } else {
                     USAGE_INTERVAL
                 };
-                smol::Timer::after(delay).await;
+                // Race: sleep vs wake signal (e.g. when the popover opens and the
+                // data is stale). Don't reset consecutive_failures on wake — keep
+                // the backoff to avoid retry storms during failures.
+                smol::future::or(
+                    async {
+                        smol::Timer::after(delay).await;
+                    },
+                    async {
+                        let _ = wake_rx.recv().await;
+                    },
+                )
+                .await;
+                // Drain any extra wake signals.
+                while wake_rx.try_recv().is_ok() {}
             }
         });
 
         Self {
             data,
+            wake_tx,
+            wake_sent,
+            last_fetch_at,
             _poll_task: poll_task,
         }
     }
@@ -459,6 +511,7 @@ impl CodexUsage {
             let _ = this.update(cx, |this, cx| {
                 if hover_token.load(Ordering::SeqCst) == token {
                     this.popover_visible = true;
+                    this.data.read(cx).request_fresh_fetch();
                     cx.notify();
                 }
             });
@@ -504,6 +557,8 @@ impl CodexUsage {
             _ => return div().size_0().into_any_element(),
         };
 
+        let working = read_working_days(cx);
+        let plan = data.plan_type.clone();
         let bounds = self.trigger_bounds;
         let position = point(bounds.origin.x, bounds.origin.y - px(4.0));
 
@@ -513,17 +568,9 @@ impl CodexUsage {
                 .anchor(Anchor::BottomLeft)
                 .snap_to_window()
                 .child(
-                    div()
+                    usage_popover_container(t)
                         .id("codex-usage-popover")
                         .occlude()
-                        .min_w(px(280.0))
-                        .max_w(px(400.0))
-                        .bg(rgb(t.bg_primary))
-                        .border_1()
-                        .border_color(rgb(t.border))
-                        .rounded(px(6.0))
-                        .shadow_lg()
-                        .p(px(10.0))
                         .on_hover(cx.listener(|this, hovered: &bool, _window, cx| {
                             if *hovered {
                                 this.hover_token.fetch_add(1, Ordering::SeqCst);
@@ -534,84 +581,53 @@ impl CodexUsage {
                         .on_mouse_down(MouseButton::Left, |_, _, cx| {
                             cx.stop_propagation();
                         })
+                        .child(usage_popover_header(
+                            "CODEX USAGE",
+                            Some(plan.as_str()),
+                            "https://chatgpt.com",
+                            "Open usage settings on chatgpt.com",
+                            t,
+                            cx,
+                        ))
                         .child(
-                            v_flex()
-                                .gap(px(8.0))
-                                .child(
-                                    h_flex()
-                                        .justify_between()
-                                        .child(
-                                            div()
-                                                .text_size(ui_text_md(cx))
-                                                .font_weight(FontWeight::SEMIBOLD)
-                                                .text_color(rgb(t.text_primary))
-                                                .child("Codex Usage"),
-                                        )
-                                        .child(
-                                            div()
-                                                .text_size(ui_text_sm(cx))
-                                                .text_color(rgb(t.text_muted))
-                                                .child(data.plan_type.clone()),
-                                        ),
-                                )
+                            usage_body_container()
                                 .when_some(data.primary_window.as_ref(), |el, w| {
-                                    el.child(render_window_row(t, cx, "Rate Limit", w))
+                                    el.child(render_usage_row(
+                                        t,
+                                        cx,
+                                        &window_row("Rate Limit", w, "codex-marker-primary"),
+                                        working,
+                                    ))
                                 })
                                 .when_some(data.secondary_window.as_ref(), |el, w| {
-                                    el.child(render_window_row(t, cx, "Secondary", w))
+                                    el.child(render_usage_row(
+                                        t,
+                                        cx,
+                                        &window_row("Secondary", w, "codex-marker-secondary"),
+                                        working,
+                                    ))
                                 })
                                 .when_some(data.review_primary.as_ref(), |el, w| {
-                                    el.child(render_window_row(t, cx, "Code Review", w))
+                                    el.child(render_usage_row(
+                                        t,
+                                        cx,
+                                        &window_row("Code Review", w, "codex-marker-review"),
+                                        working,
+                                    ))
                                 })
-                                .when(
-                                    data.primary_window.as_ref().and_then(|w| w.time_elapsed_pct).is_some()
-                                        || data.secondary_window.as_ref().and_then(|w| w.time_elapsed_pct).is_some(),
-                                    |el| {
-                                        el.child(
-                                            div()
-                                                .text_size(ui_text_xs(cx))
-                                                .text_color(rgb(t.text_muted))
-                                                .child("Bar color = pace · Marker = time elapsed"),
-                                        )
-                                    },
-                                )
                                 .when_some(data.credits.as_ref(), |el, c| {
-                                    if c.unlimited {
-                                        el.child(
-                                            h_flex()
-                                                .justify_between()
-                                                .child(
-                                                    div()
-                                                        .text_size(ui_text_ms(cx))
-                                                        .text_color(rgb(t.text_secondary))
-                                                        .child("Credits"),
-                                                )
-                                                .child(
-                                                    div()
-                                                        .text_size(ui_text_ms(cx))
-                                                        .text_color(rgb(t.metric_normal))
-                                                        .child("Unlimited"),
-                                                ),
-                                        )
+                                    let value = if c.unlimited {
+                                        Some(("Unlimited".to_string(), t.metric_normal))
                                     } else if c.has_credits {
-                                        el.child(
-                                            h_flex()
-                                                .justify_between()
-                                                .child(
-                                                    div()
-                                                        .text_size(ui_text_ms(cx))
-                                                        .text_color(rgb(t.text_secondary))
-                                                        .child("Credits"),
-                                                )
-                                                .child(
-                                                    div()
-                                                        .text_size(ui_text_ms(cx))
-                                                        .text_color(rgb(t.text_primary))
-                                                        .child(format!("${:.2}", c.balance)),
-                                                ),
-                                        )
+                                        Some((format!("${:.2}", c.balance), t.text_primary))
                                     } else {
-                                        el
+                                        None
+                                    };
+                                    match value {
+                                        Some((text, color)) => el
+                                            .child(usage_divider(t))
+                                            .child(usage_kv_row(t, cx, "Credits", text, color)),
+                                        None => el,
                                     }
                                 }),
                         ),
@@ -620,53 +636,6 @@ impl CodexUsage {
         .with_priority(1)
         .into_any_element()
     }
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum Severity {
-    Normal,
-    Warning,
-    Critical,
-}
-
-fn severity_color(t: &ThemeColors, s: Severity) -> u32 {
-    match s {
-        Severity::Normal => t.metric_normal,
-        Severity::Warning => t.metric_warning,
-        Severity::Critical => t.metric_critical,
-    }
-}
-
-/// Severity from absolute utilization — how close to the hard cap.
-fn abs_severity(pct: u64) -> Severity {
-    if pct > 80 {
-        Severity::Critical
-    } else if pct > 60 {
-        Severity::Warning
-    } else {
-        Severity::Normal
-    }
-}
-
-/// Severity from pace — how far ahead usage is of where it "should" be at this
-/// point in the period. `Critical` means the user is burning budget fast enough
-/// to run out before the period resets unless they slow down.
-fn pace_severity(usage_pct: u64, time_pct: Option<f64>) -> Severity {
-    match time_pct {
-        Some(tp) if (usage_pct as f64) > tp + 15.0 => Severity::Critical,
-        Some(tp) if (usage_pct as f64) > tp + 5.0 => Severity::Warning,
-        _ => Severity::Normal,
-    }
-}
-
-fn utilization_color(t: &ThemeColors, pct: u64) -> u32 {
-    severity_color(t, abs_severity(pct))
-}
-
-#[derive(Clone, Copy)]
-enum SegmentUnit {
-    Hour,
-    Day,
 }
 
 /// Pick the grid granularity for a window: per-hour up to a day, per-day for
@@ -679,78 +648,6 @@ fn segment_unit_for_window(window_seconds: u64) -> Option<SegmentUnit> {
     }
 }
 
-/// Compute reset-anchored grid boundaries for a usage bar, plus the block that
-/// currently contains "now".
-///
-/// Boundaries land on the user's *actual* reset time-of-day — e.g. a Sunday
-/// 12:00 weekly reset yields noon-to-noon day blocks — computed with calendar
-/// arithmetic so they stay correct across DST and for any reset time, rather
-/// than just evenly dividing the bar. Returns the divider fractions (0..1,
-/// excluding the ends) and the (start, end) fractions of the current block.
-fn reset_aligned_segments(
-    reset_at: u64,
-    period_secs: f64,
-    unit: SegmentUnit,
-) -> (Vec<f32>, Option<(f32, f32)>) {
-    if reset_at == 0 || period_secs <= 0.0 {
-        return (Vec::new(), None);
-    }
-    let reset = match jiff::Timestamp::from_second(reset_at as i64) {
-        Ok(ts) => ts.to_zoned(jiff::tz::TimeZone::system()),
-        Err(_) => return (Vec::new(), None),
-    };
-    let reset_epoch = reset_at as f64;
-    let start_epoch = reset_epoch - period_secs;
-    let now_epoch = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs_f64())
-        .unwrap_or(start_epoch);
-
-    // Keep the grid legible on a thin bar: if a window spans more units than
-    // this, step by a whole multiple (e.g. every 2 days), which is still
-    // anchored to the reset time-of-day.
-    let (unit_secs, max_blocks) = match unit {
-        SegmentUnit::Hour => (3_600.0, 12.0),
-        SegmentUnit::Day => (86_400.0, 14.0),
-    };
-    let units = (period_secs / unit_secs).round().max(1.0);
-    let multiplier = (units / max_blocks).ceil().max(1.0) as i64;
-    let step = match unit {
-        SegmentUnit::Hour => jiff::Span::new().hours(multiplier),
-        SegmentUnit::Day => jiff::Span::new().days(multiplier),
-    };
-
-    // Walk back from the reset, one block at a time, until the window start is
-    // covered. `bounds` ends up holding boundary epochs in ascending order.
-    let mut bounds = vec![reset_epoch];
-    let mut cursor = reset;
-    for _ in 0..64 {
-        cursor = match cursor.checked_sub(step) {
-            Ok(z) => z,
-            Err(_) => break,
-        };
-        let epoch = cursor.timestamp().as_millisecond() as f64 / 1_000.0;
-        bounds.push(epoch);
-        if epoch <= start_epoch {
-            break;
-        }
-    }
-    bounds.reverse();
-
-    let frac = |epoch: f64| ((epoch - start_epoch) / period_secs) as f32;
-    let dividers = bounds
-        .iter()
-        .map(|&epoch| frac(epoch))
-        .filter(|&f| f > 0.001 && f < 0.999)
-        .collect();
-    let current = bounds.windows(2).find_map(|w| {
-        (now_epoch >= w[0] && now_epoch < w[1])
-            .then(|| (frac(w[0]).max(0.0), frac(w[1]).min(1.0)))
-    });
-
-    (dividers, current)
-}
-
 fn format_window_label(window_seconds: u64) -> &'static str {
     match window_seconds {
         0..=3600 => "1h",
@@ -761,213 +658,51 @@ fn format_window_label(window_seconds: u64) -> &'static str {
     }
 }
 
-fn format_reset_time(reset_at: u64) -> String {
-    if reset_at == 0 {
-        return String::new();
+/// Build a shared [`UsageRow`] from a Codex rate-limit window.
+fn window_row(label: &str, window: &RateLimitWindow, marker_id: &'static str) -> UsageRow {
+    let unit = segment_unit_for_window(window.window_seconds);
+    let reset_epoch = (window.reset_at > 0).then(|| window.reset_at as f64);
+    UsageRow {
+        label: label.into(),
+        period: format_window_label(window.window_seconds).into(),
+        pct: window.used_percent as f64,
+        time_pct: window.time_elapsed_pct,
+        reset_epoch,
+        period_secs: window.window_seconds as f64,
+        unit,
+        marker_id: marker_id.into(),
     }
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    if reset_at <= now {
-        return "now".to_string();
-    }
-    let remaining = reset_at - now;
-    let hours = remaining / 3600;
-    let minutes = (remaining % 3600) / 60;
-    if hours > 24 {
-        let days = hours / 24;
-        format!("{}d {}h", days, hours % 24)
-    } else if hours > 0 {
-        format!("{}h {}m", hours, minutes)
-    } else {
-        format!("{}m", minutes)
-    }
-}
-
-fn render_window_row(
-    t: &ThemeColors,
-    cx: &App,
-    label: &str,
-    window: &RateLimitWindow,
-) -> impl IntoElement {
-    let pct = window.used_percent;
-    let window_label = format_window_label(window.window_seconds);
-    let reset = format_reset_time(window.reset_at);
-    let pace = pace_severity(pct, window.time_elapsed_pct);
-    // % text reflects whichever is worse: nearness to the cap, or burn pace.
-    let pct_color = severity_color(t, abs_severity(pct).max(pace));
-    let pace_msg: Option<(&str, u32)> = match pace {
-        Severity::Critical => Some(("Slow down to last the period", t.metric_critical)),
-        Severity::Warning => Some(("Ahead of pace", t.metric_warning)),
-        Severity::Normal => None,
-    };
-
-    v_flex()
-        .gap(px(2.0))
-        .child(
-            h_flex()
-                .justify_between()
-                .child(
-                    div()
-                        .text_size(ui_text_ms(cx))
-                        .text_color(rgb(t.text_secondary))
-                        .child(format!("{} ({})", label, window_label)),
-                )
-                .child(
-                    h_flex()
-                        .gap(px(6.0))
-                        .child(
-                            div()
-                                .text_size(ui_text_ms(cx))
-                                .text_color(rgb(pct_color))
-                                .child(format!("{}%", pct)),
-                        )
-                        .when(!reset.is_empty(), |el| {
-                            el.child(
-                                div()
-                                    .text_size(ui_text_sm(cx))
-                                    .text_color(rgb(t.text_muted))
-                                    .child(format!("resets in {}", reset)),
-                            )
-                        }),
-                ),
-        )
-        .child({
-            let (dividers, current_seg) = segment_unit_for_window(window.window_seconds)
-                .map(|unit| {
-                    reset_aligned_segments(
-                        window.reset_at,
-                        window.window_seconds as f64,
-                        unit,
-                    )
-                })
-                .unwrap_or_default();
-            render_usage_with_time_bar(t, pct, window.time_elapsed_pct, dividers, current_seg)
-        })
-        .when_some(pace_msg, |el, (msg, col)| {
-            el.child(
-                div()
-                    .text_size(ui_text_sm(cx))
-                    .font_weight(FontWeight::MEDIUM)
-                    .text_color(rgb(col))
-                    .child(msg),
-            )
-        })
-}
-
-fn render_usage_with_time_bar(
-    t: &ThemeColors,
-    usage_pct: u64,
-    time_pct: Option<f64>,
-    dividers: Vec<f32>,
-    current_seg: Option<(f32, f32)>,
-) -> impl IntoElement {
-    let clamped_usage = (usage_pct as f32).clamp(0.0, 100.0);
-
-    // Base fill reflects nearness to the hard cap. Any usage *beyond* the pace
-    // marker is overage — drawn on top in warning/critical — so being over the
-    // budget for this point in the period is visible directly on the bar.
-    let base_color = severity_color(t, abs_severity(usage_pct));
-    let overage = time_pct.and_then(|tp| {
-        let start = tp.clamp(0.0, 100.0) as f32;
-        let width = clamped_usage - start;
-        if width <= 0.0 {
-            return None;
-        }
-        let color = if width > 15.0 {
-            t.metric_critical
-        } else {
-            t.metric_warning
-        };
-        Some((start, width, color))
-    });
-
-    // Divider lines at the reset-anchored day/hour boundaries, so the pace
-    // marker can be read against a real time grid.
-    let divider_els = dividers.into_iter().map(move |f| {
-        div()
-            .absolute()
-            .top_0()
-            .h_full()
-            .w(px(1.0))
-            .bg(rgb(t.border))
-            .left(relative(f))
-    });
-
-    // Translucent band over the block the user is currently in (today / this
-    // hour). Derived from text_primary so it adapts to light and dark themes.
-    let mut highlight = rgb(t.text_primary);
-    highlight.a = 0.14;
-
-    div()
-        .h(px(4.0))
-        .w_full()
-        .rounded(px(2.0))
-        .bg(rgb(t.bg_secondary))
-        .relative()
-        .child(
-            div()
-                .h_full()
-                .rounded(px(2.0))
-                .bg(rgb(base_color))
-                .w(relative(clamped_usage / 100.0)),
-        )
-        .when_some(overage, |el, (start, width, color)| {
-            el.child(
-                div()
-                    .absolute()
-                    .top_0()
-                    .h_full()
-                    .left(relative(start / 100.0))
-                    .w(relative(width / 100.0))
-                    .rounded_r(px(2.0))
-                    .bg(rgb(color)),
-            )
-        })
-        .children(divider_els)
-        .when_some(current_seg, |el, (start, end)| {
-            el.child(
-                div()
-                    .absolute()
-                    .top_0()
-                    .h_full()
-                    .left(relative(start))
-                    .w(relative((end - start).max(0.0)))
-                    .bg(highlight),
-            )
-        })
-        .when_some(time_pct, |el, tp| {
-            let clamped_time = tp.clamp(0.0, 100.0) as f32;
-            el.child(
-                div()
-                    .absolute()
-                    .top(px(-1.0))
-                    .left(relative(clamped_time / 100.0))
-                    .w(px(1.5))
-                    .h(px(6.0))
-                    .rounded(px(1.0))
-                    .bg(rgb(t.text_primary)),
-            )
-        })
 }
 
 impl Render for CodexUsage {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let t = theme(cx);
 
+        let working = read_working_days(cx);
         let data = self.data.read(cx).data.lock();
-        let (primary, secondary) = match data.as_ref() {
-            Some(d) => (
-                d.primary_window
-                    .as_ref()
-                    .map(|w| (w.used_percent, w.window_seconds)),
-                d.secondary_window
-                    .as_ref()
-                    .map(|w| (w.used_percent, w.window_seconds)),
-            ),
+        let mut items: Vec<(SharedString, f64, Option<f64>)> = Vec::new();
+        match data.as_ref() {
+            Some(d) => {
+                for w in [d.primary_window.as_ref(), d.secondary_window.as_ref()]
+                    .into_iter()
+                    .flatten()
+                {
+                    let et = effective_time_pct(
+                        (w.reset_at > 0).then(|| w.reset_at as f64),
+                        w.window_seconds as f64,
+                        segment_unit_for_window(w.window_seconds),
+                        working,
+                        w.time_elapsed_pct,
+                    );
+                    items.push((
+                        format_window_label(w.window_seconds).into(),
+                        w.used_percent as f64,
+                        et,
+                    ));
+                }
+            }
             None => return div().size_0().into_any_element(),
-        };
+        }
         drop(data);
 
         let entity_handle = cx.entity().clone();
@@ -977,53 +712,12 @@ impl Render for CodexUsage {
                 h_flex()
                     .id("codex-usage-trigger")
                     .cursor_pointer()
-                    .gap(px(3.0))
+                    .gap(px(4.0))
                     .px(px(4.0))
                     .py(px(1.0))
                     .rounded(px(3.0))
                     .hover(|s| s.bg(rgb(t.bg_hover)))
-                    .when_some(primary, |el, (pct, window_secs)| {
-                        el.child(
-                            h_flex()
-                                .gap(px(3.0))
-                                .child(
-                                    div()
-                                        .text_size(ui_text_ms(cx))
-                                        .text_color(rgb(t.text_muted))
-                                        .child(format_window_label(window_secs)),
-                                )
-                                .child(
-                                    div()
-                                        .text_size(ui_text_ms(cx))
-                                        .text_color(rgb(utilization_color(&t, pct)))
-                                        .child(format!("{}%", pct)),
-                                ),
-                        )
-                    })
-                    .when_some(secondary, |el, (pct, window_secs)| {
-                        el.child(
-                            div()
-                                .text_size(ui_text_ms(cx))
-                                .text_color(rgb(t.text_muted))
-                                .child("|"),
-                        )
-                        .child(
-                            h_flex()
-                                .gap(px(3.0))
-                                .child(
-                                    div()
-                                        .text_size(ui_text_ms(cx))
-                                        .text_color(rgb(t.text_muted))
-                                        .child(format_window_label(window_secs)),
-                                )
-                                .child(
-                                    div()
-                                        .text_size(ui_text_ms(cx))
-                                        .text_color(rgb(utilization_color(&t, pct)))
-                                        .child(format!("{}%", pct)),
-                                ),
-                        )
-                    })
+                    .children(usage_trigger_items(&t, cx, &items))
                     .child(
                         canvas(
                             move |bounds, _window, app| {
@@ -1076,33 +770,4 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_reset_aligned_segments_guards() {
-        // No reset / no window → no grid.
-        assert_eq!(
-            reset_aligned_segments(0, 7.0 * 86400.0, SegmentUnit::Day),
-            (Vec::new(), None)
-        );
-        assert_eq!(
-            reset_aligned_segments(1_700_000_000, 0.0, SegmentUnit::Day),
-            (Vec::new(), None)
-        );
-    }
-
-    #[test]
-    fn test_reset_aligned_segments_weekly() {
-        // A 7-day window yields ~6 internal day boundaries, all strictly inside
-        // the bar and in ascending order. (Exact count can vary by ±1 around a
-        // DST transition; the range stays small.)
-        let period = 7.0 * 86400.0;
-        let (dividers, _current) =
-            reset_aligned_segments(1_700_000_000, period, SegmentUnit::Day);
-        assert!(
-            (5..=7).contains(&dividers.len()),
-            "expected ~6 dividers, got {}",
-            dividers.len()
-        );
-        assert!(dividers.iter().all(|&f| f > 0.0 && f < 1.0));
-        assert!(dividers.windows(2).all(|w| w[0] < w[1]));
-    }
 }

--- a/crates/okena-usage/Cargo.toml
+++ b/crates/okena-usage/Cargo.toml
@@ -1,23 +1,14 @@
 [package]
-name = "okena-ext-claude"
+name = "okena-usage"
 version = "0.1.0"
 edition = "2024"
 license = "MIT"
 
 [dependencies]
-okena-core = { path = "../okena-core", features = ["blocking-http"] }
-okena-extensions = { path = "../okena-extensions" }
+okena-core = { path = "../okena-core" }
 okena-ui = { path = "../okena-ui" }
-okena-usage = { path = "../okena-usage" }
+okena-extensions = { path = "../okena-extensions" }
 gpui = { git = "https://github.com/zed-industries/zed", package = "gpui" }
 gpui-component = { git = "https://github.com/longbridge/gpui-component", package = "gpui-component" }
 serde_json = "1.0"
-smol = "2.0"
-parking_lot = "0.12"
-dirs = "5.0"
-log = "0.4"
 jiff = "0.2"
-sha2 = "0.10"
-
-[dev-dependencies]
-tempfile = "3"

--- a/crates/okena-usage/src/lib.rs
+++ b/crates/okena-usage/src/lib.rs
@@ -221,20 +221,23 @@ pub fn reset_aligned_segments(
         && working.count() >= 1
         && !working.is_all()
         && (2..=8).contains(&day_units);
+    // If no working day lands in the window, `working_day_reshape` returns
+    // `None` and we fall through to the plain grid below.
+    if remap
+        && let Some(seg) = working_day_reshape(start_epoch, reset_epoch, working, now_epoch)
+    {
+        return seg;
+    }
 
     // Keep the grid legible on a thin bar: if a window spans more units than
     // this, step by a whole multiple (e.g. every 2 days), still anchored to the
-    // reset time-of-day. Reshaped grids always step one day at a time.
+    // reset time-of-day.
     let (unit_secs, max_blocks) = match unit {
         SegmentUnit::Hour => (3_600.0, 12.0),
         SegmentUnit::Day => (86_400.0, 14.0),
     };
     let units = (period_secs / unit_secs).round().max(1.0);
-    let multiplier = if remap {
-        1
-    } else {
-        (units / max_blocks).ceil().max(1.0) as i64
-    };
+    let multiplier = (units / max_blocks).ceil().max(1.0) as i64;
     let step = match unit {
         SegmentUnit::Hour => jiff::Span::new().hours(multiplier),
         SegmentUnit::Day => jiff::Span::new().days(multiplier),
@@ -258,83 +261,106 @@ pub fn reset_aligned_segments(
     bounds.reverse();
 
     let frac = |epoch: f64| ((epoch - start_epoch) / period_secs) as f32;
-
-    if !remap {
-        let dividers = bounds
-            .iter()
-            .map(|z| frac(epoch_of(z)))
-            .filter(|&f| f > 0.001 && f < 0.999)
-            .collect();
-        let epochs: Vec<f64> = bounds.iter().map(epoch_of).collect();
-        let current = epochs.windows(2).find_map(|w| {
-            (now_epoch >= w[0] && now_epoch < w[1])
-                .then(|| (frac(w[0]).max(0.0), frac(w[1]).min(1.0)))
-        });
-        return Segments {
-            dividers,
-            current,
-            time_pct: None,
-        };
-    }
-
-    // Reshape: each calendar block becomes (start, end, is_working) labelled by
-    // its start weekday, then working blocks are laid out as equal segments.
-    let blocks: Vec<(f64, f64, bool)> = bounds
-        .windows(2)
-        .map(|w| {
-            let start = epoch_of(&w[0]);
-            let end = epoch_of(&w[1]);
-            let weekday = w[0].weekday().to_monday_zero_offset() as usize % 7;
-            (start, end, working.days[weekday])
-        })
+    let dividers = bounds
+        .iter()
+        .map(|z| frac(epoch_of(z)))
+        .filter(|&f| f > 0.001 && f < 0.999)
         .collect();
-
-    let n = blocks.iter().filter(|(_, _, w)| *w).count();
-    if n == 0 {
-        // No working day fell inside this window (only possible for an odd
-        // partial window). Fall back to the plain calendar grid.
-        let dividers = bounds
-            .iter()
-            .map(|z| frac(epoch_of(z)))
-            .filter(|&f| f > 0.001 && f < 0.999)
-            .collect();
-        return Segments {
-            dividers,
-            current: None,
-            time_pct: None,
-        };
-    }
-
-    let seg_w = 1.0_f32 / n as f32;
-    let mut dividers = Vec::new();
-    let mut current = None;
-    let mut elapsed_working = 0.0_f64; // working time elapsed, in units of blocks (0..=n)
-    let mut wi = 0_usize; // index among working blocks
-    for &(start, end, is_work) in &blocks {
-        if !is_work {
-            continue;
-        }
-        let seg_start = wi as f32 * seg_w;
-        let seg_end = (wi + 1) as f32 * seg_w;
-        if wi > 0 {
-            dividers.push(seg_start);
-        }
-        if now_epoch >= start && now_epoch < end {
-            current = Some((seg_start, seg_end));
-            let frac_in = ((now_epoch - start) / (end - start)).clamp(0.0, 1.0);
-            elapsed_working = wi as f64 + frac_in;
-        } else if now_epoch >= end {
-            elapsed_working = (wi + 1) as f64;
-        }
-        wi += 1;
-    }
-    let time_pct = (elapsed_working / n as f64 * 100.0).clamp(0.0, 100.0);
-
+    let epochs: Vec<f64> = bounds.iter().map(epoch_of).collect();
+    let current = epochs.windows(2).find_map(|w| {
+        (now_epoch >= w[0] && now_epoch < w[1])
+            .then(|| (frac(w[0]).max(0.0), frac(w[1]).min(1.0)))
+    });
     Segments {
         dividers,
         current,
-        time_pct: Some(time_pct),
+        time_pct: None,
     }
+}
+
+/// Reshape a ~weekly window to one equal block per **working calendar day**.
+///
+/// Blocks are keyed by calendar date (local midnight to midnight), not by the
+/// reset time-of-day, so "today" always maps to today's block. With a reset at,
+/// say, 13:00, a reset-anchored grid would put Thursday morning in the block
+/// that *started* Wednesday — one block too early. Keying by date fixes that.
+///
+/// The window's two partial edge days together cover one weekday; we keep
+/// whichever of them has more coverage, leaving exactly one date per weekday.
+/// Working days are then laid out as equal segments in chronological order, and
+/// the pace marker advances across working days only (frozen on off-days).
+/// Returns `None` if no working day falls in the window (caller uses the plain
+/// grid instead).
+fn working_day_reshape(
+    start_epoch: f64,
+    reset_epoch: f64,
+    working: WorkingDays,
+    now_epoch: f64,
+) -> Option<Segments> {
+    let tz = jiff::tz::TimeZone::system();
+    let start_date = epoch_to_local(start_epoch)?.date();
+    let end_date = epoch_to_local(reset_epoch)?.date();
+
+    // For each weekday keep the in-window calendar date with the most coverage,
+    // so the two partial edge days collapse to a single weekday.
+    let mut best: [Option<(jiff::civil::Date, f64)>; 7] = [None; 7];
+    let mut d = start_date;
+    for _ in 0..10 {
+        let day_start = epoch_of(&d.to_zoned(tz.clone()).ok()?);
+        let next = d.tomorrow().ok()?;
+        let day_end = epoch_of(&next.to_zoned(tz.clone()).ok()?);
+        let overlap = day_end.min(reset_epoch) - day_start.max(start_epoch);
+        if overlap > 0.0 {
+            let wd = (d.weekday().to_monday_zero_offset() as usize) % 7;
+            if best[wd].is_none_or(|(_, ov)| overlap > ov) {
+                best[wd] = Some((d, overlap));
+            }
+        }
+        if d == end_date {
+            break;
+        }
+        d = next;
+    }
+
+    // The working calendar dates, chronological.
+    let mut dates: Vec<jiff::civil::Date> = (0..7)
+        .filter(|&wd| working.days[wd])
+        .filter_map(|wd| best[wd].map(|(date, _)| date))
+        .collect();
+    dates.sort();
+    let n = dates.len();
+    if n == 0 {
+        return None;
+    }
+
+    let seg_w = 1.0_f32 / n as f32;
+    let dividers: Vec<f32> = (1..n).map(|k| k as f32 * seg_w).collect();
+
+    // Place the marker by where today sits among the working dates.
+    let today = epoch_to_local(now_epoch)?.date();
+    let (current, time_pct) = if let Some(k) = dates.iter().position(|&dt| dt == today) {
+        let midnight = today
+            .to_zoned(tz.clone())
+            .ok()
+            .map(|z| epoch_of(&z))
+            .unwrap_or(now_epoch);
+        let frac = (((now_epoch - midnight) / 86_400.0).clamp(0.0, 1.0)) as f32;
+        let seg_start = k as f32 * seg_w;
+        let tp = ((k as f32 + frac) / n as f32 * 100.0).clamp(0.0, 100.0) as f64;
+        (Some((seg_start, seg_start + seg_w)), tp)
+    } else {
+        // Off-day (or outside the window): sit on the boundary after the last
+        // elapsed working day; no current-block highlight.
+        let elapsed = dates.iter().filter(|&&dt| dt < today).count();
+        let tp = (elapsed as f64 / n as f64 * 100.0).clamp(0.0, 100.0);
+        (None, tp)
+    };
+
+    Some(Segments {
+        dividers,
+        current,
+        time_pct: Some(time_pct),
+    })
 }
 
 /// The time-elapsed fraction a row will actually use: the working-day-reshaped
@@ -622,6 +648,28 @@ pub fn render_usage_row(
         })
 }
 
+/// A divider color that contrasts with whatever background sits *behind* it:
+/// a translucent dark line over a light/bright fill, a translucent light line
+/// over a dark fill or the dark empty track. Picked per-divider from the
+/// background's luminance so the grid stays visible on any theme — a single
+/// fixed color can't, since a dark cut vanishes on a dark track while a light
+/// line vanishes on a pale fill (e.g. the `neumie-contrast` gray/tan fills).
+fn divider_overlay(bg_hex: u32) -> Rgba {
+    let (r, g, b) = ThemeColors::hex_to_rgb(bg_hex);
+    let luminance = 0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32;
+    if luminance < 128.0 {
+        // Dark background → a translucent white line.
+        let mut c = rgb(0xffffff);
+        c.a = 0.6;
+        c
+    } else {
+        // Light/bright background → a translucent black line.
+        let mut c = rgb(0x000000);
+        c.a = 0.5;
+        c
+    }
+}
+
 /// The 6px usage bar: base fill (nearness to cap), overage band (usage beyond
 /// the pace marker), the reset-anchored day/hour grid, the current-block
 /// highlight, and the time-elapsed marker.
@@ -650,18 +698,34 @@ pub fn render_usage_bar(
         Some((start, width, color))
     });
 
-    // Dividers cut the bar down to the popover background, so they read as
-    // notches that stay visible over any fill color (yellow/green/red) as well
-    // as the empty track — unlike a subtle border line, which disappears on a
-    // light fill.
-    let divider_color = t.bg_primary;
+    // Each divider takes a dark or light overlay depending on what's behind it
+    // at that point — the fill (base or, within the overage band, the overage
+    // color) where the bar is filled, otherwise the empty track. This keeps the
+    // grid visible across both the colored fill and the (often dominant) empty
+    // track on every theme. See [`divider_overlay`].
+    let usage_frac = clamped_usage / 100.0;
+    let track_hex = t.bg_secondary;
+    let fill_hex = base_color;
+    let overage_for_dividers = overage;
     let divider_els = seg.dividers.clone().into_iter().map(move |f| {
+        let behind = if f > usage_frac {
+            track_hex
+        } else if let Some((ostart, owidth, ocolor)) = overage_for_dividers {
+            let pct = f * 100.0;
+            if pct >= ostart && pct <= ostart + owidth {
+                ocolor
+            } else {
+                fill_hex
+            }
+        } else {
+            fill_hex
+        };
         div()
             .absolute()
             .top_0()
             .h_full()
             .w(px(1.5))
-            .bg(rgb(divider_color))
+            .bg(divider_overlay(behind))
             .left(relative(f))
     });
 
@@ -986,6 +1050,46 @@ mod tests {
     }
 
     #[test]
+    fn reshape_marker_tracks_calendar_day_not_reset_time() {
+        // Weekly window resetting Sat 2026-06-20 11:00Z, Mon–Fri working.
+        // "Now" is Thursday 2026-06-18 09:00Z. Thursday is the 4th of 5 working
+        // days, so the marker must land in the 4th block (second-to-last),
+        // *not* the 3rd — the reset is at 11:00/13:00 local, but blocks key off
+        // the calendar date, not the reset time-of-day.
+        let reset = 1_781_953_200.0_f64; // 2026-06-20T11:00:00Z (Sat)
+        let now = 1_781_773_200.0_f64; // 2026-06-18T09:00:00Z (Thu)
+        let start = reset - 7.0 * 86_400.0;
+        let mon_fri = WorkingDays {
+            days: [true, true, true, true, true, false, false],
+        };
+        let seg = working_day_reshape(start, reset, mon_fri, now).expect("reshape");
+        assert_eq!(seg.dividers, vec![0.2, 0.4, 0.6, 0.8], "5 equal blocks");
+        let (cs, ce) = seg.current.expect("Thursday is a working day → highlighted");
+        assert!(
+            (cs - 0.6).abs() < 1e-4 && (ce - 0.8).abs() < 1e-4,
+            "Thursday must be the 4th block, got ({cs}, {ce})"
+        );
+        let tp = seg.time_pct.expect("working pace");
+        assert!((60.0..80.0).contains(&tp), "marker mid-Thursday, got {tp}");
+    }
+
+    #[test]
+    fn reshape_off_day_pegs_to_boundary() {
+        // Same window, but "now" is Saturday 2026-06-20 09:00Z (an off-day,
+        // after the whole Mon–Fri week): the marker pegs to 100% with no
+        // current-block highlight.
+        let reset = 1_781_953_200.0_f64;
+        let now = 1_781_946_000.0_f64; // 2026-06-20T09:00:00Z (Sat)
+        let start = reset - 7.0 * 86_400.0;
+        let mon_fri = WorkingDays {
+            days: [true, true, true, true, true, false, false],
+        };
+        let seg = working_day_reshape(start, reset, mon_fri, now).expect("reshape");
+        assert!(seg.current.is_none(), "off-day → no highlight");
+        assert_eq!(seg.time_pct, Some(100.0), "all 5 working days elapsed");
+    }
+
+    #[test]
     fn hour_window_never_reshapes() {
         let mon_fri = WorkingDays {
             days: [true, true, true, true, true, false, false],
@@ -1011,6 +1115,19 @@ mod tests {
         let on_pace = abs_severity(65.0).max(pace_severity(65.0, Some(64.0)));
         assert_eq!(ahead, Severity::Critical, "over-pace 65% must be critical");
         assert_eq!(on_pace, Severity::Warning, "on-pace 65% stays warning");
+    }
+
+    #[test]
+    fn divider_overlay_contrasts_background() {
+        // Dark track (neumie-contrast bg_secondary) → light line.
+        let on_dark = divider_overlay(0x252526);
+        assert!(on_dark.r > 0.5 && on_dark.a > 0.0, "dark bg → light divider");
+        // Pale fill (neumie-contrast metric_normal/warning) → dark line.
+        let on_pale = divider_overlay(0xa0a0a0);
+        assert!(on_pale.r < 0.5 && on_pale.a > 0.0, "light bg → dark divider");
+        // Bright yellow fill → still a dark line (the earlier complaint).
+        let on_yellow = divider_overlay(0xe5e510);
+        assert!(on_yellow.r < 0.5, "bright bg → dark divider");
     }
 
     #[test]

--- a/crates/okena-usage/src/lib.rs
+++ b/crates/okena-usage/src/lib.rs
@@ -1,0 +1,1028 @@
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
+
+//! Shared usage-bar UI and logic for the Claude and Codex usage widgets.
+//!
+//! Both extensions render an identical popover (a header bar, one row per
+//! rate-limit window, an optional extra/credits row) over the same primitives
+//! defined here, so the two widgets cannot drift apart. The crate also owns
+//! the **working-days** feature: a shared user preference that tailors the
+//! multi-day (weekly) bar to the days the user actually works.
+
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+use gpui_component::tooltip::Tooltip;
+use gpui_component::{h_flex, v_flex};
+use okena_extensions::ExtensionSettingsStore;
+use okena_ui::settings::{section_container, section_header};
+use okena_ui::theme::ThemeColors;
+use okena_ui::tokens::{ui_text_md, ui_text_ms, ui_text_sm, ui_text_xs};
+
+// ============================================================================
+// Severity
+// ============================================================================
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum Severity {
+    Normal,
+    Warning,
+    Critical,
+}
+
+pub fn severity_color(t: &ThemeColors, s: Severity) -> u32 {
+    match s {
+        Severity::Normal => t.metric_normal,
+        Severity::Warning => t.metric_warning,
+        Severity::Critical => t.metric_critical,
+    }
+}
+
+/// Severity from absolute utilization — how close to the hard cap.
+pub fn abs_severity(pct: f64) -> Severity {
+    if pct > 80.0 {
+        Severity::Critical
+    } else if pct > 60.0 {
+        Severity::Warning
+    } else {
+        Severity::Normal
+    }
+}
+
+/// Severity from pace — how far ahead usage is of where it "should" be at this
+/// point in the period. `Critical` means the user is burning budget fast enough
+/// to run out before the period resets unless they slow down.
+pub fn pace_severity(usage_pct: f64, time_pct: Option<f64>) -> Severity {
+    match time_pct {
+        Some(tp) if usage_pct > tp + 15.0 => Severity::Critical,
+        Some(tp) if usage_pct > tp + 5.0 => Severity::Warning,
+        _ => Severity::Normal,
+    }
+}
+
+pub fn utilization_color(t: &ThemeColors, pct: f64) -> u32 {
+    severity_color(t, abs_severity(pct))
+}
+
+/// The headline color for a metric: the worse of nearness-to-cap and burn
+/// pace. The popover percentage and the status-bar trigger both use this, so
+/// they always show the same color for the same metric.
+pub fn headline_color(t: &ThemeColors, pct: f64, time_pct: Option<f64>) -> u32 {
+    severity_color(t, abs_severity(pct).max(pace_severity(pct, time_pct)))
+}
+
+// ============================================================================
+// Working days (shared setting)
+// ============================================================================
+
+/// Settings namespace for the shared usage preferences blob. Stored in the
+/// generic `extension_settings` map (not tied to one extension) so both the
+/// Claude and Codex widgets read the same value.
+pub const USAGE_SETTINGS_KEY: &str = "usage";
+
+/// The days of the week the user works, indexed `0 = Monday .. 6 = Sunday`.
+///
+/// Default (and the "I work every day" selection) is all seven days, which
+/// reproduces the original behavior — the bar is not reshaped.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct WorkingDays {
+    pub days: [bool; 7],
+}
+
+impl WorkingDays {
+    pub fn all() -> Self {
+        Self { days: [true; 7] }
+    }
+
+    pub fn count(&self) -> usize {
+        self.days.iter().filter(|&&d| d).count()
+    }
+
+    pub fn is_all(&self) -> bool {
+        self.days.iter().all(|&d| d)
+    }
+
+    /// Parse from the persisted `{"working_days": [..]}` blob. An absent or
+    /// empty list means "every day" (no tailoring).
+    pub fn from_value(v: Option<&serde_json::Value>) -> Self {
+        match v
+            .and_then(|v| v.get("working_days"))
+            .and_then(|a| a.as_array())
+        {
+            Some(arr) if !arr.is_empty() => {
+                let mut days = [false; 7];
+                for x in arr {
+                    if let Some(i) = x.as_u64()
+                        && (i as usize) < 7
+                    {
+                        days[i as usize] = true;
+                    }
+                }
+                // A list that parsed to nothing valid falls back to all days.
+                if days.iter().any(|&d| d) {
+                    Self { days }
+                } else {
+                    Self::all()
+                }
+            }
+            _ => Self::all(),
+        }
+    }
+
+    pub fn to_value(&self) -> serde_json::Value {
+        let idx: Vec<u64> = (0..7).filter(|&i| self.days[i]).map(|i| i as u64).collect();
+        serde_json::json!({ "working_days": idx })
+    }
+}
+
+/// Read the shared working-days preference (defaults to all days).
+pub fn read_working_days(cx: &App) -> WorkingDays {
+    let value = cx
+        .try_global::<ExtensionSettingsStore>()
+        .and_then(|store| store.get(USAGE_SETTINGS_KEY, cx));
+    WorkingDays::from_value(value.as_ref())
+}
+
+/// Persist the shared working-days preference.
+pub fn write_working_days(days: WorkingDays, cx: &mut App) {
+    ExtensionSettingsStore::update(USAGE_SETTINGS_KEY, days.to_value(), cx);
+}
+
+// ============================================================================
+// Reset-anchored grid + working-day reshaping
+// ============================================================================
+
+#[derive(Clone, Copy)]
+pub enum SegmentUnit {
+    Hour,
+    Day,
+}
+
+/// Grid geometry for a usage bar.
+#[derive(Clone, Default)]
+pub struct Segments {
+    /// Divider fractions in `(0, 1)`, excluding the ends.
+    pub dividers: Vec<f32>,
+    /// `(start, end)` fractions of the block that currently contains "now".
+    pub current: Option<(f32, f32)>,
+    /// When working-day reshaping is active, the time-elapsed fraction (0–100)
+    /// recomputed on *working* time. `None` → the caller's own linear value is
+    /// used instead.
+    pub time_pct: Option<f64>,
+}
+
+fn epoch_of(z: &jiff::Zoned) -> f64 {
+    z.timestamp().as_millisecond() as f64 / 1_000.0
+}
+
+fn epoch_to_local(epoch: f64) -> Option<jiff::Zoned> {
+    let ts = jiff::Timestamp::from_millisecond((epoch * 1_000.0) as i64).ok()?;
+    Some(ts.to_zoned(jiff::tz::TimeZone::system()))
+}
+
+fn now_secs() -> Option<f64> {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs_f64())
+}
+
+/// Compute reset-anchored grid boundaries for a usage bar, plus the block that
+/// currently contains "now".
+///
+/// Boundaries land on the user's *actual* reset time-of-day — e.g. a Sunday
+/// 12:00 weekly reset yields noon-to-noon day blocks — computed with calendar
+/// arithmetic so they stay correct across DST and for any reset time.
+///
+/// When `working` is a strict subset of the week and the window is roughly a
+/// week long, the weekly grid is **reshaped to one equal block per working
+/// day** (N blocks instead of 7): non-working days are dropped from the axis,
+/// and the returned [`Segments::time_pct`] advances only across working time so
+/// the pace marker reflects the user's real schedule.
+pub fn reset_aligned_segments(
+    reset_epoch: f64,
+    period_secs: f64,
+    unit: SegmentUnit,
+    working: WorkingDays,
+) -> Segments {
+    if period_secs <= 0.0 || reset_epoch <= 0.0 {
+        return Segments::default();
+    }
+    let reset = match epoch_to_local(reset_epoch) {
+        Some(z) => z,
+        None => return Segments::default(),
+    };
+    let start_epoch = reset_epoch - period_secs;
+    let now_epoch = now_secs().unwrap_or(start_epoch);
+
+    // Reshape to working-day blocks only for ~weekly windows with a real subset
+    // of days selected. Hour windows and longer/shorter day windows keep the
+    // plain calendar grid.
+    let day_units = (period_secs / 86_400.0).round() as i64;
+    let remap = matches!(unit, SegmentUnit::Day)
+        && working.count() >= 1
+        && !working.is_all()
+        && (2..=8).contains(&day_units);
+
+    // Keep the grid legible on a thin bar: if a window spans more units than
+    // this, step by a whole multiple (e.g. every 2 days), still anchored to the
+    // reset time-of-day. Reshaped grids always step one day at a time.
+    let (unit_secs, max_blocks) = match unit {
+        SegmentUnit::Hour => (3_600.0, 12.0),
+        SegmentUnit::Day => (86_400.0, 14.0),
+    };
+    let units = (period_secs / unit_secs).round().max(1.0);
+    let multiplier = if remap {
+        1
+    } else {
+        (units / max_blocks).ceil().max(1.0) as i64
+    };
+    let step = match unit {
+        SegmentUnit::Hour => jiff::Span::new().hours(multiplier),
+        SegmentUnit::Day => jiff::Span::new().days(multiplier),
+    };
+
+    // Walk back from the reset, one block at a time, until the window start is
+    // covered. `bounds` ends up holding boundary datetimes in ascending order.
+    let mut bounds = vec![reset.clone()];
+    let mut cursor = reset;
+    for _ in 0..64 {
+        cursor = match cursor.checked_sub(step) {
+            Ok(z) => z,
+            Err(_) => break,
+        };
+        let epoch = epoch_of(&cursor);
+        bounds.push(cursor.clone());
+        if epoch <= start_epoch {
+            break;
+        }
+    }
+    bounds.reverse();
+
+    let frac = |epoch: f64| ((epoch - start_epoch) / period_secs) as f32;
+
+    if !remap {
+        let dividers = bounds
+            .iter()
+            .map(|z| frac(epoch_of(z)))
+            .filter(|&f| f > 0.001 && f < 0.999)
+            .collect();
+        let epochs: Vec<f64> = bounds.iter().map(epoch_of).collect();
+        let current = epochs.windows(2).find_map(|w| {
+            (now_epoch >= w[0] && now_epoch < w[1])
+                .then(|| (frac(w[0]).max(0.0), frac(w[1]).min(1.0)))
+        });
+        return Segments {
+            dividers,
+            current,
+            time_pct: None,
+        };
+    }
+
+    // Reshape: each calendar block becomes (start, end, is_working) labelled by
+    // its start weekday, then working blocks are laid out as equal segments.
+    let blocks: Vec<(f64, f64, bool)> = bounds
+        .windows(2)
+        .map(|w| {
+            let start = epoch_of(&w[0]);
+            let end = epoch_of(&w[1]);
+            let weekday = w[0].weekday().to_monday_zero_offset() as usize % 7;
+            (start, end, working.days[weekday])
+        })
+        .collect();
+
+    let n = blocks.iter().filter(|(_, _, w)| *w).count();
+    if n == 0 {
+        // No working day fell inside this window (only possible for an odd
+        // partial window). Fall back to the plain calendar grid.
+        let dividers = bounds
+            .iter()
+            .map(|z| frac(epoch_of(z)))
+            .filter(|&f| f > 0.001 && f < 0.999)
+            .collect();
+        return Segments {
+            dividers,
+            current: None,
+            time_pct: None,
+        };
+    }
+
+    let seg_w = 1.0_f32 / n as f32;
+    let mut dividers = Vec::new();
+    let mut current = None;
+    let mut elapsed_working = 0.0_f64; // working time elapsed, in units of blocks (0..=n)
+    let mut wi = 0_usize; // index among working blocks
+    for &(start, end, is_work) in &blocks {
+        if !is_work {
+            continue;
+        }
+        let seg_start = wi as f32 * seg_w;
+        let seg_end = (wi + 1) as f32 * seg_w;
+        if wi > 0 {
+            dividers.push(seg_start);
+        }
+        if now_epoch >= start && now_epoch < end {
+            current = Some((seg_start, seg_end));
+            let frac_in = ((now_epoch - start) / (end - start)).clamp(0.0, 1.0);
+            elapsed_working = wi as f64 + frac_in;
+        } else if now_epoch >= end {
+            elapsed_working = (wi + 1) as f64;
+        }
+        wi += 1;
+    }
+    let time_pct = (elapsed_working / n as f64 * 100.0).clamp(0.0, 100.0);
+
+    Segments {
+        dividers,
+        current,
+        time_pct: Some(time_pct),
+    }
+}
+
+/// The time-elapsed fraction a row will actually use: the working-day-reshaped
+/// value when reshaping applies, otherwise the caller's linear value. Lets the
+/// status-bar trigger compute the same pace color the popover row shows.
+pub fn effective_time_pct(
+    reset_epoch: Option<f64>,
+    period_secs: f64,
+    unit: Option<SegmentUnit>,
+    working: WorkingDays,
+    linear: Option<f64>,
+) -> Option<f64> {
+    match (unit, reset_epoch) {
+        (Some(u), Some(r)) => reset_aligned_segments(r, period_secs, u, working)
+            .time_pct
+            .or(linear),
+        _ => linear,
+    }
+}
+
+// ============================================================================
+// Reset-time formatting (absolute, with smart labels)
+// ============================================================================
+
+/// Format a reset time (Unix epoch seconds) to a human-readable short form in
+/// the local timezone, e.g. `today, 14:00 PST` / `Tue, 09:00 PST` /
+/// `Jun 21, 09:00 PST`. Returns an empty string for an unset/invalid time.
+pub fn format_reset_time_epoch(reset_epoch: f64, include_date: bool) -> String {
+    if reset_epoch <= 0.0 {
+        return String::new();
+    }
+    let Some(zoned) = epoch_to_local(reset_epoch) else {
+        return String::new();
+    };
+
+    if include_date {
+        let today = jiff::Zoned::now().date();
+        let reset_date = zoned.date();
+
+        let diff_days = today
+            .until(reset_date)
+            .ok()
+            .map(|span| span.get_days())
+            .unwrap_or(i32::MAX);
+
+        let date_label = match diff_days {
+            0 => Some("today"),
+            1 => Some("tomorrow"),
+            _ => None,
+        };
+
+        return match date_label {
+            Some(label) => format!("{}, {}", label, zoned.strftime("%H:%M %Z")),
+            None if (2..=6).contains(&diff_days) => zoned.strftime("%a, %H:%M %Z").to_string(),
+            None => zoned.strftime("%b %-d, %H:%M %Z").to_string(),
+        };
+    }
+
+    zoned.strftime("%H:%M %Z").to_string()
+}
+
+// ============================================================================
+// Popover chrome
+// ============================================================================
+
+/// Styled popover container (the caller adds `id`, `occlude`, hover/click
+/// handlers and children).
+pub fn usage_popover_container(t: &ThemeColors) -> Div {
+    div()
+        .min_w(px(300.0))
+        .max_w(px(420.0))
+        .bg(rgb(t.bg_primary))
+        .border_1()
+        .border_color(rgb(t.border))
+        .rounded(px(8.0))
+        .shadow_lg()
+}
+
+/// Bordered popover header: an uppercase title on the left, an optional muted
+/// plan badge and a "Settings ↗" link on the right.
+pub fn usage_popover_header(
+    title: &str,
+    plan: Option<&str>,
+    settings_url: &'static str,
+    settings_tooltip: &'static str,
+    t: &ThemeColors,
+    cx: &App,
+) -> impl IntoElement {
+    let muted = t.text_muted;
+    let primary = t.text_primary;
+    let link_id = SharedString::from(format!("{}-settings-link", title));
+
+    h_flex()
+        .px(px(12.0))
+        .py(px(7.0))
+        .items_center()
+        .justify_between()
+        .border_b_1()
+        .border_color(rgb(t.border))
+        .child(
+            div()
+                .text_size(ui_text_xs(cx))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(rgb(t.text_secondary))
+                .child(title.to_string()),
+        )
+        .child(
+            h_flex()
+                .gap(px(8.0))
+                .items_center()
+                .when_some(plan, |el, plan| {
+                    el.child(
+                        div()
+                            .text_size(ui_text_xs(cx))
+                            .text_color(rgb(t.text_muted))
+                            .child(plan.to_string()),
+                    )
+                })
+                .child(
+                    h_flex()
+                        .id(link_id)
+                        // Left padding only, so the trailing icon sits flush
+                        // with the header's 12px inset (matching the title on
+                        // the left) instead of looking inset on the right.
+                        .gap(px(4.0))
+                        .items_center()
+                        .pl(px(4.0))
+                        .py(px(1.0))
+                        .rounded(px(3.0))
+                        .cursor_pointer()
+                        .text_color(rgb(muted))
+                        .hover(|s| s.text_color(rgb(primary)).bg(rgb(t.bg_hover)))
+                        .child(
+                            div()
+                                .text_size(ui_text_xs(cx))
+                                .line_height(px(10.0))
+                                .child("Settings"),
+                        )
+                        // `currentColor` resolves from the svg's *own* text_color,
+                        // not the parent's — without this the icon renders as an
+                        // invisible black glyph, leaving its slot looking like
+                        // stray right padding.
+                        .child(
+                            svg()
+                                .path("icons/external-link.svg")
+                                .size(px(10.0))
+                                .text_color(rgb(muted)),
+                        )
+                        .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                            cx.stop_propagation();
+                        })
+                        .on_click(move |_, _, _cx| {
+                            okena_core::process::open_url(settings_url);
+                        })
+                        .tooltip(move |window, cx| Tooltip::new(settings_tooltip).build(window, cx)),
+                ),
+        )
+}
+
+/// Padded popover body container (the caller adds the rows).
+pub fn usage_body_container() -> Div {
+    v_flex().px(px(12.0)).py(px(10.0)).gap(px(7.0))
+}
+
+pub fn usage_divider(t: &ThemeColors) -> impl IntoElement {
+    div().h(px(1.0)).w_full().bg(rgb(t.border))
+}
+
+// ============================================================================
+// Rows + bars
+// ============================================================================
+
+/// One rate-limit window's worth of data, ready to render as a row.
+pub struct UsageRow {
+    /// Primary label, e.g. `Session` / `Weekly` / `Rate Limit`.
+    pub label: SharedString,
+    /// Period badge, e.g. `5h` / `7d`.
+    pub period: SharedString,
+    /// Utilization 0–100.
+    pub pct: f64,
+    /// Linear time-elapsed fraction 0–100 from the API (overridden by
+    /// working-day reshaping when active).
+    pub time_pct: Option<f64>,
+    /// Reset time as Unix epoch seconds, used for the grid + "resets …" label.
+    pub reset_epoch: Option<f64>,
+    /// Length of this rate-limit window in seconds.
+    pub period_secs: f64,
+    /// Grid granularity; `None` disables the grid (sub-hour windows).
+    pub unit: Option<SegmentUnit>,
+    /// Stable element id for the time marker (for its tooltip).
+    pub marker_id: SharedString,
+}
+
+/// Render a usage row: label + period badge, percentage, the usage/time bar,
+/// and a pace message + "resets …" line.
+pub fn render_usage_row(
+    t: &ThemeColors,
+    cx: &App,
+    row: &UsageRow,
+    working: WorkingDays,
+) -> impl IntoElement {
+    let seg = match (row.unit, row.reset_epoch) {
+        (Some(unit), Some(reset)) => {
+            reset_aligned_segments(reset, row.period_secs, unit, working)
+        }
+        _ => Segments::default(),
+    };
+    // Working-day reshaping overrides the linear pace value when active.
+    let effective_time = seg.time_pct.or(row.time_pct);
+
+    let pct = row.pct;
+    let pace = pace_severity(pct, effective_time);
+    // % text reflects whichever is worse: nearness to the cap, or burn pace.
+    let pct_color = headline_color(t, pct, effective_time);
+    let pace_msg: Option<(&str, u32)> = match pace {
+        Severity::Critical => Some(("Slow down to last the period", t.metric_critical)),
+        Severity::Warning => Some(("Ahead of pace", t.metric_warning)),
+        Severity::Normal => None,
+    };
+
+    let include_date = matches!(row.unit, Some(SegmentUnit::Day));
+    let resets_label = row
+        .reset_epoch
+        .map(|e| format_reset_time_epoch(e, include_date))
+        .filter(|s| !s.is_empty());
+
+    v_flex()
+        .gap(px(5.0))
+        .child(
+            h_flex()
+                .items_baseline()
+                .justify_between()
+                .child(
+                    h_flex()
+                        .gap(px(6.0))
+                        .items_baseline()
+                        .child(
+                            div()
+                                .text_size(ui_text_ms(cx))
+                                .text_color(rgb(t.text_primary))
+                                .child(row.label.clone()),
+                        )
+                        .child(
+                            div()
+                                .text_size(ui_text_xs(cx))
+                                .text_color(rgb(t.text_muted))
+                                .child(row.period.clone()),
+                        ),
+                )
+                .child(
+                    div()
+                        .text_size(ui_text_md(cx))
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .text_color(rgb(pct_color))
+                        .child(format!("{:.0}%", pct)),
+                ),
+        )
+        .child(render_usage_bar(
+            t,
+            pct,
+            effective_time,
+            row.marker_id.clone(),
+            &seg,
+        ))
+        .when(pace_msg.is_some() || resets_label.is_some(), |el| {
+            el.child(
+                h_flex()
+                    .justify_between()
+                    .items_baseline()
+                    .child(
+                        div()
+                            .text_size(ui_text_xs(cx))
+                            .font_weight(FontWeight::MEDIUM)
+                            .when_some(pace_msg, |d, (msg, col)| d.text_color(rgb(col)).child(msg)),
+                    )
+                    .when_some(resets_label, |el, label| {
+                        el.child(
+                            div()
+                                .text_size(ui_text_xs(cx))
+                                .text_color(rgb(t.text_muted))
+                                .child(format!("resets {}", label)),
+                        )
+                    }),
+            )
+        })
+}
+
+/// The 6px usage bar: base fill (nearness to cap), overage band (usage beyond
+/// the pace marker), the reset-anchored day/hour grid, the current-block
+/// highlight, and the time-elapsed marker.
+pub fn render_usage_bar(
+    t: &ThemeColors,
+    usage_pct: f64,
+    time_pct: Option<f64>,
+    marker_id: impl Into<ElementId>,
+    seg: &Segments,
+) -> impl IntoElement {
+    let marker_id = marker_id.into();
+    let clamped_usage = usage_pct.clamp(0.0, 100.0) as f32;
+    let base_color = severity_color(t, abs_severity(usage_pct));
+
+    let overage = time_pct.and_then(|tp| {
+        let start = tp.clamp(0.0, 100.0) as f32;
+        let width = clamped_usage - start;
+        if width <= 0.0 {
+            return None;
+        }
+        let color = if width > 15.0 {
+            t.metric_critical
+        } else {
+            t.metric_warning
+        };
+        Some((start, width, color))
+    });
+
+    // Dividers cut the bar down to the popover background, so they read as
+    // notches that stay visible over any fill color (yellow/green/red) as well
+    // as the empty track — unlike a subtle border line, which disappears on a
+    // light fill.
+    let divider_color = t.bg_primary;
+    let divider_els = seg.dividers.clone().into_iter().map(move |f| {
+        div()
+            .absolute()
+            .top_0()
+            .h_full()
+            .w(px(1.5))
+            .bg(rgb(divider_color))
+            .left(relative(f))
+    });
+
+    // Translucent band over the current block. Derived from text_primary so it
+    // lightens on dark themes and darkens on light ones.
+    let mut highlight = rgb(t.text_primary);
+    highlight.a = 0.14;
+
+    div()
+        .h(px(6.0))
+        .w_full()
+        .rounded_full()
+        .bg(rgb(t.bg_secondary))
+        .relative()
+        .child(
+            div()
+                .h_full()
+                .rounded_full()
+                .bg(rgb(base_color))
+                .w(relative(clamped_usage / 100.0)),
+        )
+        .when_some(overage, |el, (start, width, color)| {
+            el.child(
+                div()
+                    .absolute()
+                    .top_0()
+                    .h_full()
+                    .left(relative(start / 100.0))
+                    .w(relative(width / 100.0))
+                    .rounded_r(px(3.0))
+                    .bg(rgb(color)),
+            )
+        })
+        .children(divider_els)
+        .when_some(seg.current, |el, (start, end)| {
+            el.child(
+                div()
+                    .absolute()
+                    .top_0()
+                    .h_full()
+                    .left(relative(start))
+                    .w(relative((end - start).max(0.0)))
+                    .bg(highlight),
+            )
+        })
+        .when_some(time_pct, |el, tp| {
+            let clamped_time = tp.clamp(0.0, 100.0) as f32;
+            let marker_color = t.text_primary;
+            el.child(
+                div()
+                    .id(marker_id)
+                    .absolute()
+                    .top(px(-4.0))
+                    .left(relative(clamped_time / 100.0))
+                    .w(px(8.0))
+                    .h(px(14.0))
+                    .flex()
+                    .items_center()
+                    .justify_start()
+                    .child(
+                        div()
+                            .w(px(2.0))
+                            .h(px(10.0))
+                            .rounded(px(1.0))
+                            .bg(rgb(marker_color)),
+                    )
+                    .tooltip(|window, cx| {
+                        Tooltip::new("Time elapsed in this period").build(window, cx)
+                    }),
+            )
+        })
+}
+
+/// A plain progress bar (no grid/marker) for credit/extra-usage rows.
+pub fn render_simple_bar(t: &ThemeColors, pct: f64) -> impl IntoElement {
+    let clamped = pct.clamp(0.0, 100.0) as f32;
+    let color = utilization_color(t, pct);
+
+    div()
+        .h(px(6.0))
+        .w_full()
+        .rounded_full()
+        .bg(rgb(t.bg_secondary))
+        .child(
+            div()
+                .h_full()
+                .rounded_full()
+                .bg(rgb(color))
+                .w(relative(clamped / 100.0)),
+        )
+}
+
+/// A simple label/value row (e.g. "Credits  Unlimited", "Extra Usage  $2 / $50").
+pub fn usage_kv_row(
+    t: &ThemeColors,
+    cx: &App,
+    label: &str,
+    value: String,
+    value_color: u32,
+) -> impl IntoElement {
+    h_flex()
+        .items_baseline()
+        .justify_between()
+        .child(
+            div()
+                .text_size(ui_text_ms(cx))
+                .text_color(rgb(t.text_secondary))
+                .child(label.to_string()),
+        )
+        .child(
+            div()
+                .text_size(ui_text_ms(cx))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(rgb(value_color))
+                .child(value),
+        )
+}
+
+// ============================================================================
+// Status-bar trigger
+// ============================================================================
+
+/// One status-bar trigger entry: `label`, utilization, and the effective
+/// time-elapsed value (so the color matches the popover headline exactly).
+pub type TriggerItem = (SharedString, f64, Option<f64>);
+
+/// Build the inner content of the status-bar trigger — `5h 42% | 7d 70%`.
+/// The caller wraps these in a hoverable, bounds-tracking container.
+pub fn usage_trigger_items(t: &ThemeColors, cx: &App, items: &[TriggerItem]) -> Vec<AnyElement> {
+    let mut out = Vec::new();
+    for (i, (label, pct, time_pct)) in items.iter().enumerate() {
+        if i > 0 {
+            out.push(
+                div()
+                    .text_size(ui_text_ms(cx))
+                    .text_color(rgb(t.text_muted))
+                    .child("|")
+                    .into_any_element(),
+            );
+        }
+        out.push(
+            h_flex()
+                .gap(px(3.0))
+                .child(
+                    div()
+                        .text_size(ui_text_ms(cx))
+                        .text_color(rgb(t.text_muted))
+                        .child(label.clone()),
+                )
+                .child(
+                    div()
+                        .text_size(ui_text_ms(cx))
+                        .text_color(rgb(headline_color(t, *pct, *time_pct)))
+                        .child(format!("{:.0}%", pct)),
+                )
+                .into_any_element(),
+        );
+    }
+    out
+}
+
+// ============================================================================
+// Working-days settings control
+// ============================================================================
+
+/// A self-contained settings control for the shared working-days preference.
+/// Both the Claude and Codex settings panels embed one of these.
+pub struct WorkingDaysSetting;
+
+impl WorkingDaysSetting {
+    pub fn new(cx: &mut Context<Self>) -> Self {
+        // Re-render if the shared setting changes elsewhere.
+        cx.observe_global::<ExtensionSettingsStore>(|_, cx| cx.notify())
+            .detach();
+        Self
+    }
+
+    fn toggle(&mut self, idx: usize, cx: &mut Context<Self>) {
+        let mut days = read_working_days(cx);
+        // Keep at least one working day selected.
+        if days.days[idx] && days.count() <= 1 {
+            return;
+        }
+        days.days[idx] = !days.days[idx];
+        write_working_days(days, cx);
+        cx.notify();
+    }
+}
+
+impl Render for WorkingDaysSetting {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let t = okena_extensions::theme(cx);
+        let days = read_working_days(cx);
+        const LABELS: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+        let mut chips = h_flex().gap(px(6.0)).flex_wrap();
+        for (i, label) in LABELS.iter().enumerate() {
+            let active = days.days[i];
+            let mut chip = div()
+                .id(SharedString::from(format!("workday-{i}")))
+                .cursor_pointer()
+                .px(px(10.0))
+                .py(px(4.0))
+                .rounded(px(6.0))
+                .border_1()
+                .text_size(ui_text_sm(cx))
+                .child(label.to_string())
+                .on_click(cx.listener(move |this, _, _, cx| this.toggle(i, cx)));
+            if active {
+                let mut bg = rgb(t.border_active);
+                bg.a = 0.18;
+                chip = chip
+                    .bg(bg)
+                    .border_color(rgb(t.border_active))
+                    .text_color(rgb(t.text_primary))
+                    .font_weight(FontWeight::MEDIUM);
+            } else {
+                chip = chip
+                    .bg(rgb(t.bg_secondary))
+                    .border_color(rgb(t.bg_secondary))
+                    .text_color(rgb(t.text_muted))
+                    .hover(|s| s.text_color(rgb(t.text_secondary)));
+            }
+            chips = chips.child(chip);
+        }
+
+        v_flex()
+            .gap(px(8.0))
+            .child(section_header("Working days", &t, cx))
+            .child(
+                section_container(&t).child(
+                    v_flex()
+                        .px(px(12.0))
+                        .py(px(10.0))
+                        .gap(px(8.0))
+                        .child(
+                            div()
+                                .text_size(ui_text_sm(cx))
+                                .text_color(rgb(t.text_muted))
+                                .child(
+                                    "Tailor the weekly usage bar to the days you work — \
+                                     the bar shows one block per working day. \
+                                     Shared across Claude and Codex.",
+                                ),
+                        )
+                        .child(chips),
+                ),
+            )
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // gpui::* re-exports a `test` attribute macro that conflicts with the built-in;
+    // alias the built-in so `#[test]` works normally in this module.
+    use core::prelude::rust_2024::test;
+
+    #[test]
+    fn working_days_default_is_all() {
+        assert!(WorkingDays::from_value(None).is_all());
+        let empty = serde_json::json!({ "working_days": [] });
+        assert!(WorkingDays::from_value(Some(&empty)).is_all());
+    }
+
+    #[test]
+    fn working_days_round_trip() {
+        let wd = WorkingDays {
+            days: [true, true, true, true, true, false, false], // Mon-Fri
+        };
+        assert_eq!(wd.count(), 5);
+        assert!(!wd.is_all());
+        let parsed = WorkingDays::from_value(Some(&wd.to_value()));
+        assert_eq!(parsed, wd);
+    }
+
+    #[test]
+    fn working_days_ignores_out_of_range() {
+        let v = serde_json::json!({ "working_days": [0, 9, 3] });
+        let wd = WorkingDays::from_value(Some(&v));
+        assert!(wd.days[0] && wd.days[3]);
+        assert_eq!(wd.count(), 2);
+    }
+
+    #[test]
+    fn all_days_keeps_calendar_grid() {
+        // All days selected → no reshaping → linear grid, no working-time override.
+        let period = 7.0 * 86_400.0;
+        let seg = reset_aligned_segments(1_700_000_000.0, period, SegmentUnit::Day, WorkingDays::all());
+        assert!(seg.time_pct.is_none(), "all-days must not override pace");
+        assert!(
+            (5..=7).contains(&seg.dividers.len()),
+            "expected ~6 dividers, got {}",
+            seg.dividers.len()
+        );
+        assert!(seg.dividers.iter().all(|&f| f > 0.0 && f < 1.0));
+        assert!(seg.dividers.windows(2).all(|w| w[0] < w[1]));
+    }
+
+    #[test]
+    fn five_working_days_reshape_to_five_blocks() {
+        // Mon-Fri over a 7-day window → 5 equal blocks → 4 internal dividers,
+        // and a working-time pace override.
+        let period = 7.0 * 86_400.0;
+        let mon_fri = WorkingDays {
+            days: [true, true, true, true, true, false, false],
+        };
+        let seg = reset_aligned_segments(1_700_000_000.0, period, SegmentUnit::Day, mon_fri);
+        assert_eq!(seg.dividers.len(), 4, "5 blocks → 4 dividers, got {:?}", seg.dividers);
+        // Equal blocks at 1/5, 2/5, 3/5, 4/5.
+        for (i, &d) in seg.dividers.iter().enumerate() {
+            let expected = (i + 1) as f32 / 5.0;
+            assert!((d - expected).abs() < 1e-4, "divider {i} = {d}, expected {expected}");
+        }
+        assert!(seg.time_pct.is_some(), "reshaping must provide a working-time pace");
+        let tp = seg.time_pct.unwrap();
+        assert!((0.0..=100.0).contains(&tp));
+    }
+
+    #[test]
+    fn hour_window_never_reshapes() {
+        let mon_fri = WorkingDays {
+            days: [true, true, true, true, true, false, false],
+        };
+        let seg = reset_aligned_segments(1_700_000_000.0, 5.0 * 3_600.0, SegmentUnit::Hour, mon_fri);
+        assert!(seg.time_pct.is_none(), "hour windows keep linear pace");
+    }
+
+    #[test]
+    fn guards_reject_bad_input() {
+        let seg = reset_aligned_segments(0.0, 7.0 * 86_400.0, SegmentUnit::Day, WorkingDays::all());
+        assert!(seg.dividers.is_empty() && seg.current.is_none());
+        let seg = reset_aligned_segments(1_700_000_000.0, 0.0, SegmentUnit::Day, WorkingDays::all());
+        assert!(seg.dividers.is_empty() && seg.current.is_none());
+    }
+
+    #[test]
+    fn headline_severity_takes_worse_of_abs_and_pace() {
+        // 65% absolute is only Warning, but far ahead of a 30% pace → Critical.
+        // The popover row and the status-bar trigger both color from this same
+        // max(abs, pace), so they can never show different colors for one metric.
+        let ahead = abs_severity(65.0).max(pace_severity(65.0, Some(30.0)));
+        let on_pace = abs_severity(65.0).max(pace_severity(65.0, Some(64.0)));
+        assert_eq!(ahead, Severity::Critical, "over-pace 65% must be critical");
+        assert_eq!(on_pace, Severity::Warning, "on-pace 65% stays warning");
+    }
+
+    #[test]
+    fn format_reset_time_empty_for_unset() {
+        assert_eq!(format_reset_time_epoch(0.0, true), "");
+        assert_eq!(format_reset_time_epoch(-5.0, false), "");
+    }
+
+    #[test]
+    fn format_reset_time_has_clock_and_tz() {
+        let result = format_reset_time_epoch(1_700_000_000.0, false);
+        assert!(result.contains(':'), "expected HH:MM, got {result}");
+        assert!(!result.is_empty());
+    }
+}


### PR DESCRIPTION
## What

Make the Claude and Codex usage widgets look & behave identically, and add a **working-days** setting that tailors the weekly usage bar to the days you actually work.

## How

- **New `okena-usage` crate** (extension-layer, depends on `okena-ui`) is the single source of truth for the usage UI — severity/pace logic, the reset-anchored grid, the rendering primitives, and the working-days feature. Both extensions render through it, so they can't drift apart again. (`okena-ui` itself is untouched.)
- **Shared visual language:** header bar with a plan badge + "Settings" link, 6px reset-anchored bars, a tooltip pace marker, and absolute "resets …" labels.
- **Working days:** a shared `usage` preference (default = all 7 days → behavior unchanged out of the box). For the weekly window it reshapes the grid to **one block per working day** and advances the pace marker over working time only, so "ahead of pace" reflects your real schedule. Editable from both the Claude and Codex settings panels (Codex gains a settings view — it had none).
- **Claude plan badge:** read the subscription plan from the credentials and show it in the header, matching Codex.
- **Pace color parity:** the status-bar trigger and the popover now both color from `max(absolute, pace)` (working-days-aware), so the trigger no longer shows yellow while the popover shows red.
- **Codex hover refresh:** added the same throttled hover-to-refresh Claude has.
- **Bar dividers** cut to the popover background (visible over any fill color), and the header's external-link svg is colored directly so it renders instead of looking like stray right-padding.

## Testing

- `cargo build` (full workspace): green
- Tests: `okena-usage` 10, `okena-ext-claude` 21, `okena-ext-codex` 1 — all passing
- An adversarial multi-agent review of the diff found 0 confirmed issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)