### PR TITLE
perf(terminal): optimistic close — instant pane removal, busy check off-thread

### DIFF
--- a/crates/okena-app-core/src/workspace/actions/mod.rs
+++ b/crates/okena-app-core/src/workspace/actions/mod.rs
@@ -1,7 +1,8 @@
 // Re-export action submodules from the workspace crate.
-// These contain `impl Workspace` blocks (no standalone types to re-export),
-// but re-exporting the modules makes them accessible as `crate::workspace::actions::*`.
+// These mostly contain `impl Workspace` blocks; `soft_close` also exports the
+// `PendingDecision` type. Re-exporting the modules makes them accessible as
+// `crate::workspace::actions::*`.
 #[allow(unused_imports)]
-pub use okena_workspace::actions::{focus, folder, layout, project, terminal};
+pub use okena_workspace::actions::{focus, folder, layout, project, soft_close, terminal};
 
 pub mod execute;

--- a/crates/okena-app/src/action_dispatch.rs
+++ b/crates/okena-app/src/action_dispatch.rs
@@ -170,24 +170,29 @@ impl ActionDispatcher {
                 let window_id = *window_id;
                 focus_manager.update(cx, |fm, cx| {
                     workspace.update(cx, |ws, cx| {
-                        // Interactive close of a busy terminal goes through the
-                        // grace-period soft close (undo toast). Both the single
-                        // and multi-terminal close actions are gated; whatever
-                        // isn't soft-closed falls through to the immediate close.
+                        // Interactive closes go through the optimistic soft
+                        // close: the pane is ejected immediately and the PTY's
+                        // fate (kill now vs. keep for undo) is decided off the
+                        // GPUI thread. Both the single and multi-terminal close
+                        // actions are gated; whatever isn't handled there
+                        // (feature off / terminal not in layout) falls through
+                        // to the immediate close.
                         match &action {
                             ActionRequest::CloseTerminal { project_id, terminal_id }
-                                if crate::soft_close::try_begin(
-                                    ws, fm, &*backend, &terminals, project_id, terminal_id, cx,
+                                if crate::soft_close::begin(
+                                    ws, fm, &backend, &terminals, project_id, terminal_id, cx,
                                 ) => {
                                     return;
                                 }
                             ActionRequest::CloseTerminals { project_id, terminal_ids } => {
-                                // Soft-close each busy terminal; hard-close the
-                                // rest in a single batched action.
+                                // Optimistically close each terminal (eject now,
+                                // decide kill-vs-undo off-thread); whatever isn't
+                                // handled here (feature off / not in layout)
+                                // hard-closes in a single batched action.
                                 let mut remaining = Vec::new();
                                 for terminal_id in terminal_ids {
-                                    if !crate::soft_close::try_begin(
-                                        ws, fm, &*backend, &terminals, project_id, terminal_id, cx,
+                                    if !crate::soft_close::begin(
+                                        ws, fm, &backend, &terminals, project_id, terminal_id, cx,
                                     ) {
                                         remaining.push(terminal_id.clone());
                                     }

--- a/crates/okena-app/src/soft_close.rs
+++ b/crates/okena-app/src/soft_close.rs
@@ -1,22 +1,28 @@
 //! Desktop orchestration for the grace-period "soft close".
 //!
-//! When the user closes a *busy* terminal (one with a running foreground
-//! process), instead of killing it immediately we:
-//!   1. remove the pane from the layout but keep the PTY alive,
-//!   2. show a toast with "Undo" / "Close now" and a countdown,
-//!   3. schedule the real teardown after the grace period.
+//! Every interactive close is handled *optimistically*: the pane is ejected
+//! from the layout immediately (the PTY stays alive), so the UI updates with no
+//! lag, and only then — off the GPUI thread — do we probe whether the terminal
+//! was busy. That probe can fork `tmux` / `lsof` / `pgrep` (slow on macOS),
+//! which is why it must not sit on the close keypath. Once it returns:
+//!   * idle terminal  → kill the PTY now (no toast),
+//!   * busy terminal  → show an "Undo" / "Close now" toast with a countdown and
+//!     schedule the real teardown after the grace period.
 //!
 //! The layout bookkeeping + restore live on `Workspace` (`begin_soft_close`,
-//! `undo_soft_close`, `finalize_soft_close`); this module wires the busy check,
-//! the toast, and the timer. Only the interactive desktop close path goes
-//! through here — the remote API keeps immediate-close semantics.
+//! `decide_pending_close`, `undo_soft_close`, `finalize_soft_close`); this
+//! module wires the off-thread probe, the toast, and the timer. Only the
+//! interactive desktop close path goes through here — the remote API keeps
+//! immediate-close semantics.
 
 use crate::terminal::backend::TerminalBackend;
 use crate::views::window::TerminalsRegistry;
+use crate::workspace::actions::soft_close::PendingDecision;
 use crate::workspace::focus::FocusManager;
 use crate::workspace::state::Workspace;
 use crate::workspace::toast::{Toast, ToastAction, ToastActionStyle, ToastManager};
 use gpui::*;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Prefix for the "undo" toast action id; payload is `:<project_id>:<terminal_id>`.
@@ -70,14 +76,20 @@ fn shorten_cwd(path: &str) -> String {
     format!("\u{2026}{tail}")
 }
 
-/// Attempt to soft-close a terminal. Returns `true` if the close was handled as
-/// a soft close (caller must NOT also run the immediate close); `false` if the
-/// feature is off / the terminal is idle / not found, in which case the caller
-/// should fall through to the normal immediate close.
-pub fn try_begin(
+/// Begin an optimistic close of a terminal. Returns `true` if the close was
+/// taken over here (the pane was ejected from the layout and the PTY's fate is
+/// being decided in the background); `false` if the feature is off or the
+/// terminal isn't in the layout, in which case the caller should fall through
+/// to the normal immediate close.
+///
+/// The "is this terminal busy?" probe — which can fork `tmux` / `lsof` /
+/// `pgrep` and is slow on macOS — runs *after* the pane is ejected, off the
+/// GPUI thread, so the close is perceived as instant. Idle terminals are then
+/// killed immediately; busy ones get the undo toast + grace timer.
+pub fn begin(
     ws: &mut Workspace,
     focus_manager: &mut FocusManager,
-    backend: &dyn TerminalBackend,
+    backend: &Arc<dyn TerminalBackend>,
     terminals: &TerminalsRegistry,
     project_id: &str,
     terminal_id: &str,
@@ -85,18 +97,7 @@ pub fn try_begin(
 ) -> bool {
     let grace_secs = crate::settings::settings(cx).terminal_close_grace_secs;
     if grace_secs == 0 {
-        return false; // feature disabled
-    }
-
-    // Only soft-close *busy* terminals. The foreground shell pid resolves
-    // through session backends (dtach / tmux), so "has a child" means the user
-    // actually has a command running — not just the persistence wrapper.
-    let fg_pid = backend.get_foreground_shell_pid(terminal_id);
-    let busy = fg_pid
-        .map(okena_terminal::terminal::has_child_processes)
-        .unwrap_or(false);
-    if !busy {
-        return false;
+        return false; // feature disabled — caller does an immediate close
     }
 
     let path = match ws
@@ -108,11 +109,85 @@ pub fn try_begin(
         None => return false,
     };
 
-    // Build an informative two-line toast:
-    //
-    //   title:  Closed “make”             — what's closing
-    //   detail: okena · ~/projects/okena  — project · working directory (muted)
-    //
+    // Stable toast id reserved up front. The pending record references it now,
+    // but the toast is only actually posted later *if* the terminal turns out
+    // to be busy. Only one pending close per terminal exists at a time, so a
+    // deterministic id is safe.
+    let toast_id = format!("soft-close:{terminal_id}");
+
+    // Eject the pane from the layout immediately (PTY stays alive). This is the
+    // instant, blocking-free part the user perceives as "the terminal closed".
+    ws.begin_soft_close(focus_manager, project_id, &path, terminal_id, &toast_id, cx);
+
+    // Probe busy-ness off the GPUI thread, then resolve on the next tick.
+    let backend = backend.clone();
+    let terminals = terminals.clone();
+    let project_id = project_id.to_string();
+    let terminal_id = terminal_id.to_string();
+    let grace = Duration::from_secs(grace_secs as u64);
+
+    cx.spawn(async move |ws_weak, cx| {
+        let probe_backend = backend.clone();
+        let probe_tid = terminal_id.clone();
+        // The foreground shell pid resolves through session backends (dtach /
+        // tmux); "has a child" means the user actually has a command running,
+        // not just the persistence wrapper. Both calls can spawn subprocesses.
+        let (fg_pid, busy) = smol::unblock(move || {
+            let fg_pid = probe_backend.get_foreground_shell_pid(&probe_tid);
+            let busy = fg_pid
+                .map(okena_terminal::terminal::has_child_processes)
+                .unwrap_or(false);
+            (fg_pid, busy)
+        })
+        .await;
+
+        let _ = ws_weak.update(cx, |ws, cx| {
+            if ws.decide_pending_close(&terminal_id, busy, cx) != PendingDecision::KeepForUndo {
+                // Raced (the PTY already exited) or Finalized (idle → killed).
+                // Either way there's nothing to surface.
+                return;
+            }
+
+            // Busy: surface the undo toast and schedule the real teardown.
+            let toast = build_soft_close_toast(
+                ws, &terminals, &project_id, &terminal_id, fg_pid, &toast_id, grace,
+            );
+            ToastManager::post(toast, cx);
+
+            // Schedule the real teardown once the grace period elapses. If the
+            // user already undid or force-closed, `finalize_soft_close` returns
+            // false and the toast was already dismissed by the action handler.
+            let tid = terminal_id.clone();
+            let toast_id_timer = toast_id.clone();
+            cx.spawn(async move |ws_weak, cx| {
+                smol::Timer::after(grace).await;
+                let _ = ws_weak.update(cx, |ws, cx| {
+                    if ws.finalize_soft_close(&tid, cx) {
+                        ToastManager::dismiss(&toast_id_timer, cx);
+                    }
+                });
+            })
+            .detach();
+        });
+    })
+    .detach();
+
+    true
+}
+
+/// Build the two-line undo toast for a busy soft-close:
+///
+///   title:  Closed “make”             — what's closing
+///   detail: okena · ~/projects/okena  — project · working directory (muted)
+fn build_soft_close_toast(
+    ws: &Workspace,
+    terminals: &TerminalsRegistry,
+    project_id: &str,
+    terminal_id: &str,
+    fg_pid: Option<u32>,
+    toast_id: &str,
+    grace: Duration,
+) -> Toast {
     // Read the live OSC title + cwd under a single registry lock.
     let (osc_title, cwd) = {
         let reg = terminals.lock();
@@ -143,7 +218,6 @@ pub fn try_begin(
         })
         .unwrap_or_else(|| ("Terminal closed".to_string(), String::new()));
 
-    let grace = Duration::from_secs(grace_secs as u64);
     let actions = vec![
         ToastAction::new(
             format!("{UNDO_PREFIX}:{project_id}:{terminal_id}"),
@@ -156,32 +230,11 @@ pub fn try_begin(
             ToastActionStyle::Danger,
         ),
     ];
-    let toast = {
-        let base = Toast::info(title).with_ttl(grace).with_actions(actions);
-        if detail.is_empty() { base } else { base.with_detail(detail) }
-    };
-    let toast_id = toast.id.clone();
-
-    // Remove from the layout (PTY stays alive) and record the pending close.
-    ws.begin_soft_close(focus_manager, project_id, &path, terminal_id, &toast_id, cx);
-    ToastManager::post(toast, cx);
-
-    // Schedule the real teardown once the grace period elapses. If the user
-    // already undid or force-closed, `finalize_soft_close` returns false and
-    // the toast was already dismissed by the action handler.
-    let tid = terminal_id.to_string();
-    let toast_id_timer = toast_id;
-    cx.spawn(async move |ws_weak, cx| {
-        smol::Timer::after(grace).await;
-        let _ = ws_weak.update(cx, |ws, cx| {
-            if ws.finalize_soft_close(&tid, cx) {
-                ToastManager::dismiss(&toast_id_timer, cx);
-            }
-        });
-    })
-    .detach();
-
-    true
+    let base = Toast::info(title)
+        .with_id(toast_id)
+        .with_ttl(grace)
+        .with_actions(actions);
+    if detail.is_empty() { base } else { base.with_detail(detail) }
 }
 
 #[cfg(test)]

--- a/crates/okena-state/src/toast.rs
+++ b/crates/okena-state/src/toast.rs
@@ -99,6 +99,15 @@ impl Toast {
         self
     }
 
+    /// Override the auto-generated id with a caller-chosen one. Used by the
+    /// optimistic soft-close path, which reserves a stable toast id up front
+    /// (before it knows whether a toast will actually be shown) so the same id
+    /// can later dismiss the toast on undo / kill-now / grace expiry.
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
     /// Attach clickable actions (rendered as buttons, with a countdown).
     pub fn with_actions(mut self, actions: Vec<ToastAction>) -> Self {
         self.actions = actions;

--- a/crates/okena-workspace/src/actions/soft_close.rs
+++ b/crates/okena-workspace/src/actions/soft_close.rs
@@ -9,6 +9,22 @@ use crate::focus::FocusManager;
 use crate::state::{LayoutNode, PendingClose, RestoredClose, Workspace};
 use gpui::*;
 
+/// Outcome of resolving an optimistic close once the (off-thread) busy check
+/// has come back. The terminal was already removed from the layout when the
+/// close began; this decides what happens to its still-alive PTY.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingDecision {
+    /// No pending close remained — the PTY exited on its own (or was undone)
+    /// during the check window and the exit path already cleaned up. No-op.
+    Raced,
+    /// The terminal was idle: the PTY was queued for an immediate kill. The
+    /// caller should not show an undo toast.
+    Finalized,
+    /// The terminal was busy: the pending close stays, and the caller should
+    /// post the undo toast + schedule the grace-period teardown.
+    KeepForUndo,
+}
+
 impl Workspace {
     /// Begin a soft close: snapshot the project's layout, remove the terminal
     /// from the tree (focusing a sibling, exactly like a normal close), and
@@ -74,6 +90,31 @@ impl Workspace {
         // observer drains the kill queue on this notification.
         cx.notify();
         true
+    }
+
+    /// Resolve an optimistic close after the off-thread busy check returns.
+    ///
+    /// The pane was already ejected from the layout when the close began (so the
+    /// UI updated instantly); here we decide the PTY's fate now that we know
+    /// whether the terminal was busy. Idle terminals are killed immediately;
+    /// busy ones keep their pending record so the caller can offer an undo. If
+    /// the pending record is gone (the shell exited during the check window),
+    /// this is a no-op — see [`PendingDecision::Raced`].
+    pub fn decide_pending_close(
+        &mut self,
+        terminal_id: &str,
+        busy: bool,
+        cx: &mut Context<Self>,
+    ) -> PendingDecision {
+        if !self.has_pending_close(terminal_id) {
+            return PendingDecision::Raced;
+        }
+        if busy {
+            return PendingDecision::KeepForUndo;
+        }
+        // Idle terminal — no point keeping it alive for an undo. Queue the kill.
+        self.finalize_soft_close(terminal_id, cx);
+        PendingDecision::Finalized
     }
 
     /// Undo a soft close, bringing the terminal back into the layout.
@@ -219,6 +260,7 @@ impl Workspace {
 mod tests {
     use gpui::AppContext as _;
 
+    use super::PendingDecision;
     use crate::focus::FocusManager;
     use crate::settings::HooksConfig;
     use crate::state::{LayoutNode, ProjectData, SplitDirection, Workspace, WorkspaceData};
@@ -340,6 +382,56 @@ mod tests {
 
             // Idempotent — second finalize is a no-op.
             assert!(!ws.finalize_soft_close("a", cx));
+        });
+    }
+
+    #[gpui::test]
+    fn decide_keeps_busy_terminal_for_undo(cx: &mut gpui::TestAppContext) {
+        let data = workspace_data(hsplit(vec![term("a"), term("b")]));
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            let mut fm = FocusManager::new();
+            ws.begin_soft_close(&mut fm, "p1", &[0], "a", "toast-a", cx);
+
+            // Busy → keep the pending record (no kill queued) so the caller can
+            // offer an undo.
+            assert_eq!(ws.decide_pending_close("a", true, cx), PendingDecision::KeepForUndo);
+            assert!(ws.has_pending_close("a"));
+            assert!(ws.drain_pending_terminal_kills().is_empty());
+        });
+    }
+
+    #[gpui::test]
+    fn decide_finalizes_idle_terminal(cx: &mut gpui::TestAppContext) {
+        let data = workspace_data(hsplit(vec![term("a"), term("b")]));
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            let mut fm = FocusManager::new();
+            ws.begin_soft_close(&mut fm, "p1", &[0], "a", "toast-a", cx);
+
+            // Idle → kill immediately, pending record dropped.
+            assert_eq!(ws.decide_pending_close("a", false, cx), PendingDecision::Finalized);
+            assert!(!ws.has_pending_close("a"));
+            assert_eq!(ws.drain_pending_terminal_kills(), vec!["a".to_string()]);
+        });
+    }
+
+    #[gpui::test]
+    fn decide_is_noop_when_pending_already_gone(cx: &mut gpui::TestAppContext) {
+        let data = workspace_data(hsplit(vec![term("a"), term("b")]));
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            let mut fm = FocusManager::new();
+            ws.begin_soft_close(&mut fm, "p1", &[0], "a", "toast-a", cx);
+            // Shell exited during the check window — exit path cancelled the pending close.
+            ws.cancel_pending_close("a");
+
+            // Whatever the busy result, there's nothing left to decide.
+            assert_eq!(ws.decide_pending_close("a", true, cx), PendingDecision::Raced);
+            assert!(ws.drain_pending_terminal_kills().is_empty());
         });
     }
 


### PR DESCRIPTION
## Problem

Closing a terminal had a perceptible **few-hundred-ms lag on macOS** (not reproducible on Linux).

The grace-period soft-close busy check ran **synchronously on the GPUI thread, before** the pane was removed from the layout. On macOS that check forks subprocesses:

- `get_foreground_shell_pid` → spawns `tmux list-panes` (tmux backend) or `lsof` ×2 (dtach backend)
- `has_child_processes` → spawns `pgrep -P`

On Linux these are sub-millisecond `/proc` reads, so the lag was macOS-only. Each `fork+exec` on macOS is expensive (dyld, AMFI/codesign), and they sat directly on the close keypath.

## Fix

Make every interactive close **optimistic**:

1. **Eject the pane from the layout immediately** (PTY stays alive) — instant, no subprocess work on the GPUI thread.
2. Run the busy probe **off the GPUI thread** via `smol::unblock`.
3. When it returns: **idle** → kill the PTY now (no toast); **busy** → show the undo toast + grace timer (unchanged behaviour).

The end state is identical to before — only the ordering changed — and the UI now updates instantly **regardless of session backend** (tmux/dtach/plain). Applies to both single (`CloseTerminal`) and multi (`CloseTerminals`) close.

## Changes

- **okena-workspace**: `Workspace::decide_pending_close` → `PendingDecision { Raced, Finalized, KeepForUndo }`. Pure decision logic, unit-tested; the UI layer only handles the toast.
- **okena-app**: `soft_close::try_begin` → `begin` (optimistic); extracted `build_soft_close_toast`. A stable toast id is reserved up front so the toast is posted later only if the terminal turns out busy.
- **okena-state**: `Toast::with_id`.

## Races

Unchanged. If the shell exits during the probe or grace window, the existing exit-path `cancel_pending_close` / `reap_restored_close` handle it, and `decide_pending_close` no-ops when the pending record is already gone (`Raced`).

## Tests

- `decide_keeps_busy_terminal_for_undo`, `decide_finalizes_idle_terminal`, `decide_is_noop_when_pending_already_gone` (okena-workspace).
- Full workspace build, existing soft-close suite, and clippy all green.

> Follow-up PR replaces the macOS subprocess introspection (`pgrep`/`lsof`) with `libproc` syscalls — orthogonal perf/battery win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)