### PR TITLE
perf(macos): replace pgrep/lsof/ps with libproc for process introspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,6 +886,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3687,7 +3705,7 @@ dependencies = [
  "async-channel 2.5.0",
  "async-task",
  "backtrace",
- "bindgen",
+ "bindgen 0.71.1",
  "bitflags 2.11.0",
  "block",
  "cbindgen",
@@ -4979,6 +4997,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libproc"
+version = "0.14.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a54ad7278b8bc5301d5ffd2a94251c004feb971feba96c971ea4063645990757"
+dependencies = [
+ "bindgen 0.72.1",
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5252,7 +5281,7 @@ version = "0.1.0"
 source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
 dependencies = [
  "anyhow",
- "bindgen",
+ "bindgen 0.71.1",
  "core-foundation 0.10.0",
  "core-video",
  "ctor",
@@ -6413,6 +6442,7 @@ dependencies = [
  "async-channel 2.5.0",
  "base64",
  "libc",
+ "libproc",
  "log",
  "okena-core",
  "parking_lot",

--- a/crates/okena-services/src/port_detect.rs
+++ b/crates/okena-services/src/port_detect.rs
@@ -1,3 +1,6 @@
+// macOS resolves process tree + listening ports through `okena_terminal::macos_proc`
+// (libproc), so it needs neither `command` nor `safe_output`.
+#[cfg(any(target_os = "linux", windows))]
 use okena_core::process::{command, safe_output};
 use std::collections::{HashMap, HashSet, VecDeque};
 
@@ -14,7 +17,7 @@ const EPHEMERAL_PORT_MIN: u16 = 32768;
 // ---------------------------------------------------------------------------
 
 /// Build the system-wide parent→children process tree.
-/// On Linux reads `/proc`, on macOS runs `ps -eo pid,ppid`,
+/// On Linux reads `/proc`, on macOS uses `libproc`,
 /// on Windows runs a single `wmic` call.
 pub fn build_process_tree() -> HashMap<u32, Vec<u32>> {
     #[cfg(target_os = "linux")]
@@ -105,25 +108,8 @@ fn build_process_tree_linux() -> HashMap<u32, Vec<u32>> {
 
 #[cfg(target_os = "macos")]
 fn build_process_tree_macos() -> HashMap<u32, Vec<u32>> {
-    // Single `ps` call instead of recursive `pgrep -P` per PID.
-    let mut cmd = command("ps");
-    cmd.args(["-eo", "pid,ppid"]);
-    let output = match safe_output(&mut cmd) {
-        Ok(o) if o.status.success() => o,
-        _ => return HashMap::new(),
-    };
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut tree: HashMap<u32, Vec<u32>> = HashMap::new();
-    for line in stdout.lines().skip(1) {
-        let fields: Vec<&str> = line.split_whitespace().collect();
-        if fields.len() >= 2
-            && let (Ok(pid), Ok(ppid)) = (fields[0].parse::<u32>(), fields[1].parse::<u32>())
-        {
-            tree.entry(ppid).or_default().push(pid);
-        }
-    }
-    tree
+    // libproc (`proc_pidinfo`) instead of spawning `ps`.
+    okena_terminal::macos_proc::process_tree()
 }
 
 #[cfg(windows)]
@@ -218,14 +204,8 @@ fn get_listening_port_pairs_linux() -> Vec<(u32, u16)> {
 
 #[cfg(target_os = "macos")]
 fn get_listening_port_pairs_macos() -> Vec<(u32, u16)> {
-    let mut cmd = command("lsof");
-    cmd.args(["-iTCP", "-sTCP:LISTEN", "-P", "-n"]);
-    let output = match safe_output(&mut cmd) {
-        Ok(o) if o.status.success() => o,
-        _ => return Vec::new(),
-    };
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_lsof_output(&stdout)
+    // libproc socket-fd scan instead of spawning `lsof -iTCP -sTCP:LISTEN`.
+    okena_terminal::macos_proc::listening_port_pairs()
 }
 
 #[cfg(windows)]

--- a/crates/okena-terminal/Cargo.toml
+++ b/crates/okena-terminal/Cargo.toml
@@ -31,3 +31,8 @@ anyhow = "1.0"
 regex = "1.10"
 # Decoding base64 payloads in the OSC 99 (kitty) notification protocol.
 base64 = "0.22"
+
+# macOS process introspection via libproc syscalls, replacing fork+exec of
+# `pgrep` / `lsof` (slow on macOS). Linux uses /proc directly instead.
+[target.'cfg(target_os = "macos")'.dependencies]
+libproc = "0.14"

--- a/crates/okena-terminal/src/lib.rs
+++ b/crates/okena-terminal/src/lib.rs
@@ -2,6 +2,9 @@
 
 pub mod backend;
 pub mod input;
+/// macOS process introspection via libproc (replaces `pgrep`/`lsof`/`ps`).
+#[cfg(target_os = "macos")]
+pub mod macos_proc;
 pub mod process;
 pub mod pty_manager;
 pub mod session_backend;

--- a/crates/okena-terminal/src/macos_proc.rs
+++ b/crates/okena-terminal/src/macos_proc.rs
@@ -1,0 +1,139 @@
+//! macOS process introspection via `libproc` syscalls.
+//!
+//! Replaces fork+exec of `pgrep` / `lsof` / `ps` used for child-process
+//! detection, dtach socket → pid resolution and port detection. Each external
+//! command spawn costs tens of ms on macOS (dyld + AMFI/codesign checks), and
+//! they used to sit on hot/UI paths. Linux reads `/proc` directly for the same
+//! data; this is the in-process equivalent for macOS.
+//!
+//! Everything here is best-effort: a libproc error for one pid (e.g. a process
+//! that exited mid-scan, or one we lack permission to inspect) is skipped, not
+//! propagated — mirroring how the `pgrep`/`lsof` fallbacks silently ignored
+//! such cases.
+
+use libproc::libproc::bsd_info::BSDInfo;
+use libproc::libproc::file_info::{pidfdinfo, ListFDs, ProcFDType};
+use libproc::libproc::net_info::{SocketFDInfo, SocketInfoKind, TcpSIState};
+use libproc::libproc::proc_pid::{listpidinfo, name, pidinfo};
+use libproc::processes::{pids_by_type, ProcFilter};
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::os::unix::ffi::OsStrExt;
+use std::path::PathBuf;
+
+/// Direct child pids of `ppid` — equivalent to `pgrep -P <ppid>`.
+pub fn child_pids(ppid: u32) -> Vec<u32> {
+    pids_by_type(ProcFilter::ByParentProcess { ppid }).unwrap_or_default()
+}
+
+/// Whether `ppid` has any direct child process.
+pub fn has_children(ppid: u32) -> bool {
+    !child_pids(ppid).is_empty()
+}
+
+/// The first direct child pid of `ppid` (lowest pid, for determinism). Used to
+/// walk from a dtach daemon down to the actual shell process.
+pub fn first_child_pid(ppid: u32) -> Option<u32> {
+    child_pids(ppid).into_iter().min()
+}
+
+/// Best-effort short accounting name of a process (e.g. "make", "vim").
+pub fn process_name(pid: u32) -> Option<String> {
+    name(pid as i32).ok().filter(|s| !s.is_empty())
+}
+
+/// pid → direct-children map for every process on the system — equivalent to a
+/// single `ps -eo pid,ppid` building a process tree.
+pub fn process_tree() -> HashMap<u32, Vec<u32>> {
+    let mut tree: HashMap<u32, Vec<u32>> = HashMap::new();
+    for pid in pids_by_type(ProcFilter::All).unwrap_or_default() {
+        if let Ok(info) = pidinfo::<BSDInfo>(pid as i32, 0) {
+            tree.entry(info.pbi_ppid).or_default().push(pid);
+        }
+    }
+    tree
+}
+
+/// Map each given unix-socket path to the pids that have it open — equivalent to
+/// `lsof <paths>`. Scans every process's socket fds and matches the bound
+/// unix-domain address against the requested paths (exact match, like the lsof
+/// fallback).
+pub fn pids_holding_unix_sockets(socket_paths: &[PathBuf]) -> HashMap<PathBuf, Vec<u32>> {
+    let mut result: HashMap<PathBuf, Vec<u32>> = HashMap::new();
+    if socket_paths.is_empty() {
+        return result;
+    }
+    for pid in pids_by_type(ProcFilter::All).unwrap_or_default() {
+        for socket in socket_fds(pid) {
+            if !matches!(SocketInfoKind::from(socket.psi.soi_kind), SocketInfoKind::Un) {
+                continue;
+            }
+            // SAFETY: `soi_kind == Un` means `pri_un` is the active union arm.
+            let un = unsafe { socket.psi.soi_proto.pri_un };
+            // SAFETY: `ua_sun` is the active arm of the bound-address union for a
+            // unix-domain socket.
+            let path = unsafe { sun_path(&un.unsi_addr.ua_sun) };
+            if let Some(path) = path
+                && let Some(target) = socket_paths.iter().find(|p| **p == path)
+            {
+                result.entry(target.clone()).or_default().push(pid);
+            }
+        }
+    }
+    result
+}
+
+/// All `(pid, local_port)` pairs for TCP sockets in the LISTEN state —
+/// equivalent to the `lsof -iTCP -sTCP:LISTEN` scan used for port detection.
+pub fn listening_port_pairs() -> Vec<(u32, u16)> {
+    let mut pairs = Vec::new();
+    for pid in pids_by_type(ProcFilter::All).unwrap_or_default() {
+        for socket in socket_fds(pid) {
+            if !matches!(SocketInfoKind::from(socket.psi.soi_kind), SocketInfoKind::Tcp) {
+                continue;
+            }
+            // SAFETY: `soi_kind == Tcp` means `pri_tcp` is the active union arm.
+            let tcp = unsafe { socket.psi.soi_proto.pri_tcp };
+            if !matches!(TcpSIState::from(tcp.tcpsi_state), TcpSIState::Listen) {
+                continue;
+            }
+            // insi_lport is the port in network byte order, in the low 16 bits.
+            let port = u16::from_be(tcp.tcpsi_ini.insi_lport as u16);
+            if port != 0 {
+                pairs.push((pid, port));
+            }
+        }
+    }
+    pairs
+}
+
+/// All open socket fds of `pid`, decoded. Best-effort: empty on any libproc
+/// error (process gone, permission denied, …).
+fn socket_fds(pid: u32) -> Vec<SocketFDInfo> {
+    let pid = pid as i32;
+    let Ok(info) = pidinfo::<BSDInfo>(pid, 0) else {
+        return Vec::new();
+    };
+    let Ok(fds) = listpidinfo::<ListFDs>(pid, info.pbi_nfiles as usize) else {
+        return Vec::new();
+    };
+    fds.into_iter()
+        .filter(|fd| matches!(ProcFDType::from(fd.proc_fdtype), ProcFDType::Socket))
+        .filter_map(|fd| pidfdinfo::<SocketFDInfo>(pid, fd.proc_fd).ok())
+        .collect()
+}
+
+/// Decode a bound `sockaddr_un.sun_path` into a filesystem path. Returns `None`
+/// for empty / abstract sockets.
+///
+/// SAFETY: caller must ensure `sun` is the active arm of the address union.
+unsafe fn sun_path(sun: &libc::sockaddr_un) -> Option<PathBuf> {
+    let raw = &sun.sun_path;
+    let len = raw.iter().position(|&c| c == 0).unwrap_or(raw.len());
+    if len == 0 {
+        return None;
+    }
+    // c_char is i8 on macOS; reinterpret the NUL-terminated path bytes as u8.
+    let bytes = unsafe { std::slice::from_raw_parts(raw.as_ptr().cast::<u8>(), len) };
+    Some(PathBuf::from(OsStr::from_bytes(bytes)))
+}

--- a/crates/okena-terminal/src/pty_manager.rs
+++ b/crates/okena-terminal/src/pty_manager.rs
@@ -1183,6 +1183,7 @@ fn wait_for_exit_code(pid: u32) -> Option<u32> {
 ///
 /// On Linux, reads `/proc/net/unix` to map socket paths to inode numbers,
 /// then scans `/proc/*/fd/` to find PIDs holding those inodes.
+/// On macOS, uses `libproc` to scan each process's socket fds — no subprocess.
 /// On other Unix systems, falls back to a single `lsof` invocation.
 #[cfg(unix)]
 pub(crate) fn find_pids_for_unix_sockets(
@@ -1197,7 +1198,12 @@ pub(crate) fn find_pids_for_unix_sockets(
         find_pids_for_unix_sockets_linux(socket_paths)
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "macos")]
+    {
+        crate::macos_proc::pids_holding_unix_sockets(socket_paths)
+    }
+
+    #[cfg(all(unix, not(target_os = "linux"), not(target_os = "macos")))]
     {
         find_pids_for_unix_sockets_lsof(socket_paths)
     }
@@ -1298,8 +1304,9 @@ fn find_pids_for_unix_sockets_linux(
     result
 }
 
-/// Fallback for non-Linux Unix: single `lsof` call for all sockets.
-#[cfg(all(unix, not(target_os = "linux")))]
+/// Fallback for non-Linux, non-macOS Unix (e.g. BSD): single `lsof` call for
+/// all sockets. macOS uses `crate::macos_proc` instead.
+#[cfg(all(unix, not(target_os = "linux"), not(target_os = "macos")))]
 fn find_pids_for_unix_sockets_lsof(
     socket_paths: &[std::path::PathBuf],
 ) -> HashMap<std::path::PathBuf, Vec<u32>> {
@@ -1360,7 +1367,12 @@ fn first_proc_child(pid: u32) -> Option<u32> {
     contents.split_whitespace().next().and_then(|s| s.parse().ok())
 }
 
-#[cfg(all(unix, not(target_os = "linux")))]
+#[cfg(target_os = "macos")]
+fn first_proc_child(pid: u32) -> Option<u32> {
+    crate::macos_proc::first_child_pid(pid)
+}
+
+#[cfg(all(unix, not(target_os = "linux"), not(target_os = "macos")))]
 fn first_proc_child(pid: u32) -> Option<u32> {
     let output = crate::process::safe_output(
         crate::process::command("pgrep").args(["-P", &pid.to_string()]),

--- a/crates/okena-terminal/src/terminal/child_processes.rs
+++ b/crates/okena-terminal/src/terminal/child_processes.rs
@@ -2,6 +2,7 @@
 ///
 /// On Linux, this reads `/proc/<pid>/task/*/children` directly — sub-millisecond,
 /// safe to call synchronously from UI handlers (e.g. click / key-down).
+/// On macOS, it uses `libproc` (`proc_listpids`) — no fork+exec.
 /// On other Unix, falls back to `pgrep -P` (~5–20 ms fork+exec).
 /// On non-Unix, always returns false.
 #[cfg(target_os = "linux")]
@@ -23,7 +24,12 @@ pub fn has_child_processes(pid: u32) -> bool {
     false
 }
 
-#[cfg(all(unix, not(target_os = "linux")))]
+#[cfg(target_os = "macos")]
+pub fn has_child_processes(pid: u32) -> bool {
+    crate::macos_proc::has_children(pid)
+}
+
+#[cfg(all(unix, not(target_os = "linux"), not(target_os = "macos")))]
 pub fn has_child_processes(pid: u32) -> bool {
     crate::process::safe_output(
         crate::process::command("pgrep").args(["-P", &pid.to_string()]),
@@ -38,9 +44,10 @@ pub fn has_child_processes(_pid: u32) -> bool {
 }
 
 /// Best-effort name of the foreground command running under `pid` (the shell):
-/// the first child process's `comm` (e.g. "make", "vim", "cargo"). Linux only —
-/// reads `/proc/<child>/comm`; returns `None` elsewhere or when the shell has no
-/// child. Used to give the soft-close toast a "what am I killing" hint.
+/// the first child process's name (e.g. "make", "vim", "cargo"). On Linux reads
+/// `/proc/<child>/comm`; on macOS uses `libproc`; returns `None` elsewhere or
+/// when the shell has no child. Gives the soft-close toast a "what am I killing"
+/// hint.
 #[cfg(target_os = "linux")]
 pub fn foreground_command(pid: u32) -> Option<String> {
     let task_dir = format!("/proc/{pid}/task");
@@ -63,7 +70,12 @@ pub fn foreground_command(pid: u32) -> Option<String> {
     None
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "macos")]
+pub fn foreground_command(pid: u32) -> Option<String> {
+    crate::macos_proc::first_child_pid(pid).and_then(crate::macos_proc::process_name)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub fn foreground_command(_pid: u32) -> Option<String> {
     None
 }


### PR DESCRIPTION
## Why

On macOS, several process-introspection paths forked subprocesses:

| Use | Was (macOS) | Now |
|-----|-------------|-----|
| child pids (busy check, idle detection) | `pgrep -P` | `proc_listpids(PPID)` |
| dtach socket → pid | `lsof <socket>` (×2) | socket-fd scan |
| listening ports (services) | `lsof -iTCP -sTCP:LISTEN` | socket-fd scan |
| process tree (port detection) | `ps -eo pid,ppid` | `proc_pidinfo`/BSDInfo |

Each `fork+exec` on macOS costs tens of ms (dyld + AMFI/codesign). Linux already does all of this via `/proc` reads; this brings macOS to parity with in-process `libproc` syscalls — no subprocesses.

Companion to #145 (which moved the busy check off the GPUI thread). #145 fixes the perceived close lag regardless of backend; this removes the underlying `fork+exec` cost so the same introspection is cheap everywhere it's used (close path, idle detection, services panel).

## What

New macOS-only module `okena_terminal::macos_proc` wrapping `libproc`:

- `child_pids` / `has_children` / `first_child_pid` — replaces `pgrep -P`
- `process_name` — `proc_name`; also gives the soft-close toast a foreground-command hint on macOS (was Linux-only)
- `process_tree` — replaces `ps -eo pid,ppid`
- `pids_holding_unix_sockets` — matches bound `sockaddr_un` paths; replaces `lsof <socket>`
- `listening_port_pairs` — TCP `LISTEN` sockets → `(pid, port)`; replaces `lsof -iTCP -sTCP:LISTEN`

Wired into `child_processes.rs`, `pty_manager.rs` (dtach lookup + dtach-daemon→shell walk) and `okena-services::port_detect`.

`libproc` is a **macOS-only dependency**. Linux and Windows paths are untouched; other Unix (BSD) keeps the `pgrep`/`lsof` fallback (libproc is darwin-only).

## ⚠️ Verification note

`libproc` generates its bindings via bindgen against the macOS SDK **at build time**, so the new module **only compiles on macOS**. It is `cfg`'d out on Linux, which means:

- A Linux build does **not** compile it.
- The PR `check` job (Linux-only clippy `-D warnings` + tests) does **not** exercise it.

It needs a **macOS build before merge** — either locally (`cargo build --target aarch64-apple-darwin`) or via the multi-platform `build` workflow (tag / `workflow_dispatch`). The code follows libproc's documented API, but the FFI/union/struct-field access is unverified by CI until then.

Linux side (integration, cfg gating, BSD fallback) passes `cargo clippy --workspace --all-targets -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)