### PR TITLE
feat(search): shared "search in page" across file viewer, diff viewer & content-search preview

### DIFF
--- a/crates/okena-files/src/content_search_dialog/mod.rs
+++ b/crates/okena-files/src/content_search_dialog/mod.rs
@@ -117,6 +117,12 @@ pub struct ContentSearchDialog {
     /// Prevents re-anchoring the scroll on every render — without this,
     /// the user can't scroll past the highlighted row.
     pub(super) last_scrolled_match: Option<(PathBuf, usize)>,
+    /// In-page search ("search in page") over the preview pane (Cmd/Ctrl+F).
+    pub(super) preview_search: Option<crate::in_page_search::InPageSearch>,
+    /// Signature `(file, line_count, query, case_sensitive)` the preview search
+    /// matches were last computed for. Lets render recompute only when the
+    /// previewed file (incl. async load), query, or case mode actually changes.
+    pub(super) preview_search_sig: Option<(PathBuf, usize, String, bool)>,
 }
 
 impl ContentSearchDialog {
@@ -218,6 +224,8 @@ impl ContentSearchDialog {
             preview_selection: CodeSelection::default(),
             preview_file: None,
             last_scrolled_match: None,
+            preview_search: None,
+            preview_search_sig: None,
         };
 
         // Run initial search if we have a restored query

--- a/crates/okena-files/src/content_search_dialog/preview.rs
+++ b/crates/okena-files/src/content_search_dialog/preview.rs
@@ -2,13 +2,83 @@
 
 use super::{ContentSearchDialog, ResultRow, search_match_bg};
 use crate::code_view::{build_styled_text_with_backgrounds, selection_bg_ranges};
+use crate::in_page_search::{self, InPageSearch, SearchBarCallbacks};
 use crate::theme::theme;
 use gpui::prelude::FluentBuilder;
 use gpui::*;
+use okena_ui::simple_input::InputChangedEvent;
 use okena_ui::text_utils::find_word_boundaries;
 use okena_ui::tokens::{ui_text, ui_text_ms, ui_text_sm};
+use std::rc::Rc;
 
 impl ContentSearchDialog {
+    /// Open (or refocus) the in-page search bar over the preview pane. Only
+    /// meaningful in expanded mode, where the preview is visible.
+    pub(super) fn open_preview_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(ref search) = self.preview_search {
+            search.input.update(cx, |input, cx| {
+                input.select_all(cx);
+                input.focus(window, cx);
+            });
+            return;
+        }
+        let search = InPageSearch::new(None, window, cx);
+        cx.subscribe(
+            &search.input,
+            |_this: &mut Self, _, _: &InputChangedEvent, cx| {
+                // Recompute happens in render via the signature check; just
+                // request a re-render here.
+                cx.notify();
+            },
+        )
+        .detach();
+        self.preview_search = Some(search);
+        self.preview_search_sig = None;
+        cx.notify();
+    }
+
+    /// Close the preview search bar and return focus to the main query input.
+    pub(super) fn close_preview_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.preview_search = None;
+        self.preview_search_sig = None;
+        self.search_input.update(cx, |input, cx| input.focus(window, cx));
+        cx.notify();
+    }
+
+    pub(super) fn next_preview_search(&mut self, cx: &mut Context<Self>) {
+        if let Some(search) = self.preview_search.as_mut() {
+            search.next_match();
+        }
+        self.scroll_to_preview_search_match();
+        cx.notify();
+    }
+
+    pub(super) fn prev_preview_search(&mut self, cx: &mut Context<Self>) {
+        if let Some(search) = self.preview_search.as_mut() {
+            search.prev_match();
+        }
+        self.scroll_to_preview_search_match();
+        cx.notify();
+    }
+
+    pub(super) fn toggle_preview_search_case(&mut self, cx: &mut Context<Self>) {
+        if let Some(search) = self.preview_search.as_mut() {
+            search.toggle_case();
+        }
+        // Case is part of the signature, so render will recompute.
+        self.preview_search_sig = None;
+        cx.notify();
+    }
+
+    fn scroll_to_preview_search_match(&self) {
+        if let Some(search) = self.preview_search.as_ref()
+            && let Some(cell) = search.current_cell()
+        {
+            self.preview_scroll_handle
+                .scroll_to_item(cell, ScrollStrategy::Center);
+        }
+    }
+
     /// Render the file preview panel showing the selected match's file.
     pub(super) fn render_preview_panel(&mut self, cx: &mut Context<Self>) -> impl IntoElement + use<> {
         let t = theme(cx);
@@ -75,6 +145,44 @@ impl ContentSearchDialog {
             a: 0.4,
         });
 
+        // In-page search ("search in page", Cmd/Ctrl+F): recompute matches when
+        // the previewed file (incl. async load), query, or case mode changed.
+        let search_inputs = self.preview_search.as_ref().map(|search| {
+            let query = search.input.read(cx).value().to_string();
+            let case = search.case_sensitive();
+            ((file_path.clone(), line_count, query.clone(), case), query, case)
+        });
+        if let Some((sig, query, case)) = search_inputs
+            && self.preview_search_sig.as_ref() != Some(&sig)
+        {
+            let matches = in_page_search::compute_matches(
+                &query,
+                case,
+                lines.iter().map(|l| l.plain_text.as_str()),
+            );
+            if let Some(search) = self.preview_search.as_mut() {
+                search.set_matches(matches);
+            }
+            self.preview_search_sig = Some(sig);
+        }
+        let preview_search_bar: Option<AnyElement> = self.preview_search.as_ref().map(|search| {
+            in_page_search::render_search_bar(
+                search,
+                &t,
+                cx,
+                SearchBarCallbacks {
+                    on_next: Rc::new(|this: &mut Self, cx| this.next_preview_search(cx)),
+                    on_prev: Rc::new(|this: &mut Self, cx| this.prev_preview_search(cx)),
+                    on_toggle_case: Rc::new(|this: &mut Self, cx| {
+                        this.toggle_preview_search_case(cx)
+                    }),
+                    on_close: Rc::new(|this: &mut Self, window, cx| {
+                        this.close_preview_search(window, cx)
+                    }),
+                },
+            )
+        });
+
         // Find all matches in this file to highlight them all (current brighter)
         let all_matches_in_file: Vec<(usize, Vec<std::ops::Range<usize>>)> = self
             .rows
@@ -126,6 +234,8 @@ impl ContentSearchDialog {
                     .text_ellipsis()
                     .child(relative_path),
             )
+            // In-page search bar (Cmd/Ctrl+F)
+            .children(preview_search_bar)
             // File content
             .child(
                 uniform_list(
@@ -168,6 +278,9 @@ impl ContentSearchDialog {
                                             );
                                         }
                                         bg_ranges.extend(sel_bg_ranges);
+                                        if let Some(search) = this.preview_search.as_ref() {
+                                            bg_ranges.extend(search.ranges_for_cell(line_idx, &t));
+                                        }
                                         build_styled_text_with_backgrounds(
                                             &hl.spans, &bg_ranges,
                                         )

--- a/crates/okena-files/src/content_search_dialog/render.rs
+++ b/crates/okena-files/src/content_search_dialog/render.rs
@@ -19,14 +19,18 @@ impl Render for ContentSearchDialog {
         let focus_handle = self.focus_handle.clone();
         let project_name = self.project_fs.project_name();
 
-        // Focus search input on first render
+        // Focus search input on first render. Don't steal focus while the
+        // preview's in-page search is open (its input should keep focus).
         let search_input_focus = self.search_input.read(cx).focus_handle(cx);
-        if !search_input_focus.is_focused(window) && !self.glob_editing {
+        if !search_input_focus.is_focused(window)
+            && !self.glob_editing
+            && self.preview_search.is_none()
+        {
             self.search_input.update(cx, |input, cx| input.focus(window, cx));
         }
 
         // Shared key handler for both modes
-        let key_handler = cx.listener(|this, event: &KeyDownEvent, _window, cx| {
+        let key_handler = cx.listener(|this, event: &KeyDownEvent, window, cx| {
             match event.keystroke.key.as_str() {
                 "up"
                     if this.select_prev() => {
@@ -37,6 +41,13 @@ impl Render for ContentSearchDialog {
                         cx.notify();
                     }
                 "enter" => this.open_selected(cx),
+                // In-page search over the preview (only visible when expanded)
+                "f" if (event.keystroke.modifiers.platform
+                    || event.keystroke.modifiers.control)
+                    && this.expanded =>
+                {
+                    this.open_preview_search(window, cx);
+                }
                 "tab" if !event.keystroke.modifiers.shift => {
                     this.expanded = !this.expanded;
                     if !this.search_input.read(cx).value().is_empty() {
@@ -44,7 +55,13 @@ impl Render for ContentSearchDialog {
                     }
                     cx.notify();
                 }
-                "escape" => this.close(cx),
+                "escape" => {
+                    if this.preview_search.is_some() {
+                        this.close_preview_search(window, cx);
+                    } else {
+                        this.close(cx);
+                    }
+                }
                 "c" if event.keystroke.modifiers.platform => {
                     if let Some(file_path) = &this.preview_file
                         && let Some(lines) = this.highlight_cache.get(file_path) {
@@ -193,7 +210,13 @@ impl Render for ContentSearchDialog {
             fullscreen_overlay("content-search-fullscreen", &t)
                 .track_focus(&focus_handle)
                 .key_context(self.config.key_context.as_str())
-                .on_action(cx.listener(|this, _: &Cancel, _window, cx| this.close(cx)))
+                .on_action(cx.listener(|this, _: &Cancel, window, cx| {
+                    if this.preview_search.is_some() {
+                        this.close_preview_search(window, cx);
+                    } else {
+                        this.close(cx);
+                    }
+                }))
                 .on_key_down(key_handler)
                 .child(header)
                 .child(
@@ -260,7 +283,13 @@ impl Render for ContentSearchDialog {
                 .key_context(self.config.key_context.as_str())
                 .items_start()
                 .pt(px(80.0))
-                .on_action(cx.listener(|this, _: &Cancel, _window, cx| this.close(cx)))
+                .on_action(cx.listener(|this, _: &Cancel, window, cx| {
+                    if this.preview_search.is_some() {
+                        this.close_preview_search(window, cx);
+                    } else {
+                        this.close(cx);
+                    }
+                }))
                 .on_key_down(key_handler)
                 .on_mouse_down(
                     MouseButton::Left,

--- a/crates/okena-files/src/file_viewer/mod.rs
+++ b/crates/okena-files/src/file_viewer/mod.rs
@@ -547,7 +547,7 @@ pub struct FileViewer {
     /// Delete confirmation dialog state
     pub(super) delete_confirm: Option<DeleteConfirmState>,
     /// In-file search state (Ctrl+F)
-    pub(super) search_state: Option<search::FileSearchState>,
+    pub(super) search_state: Option<crate::in_page_search::InPageSearch>,
     /// True when this viewer is hosted inside a detached window.
     /// Hides the "detach" button and is set by the detached host.
     pub(super) is_detached: bool,

--- a/crates/okena-files/src/file_viewer/render.rs
+++ b/crates/okena-files/src/file_viewer/render.rs
@@ -66,7 +66,7 @@ impl FileViewer {
         let gutter_width = (tab.line_num_width as f32) * char_width + 16.0;
 
         let mut bg_ranges = selection_bg_ranges(&tab.selection, line_number, line.plain_text.len());
-        bg_ranges.extend(self.search_bg_ranges_for_line(line_number));
+        bg_ranges.extend(self.search_bg_ranges_for_line(line_number, t));
 
         let plain_text = line.plain_text.clone();
         let line_len = line.plain_text.len();

--- a/crates/okena-files/src/file_viewer/search.rs
+++ b/crates/okena-files/src/file_viewer/search.rs
@@ -1,95 +1,45 @@
-//! In-file search for the file viewer.
+//! In-file search for the file viewer — thin glue over the shared
+//! [`crate::in_page_search`] engine. Each cell is a source line; the cell id is
+//! the line index, which is also the `source_scroll_handle` item index.
 
-use crate::file_search::Cancel;
-use gpui::prelude::FluentBuilder;
+use crate::in_page_search::{self, InPageSearch, SearchBarCallbacks};
 use gpui::*;
 use okena_core::theme::ThemeColors;
-use okena_ui::icon_button::icon_button_sized;
-use okena_ui::simple_input::{InputChangedEvent, SimpleInput, SimpleInputState};
-use okena_ui::tokens::ui_text_md;
+use okena_ui::simple_input::InputChangedEvent;
 use std::ops::Range;
+use std::rc::Rc;
 
 use super::FileViewer;
-
-/// Background color for non-current search matches.
-const SEARCH_MATCH_BG: Rgba = Rgba {
-    r: 1.0,
-    g: 0.85,
-    b: 0.0,
-    a: 0.18,
-};
-
-/// Background color for the current (active) search match.
-const SEARCH_CURRENT_MATCH_BG: Rgba = Rgba {
-    r: 1.0,
-    g: 0.6,
-    b: 0.0,
-    a: 0.4,
-};
-
-/// A single match location in the file.
-pub(crate) struct SearchMatch {
-    pub line: usize,
-    pub start_col: usize,
-    pub end_col: usize,
-}
-
-/// State for the in-file search bar.
-pub(crate) struct FileSearchState {
-    pub input: Entity<SimpleInputState>,
-    pub matches: Vec<SearchMatch>,
-    pub current_match_index: Option<usize>,
-    pub case_sensitive: bool,
-}
 
 impl FileViewer {
     /// Open the in-file search bar. If already open, refocus and select all.
     pub(super) fn open_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let tab = self.active_tab();
-        if tab.is_empty() {
+        if self.active_tab().is_empty() {
             return;
         }
 
         // If search is already open, just refocus and select all
-        if let Some(ref state) = self.search_state {
-            state.input.update(cx, |input, cx| {
+        if let Some(ref search) = self.search_state {
+            search.input.update(cx, |input, cx| {
                 input.select_all(cx);
                 input.focus(window, cx);
             });
             return;
         }
 
-        // Pre-fill with selected text if any
-        let selected_text = self.get_selected_text().unwrap_or_default();
+        // Pre-fill with the current selection (first line only).
+        let selected_text = self.get_selected_text();
+        let search = InPageSearch::new(selected_text.as_deref(), window, cx);
 
-        let input = cx.new(|cx| {
-            let mut state = SimpleInputState::new(cx)
-                .placeholder("Search...")
-                .icon("icons/search.svg");
-            if !selected_text.is_empty() {
-                // Take only the first line of selection
-                let first_line = selected_text.lines().next().unwrap_or("");
-                state.set_value(first_line, cx);
-            }
-            state
-        });
-
-        input.update(cx, |input, cx| {
-            input.focus(window, cx);
-        });
-
-        cx.subscribe(&input, |this: &mut Self, _, _: &InputChangedEvent, cx| {
-            this.perform_file_search(cx);
-        })
+        cx.subscribe(
+            &search.input,
+            |this: &mut Self, _, _: &InputChangedEvent, cx| {
+                this.perform_file_search(cx);
+            },
+        )
         .detach();
 
-        self.search_state = Some(FileSearchState {
-            input,
-            matches: Vec::new(),
-            current_match_index: None,
-            case_sensitive: false,
-        });
-
+        self.search_state = Some(search);
         self.perform_file_search(cx);
         cx.notify();
     }
@@ -103,283 +53,96 @@ impl FileViewer {
 
     /// Run the search against the active tab's content.
     pub(super) fn perform_file_search(&mut self, cx: &mut Context<Self>) {
-        let state = match self.search_state.as_mut() {
-            Some(s) => s,
-            None => return,
-        };
-
-        let query = state.input.read(cx).value().to_string();
-        if query.is_empty() {
-            state.matches.clear();
-            state.current_match_index = None;
-            cx.notify();
+        let Some(search) = self.search_state.as_ref() else {
             return;
-        }
-
-        let case_sensitive = state.case_sensitive;
-        let query_lower = if case_sensitive {
-            query.clone()
-        } else {
-            query.to_lowercase()
         };
+        let query = search.input.read(cx).value().to_string();
+        let case_sensitive = search.case_sensitive();
 
-        let tab = self.active_tab();
-        let mut matches = Vec::new();
+        // Compute into a local Vec so the `search` borrow is released before the
+        // `active_tab` borrow.
+        let matches = in_page_search::compute_matches(
+            &query,
+            case_sensitive,
+            self.active_tab()
+                .highlighted_lines
+                .iter()
+                .map(|l| l.plain_text.as_str()),
+        );
 
-        for (line_idx, line) in tab.highlighted_lines.iter().enumerate() {
-            let text = &line.plain_text;
-            let search_text = if case_sensitive {
-                text.clone()
-            } else {
-                text.to_lowercase()
-            };
-
-            let mut start = 0;
-            while let Some(pos) = search_text[start..].find(&query_lower) {
-                let abs_pos = start + pos;
-                matches.push(SearchMatch {
-                    line: line_idx,
-                    start_col: abs_pos,
-                    end_col: abs_pos + query.len(),
-                });
-                start = abs_pos + 1;
-            }
+        if let Some(search) = self.search_state.as_mut() {
+            search.set_matches(matches);
         }
-
-        let current_match_index = if matches.is_empty() {
-            None
-        } else {
-            Some(0)
-        };
-
-        if let Some(state) = self.search_state.as_mut() {
-            state.matches = matches;
-            state.current_match_index = current_match_index;
-        }
-
         self.scroll_to_current_search_match();
         cx.notify();
     }
 
     /// Navigate to the next search match.
     pub(super) fn next_search_match(&mut self, cx: &mut Context<Self>) {
-        let state = match self.search_state.as_mut() {
-            Some(s) => s,
-            None => return,
-        };
-        if state.matches.is_empty() {
-            return;
+        if let Some(search) = self.search_state.as_mut() {
+            search.next_match();
         }
-        let next = match state.current_match_index {
-            Some(idx) => (idx + 1) % state.matches.len(),
-            None => 0,
-        };
-        state.current_match_index = Some(next);
         self.scroll_to_current_search_match();
         cx.notify();
     }
 
     /// Navigate to the previous search match.
     pub(super) fn prev_search_match(&mut self, cx: &mut Context<Self>) {
-        let state = match self.search_state.as_mut() {
-            Some(s) => s,
-            None => return,
-        };
-        if state.matches.is_empty() {
-            return;
+        if let Some(search) = self.search_state.as_mut() {
+            search.prev_match();
         }
-        let prev = match state.current_match_index {
-            Some(idx) => {
-                if idx == 0 {
-                    state.matches.len() - 1
-                } else {
-                    idx - 1
-                }
-            }
-            None => state.matches.len() - 1,
-        };
-        state.current_match_index = Some(prev);
         self.scroll_to_current_search_match();
         cx.notify();
     }
 
     /// Scroll the active tab to make the current search match visible.
     fn scroll_to_current_search_match(&self) {
-        let state = match self.search_state.as_ref() {
-            Some(s) => s,
-            None => return,
-        };
-        if let Some(idx) = state.current_match_index
-            && let Some(m) = state.matches.get(idx) {
-                self.active_tab()
-                    .source_scroll_handle
-                    .scroll_to_item(m.line, ScrollStrategy::Top);
-            }
+        if let Some(search) = self.search_state.as_ref()
+            && let Some(cell) = search.current_cell()
+        {
+            self.active_tab()
+                .source_scroll_handle
+                .scroll_to_item(cell, ScrollStrategy::Top);
+        }
     }
 
     /// Toggle case sensitivity and re-run search.
     pub(super) fn toggle_search_case_sensitive(&mut self, cx: &mut Context<Self>) {
-        if let Some(ref mut state) = self.search_state {
-            state.case_sensitive = !state.case_sensitive;
+        if let Some(search) = self.search_state.as_mut() {
+            search.toggle_case();
         }
         self.perform_file_search(cx);
     }
 
     /// Get background highlight ranges for search matches on a given line.
-    pub(super) fn search_bg_ranges_for_line(&self, line_index: usize) -> Vec<(Range<usize>, Hsla)> {
-        let state = match self.search_state.as_ref() {
-            Some(s) => s,
-            None => return Vec::new(),
-        };
-
-        let current_idx = state.current_match_index;
-        state
-            .matches
-            .iter()
-            .enumerate()
-            .filter(|(_, m)| m.line == line_index)
-            .map(|(i, m)| {
-                let color = if Some(i) == current_idx {
-                    SEARCH_CURRENT_MATCH_BG
-                } else {
-                    SEARCH_MATCH_BG
-                };
-                (m.start_col..m.end_col, color.into())
-            })
-            .collect()
+    pub(super) fn search_bg_ranges_for_line(
+        &self,
+        line_index: usize,
+        t: &ThemeColors,
+    ) -> Vec<(Range<usize>, Hsla)> {
+        match self.search_state.as_ref() {
+            Some(search) => search.ranges_for_cell(line_index, t),
+            None => Vec::new(),
+        }
     }
 
     /// Render the search bar UI.
-    pub(super) fn render_search_bar(
-        &self,
-        t: &ThemeColors,
-        cx: &mut Context<Self>,
-    ) -> AnyElement {
-        let Some(state) = self.search_state.as_ref() else {
+    pub(super) fn render_search_bar(&self, t: &ThemeColors, cx: &mut Context<Self>) -> AnyElement {
+        let Some(search) = self.search_state.as_ref() else {
             return div().id("file-search-bar-empty").into_any_element();
         };
-        let match_count = state.matches.len();
-        let current_idx = state.current_match_index.map(|i| i + 1).unwrap_or(0);
-        let match_text = if match_count > 0 {
-            format!("{}/{}", current_idx, match_count)
-        } else {
-            "0/0".to_string()
-        };
-        let case_sensitive = state.case_sensitive;
-        let input = &state.input;
-
-        div()
-            .id("file-search-bar")
-            .h(px(36.0))
-            .px(px(8.0))
-            .flex()
-            .items_center()
-            .gap(px(8.0))
-            .bg(rgb(t.bg_header))
-            .border_b_1()
-            .border_color(rgb(t.border))
-            .child(
-                div()
-                    .id("file-search-input-wrapper")
-                    .key_context("FileViewerSearch")
-                    .flex_1()
-                    .min_w(px(100.0))
-                    .max_w(px(300.0))
-                    .bg(rgb(t.bg_secondary))
-                    .border_1()
-                    .border_color(rgb(t.border_active))
-                    .rounded(px(4.0))
-                    .child(SimpleInput::new(input).text_size(ui_text_md(cx)))
-                    .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                        cx.stop_propagation();
-                    })
-                    .on_action(
-                        cx.listener(|this, _: &Cancel, window, cx| {
-                            this.close_search(window, cx);
-                        }),
-                    )
-                    .on_key_down(cx.listener(|this, event: &KeyDownEvent, _window, cx| {
-                        cx.stop_propagation();
-                        if event.keystroke.key.as_str() == "enter" {
-                            if event.keystroke.modifiers.shift {
-                                this.prev_search_match(cx);
-                            } else {
-                                this.next_search_match(cx);
-                            }
-                        }
-                    })),
-            )
-            .child(
-                div()
-                    .id("file-search-case-btn")
-                    .cursor_pointer()
-                    .w(px(24.0))
-                    .h(px(24.0))
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .rounded(px(4.0))
-                    .when(case_sensitive, |s| s.bg(rgb(t.bg_selection)))
-                    .hover(|s| s.bg(rgb(t.bg_hover)))
-                    .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                        cx.stop_propagation();
-                    })
-                    .on_click(cx.listener(|this, _, _window, cx| {
-                        this.toggle_search_case_sensitive(cx);
-                    }))
-                    .child(
-                        div()
-                            .text_size(ui_text_md(cx))
-                            .font_weight(FontWeight::BOLD)
-                            .text_color(if case_sensitive {
-                                rgb(t.text_primary)
-                            } else {
-                                rgb(t.text_secondary)
-                            })
-                            .child("Aa"),
-                    ),
-            )
-            .child(
-                div()
-                    .text_size(ui_text_md(cx))
-                    .text_color(rgb(t.text_secondary))
-                    .min_w(px(40.0))
-                    .child(match_text),
-            )
-            .child(
-                icon_button_sized("file-search-prev-btn", "icons/chevron-up.svg", 24.0, 14.0, t)
-                    .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                        cx.stop_propagation();
-                    })
-                    .on_click(cx.listener(|this, _, _window, cx| {
-                        this.prev_search_match(cx);
-                    })),
-            )
-            .child(
-                icon_button_sized(
-                    "file-search-next-btn",
-                    "icons/chevron-down.svg",
-                    24.0,
-                    14.0,
-                    t,
-                )
-                .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                    cx.stop_propagation();
-                })
-                .on_click(cx.listener(|this, _, _window, cx| {
-                    this.next_search_match(cx);
-                })),
-            )
-            .child(
-                icon_button_sized("file-search-close-btn", "icons/close.svg", 24.0, 14.0, t)
-                    .hover(|s| s.bg(gpui::rgba(0xf14c4c99)))
-                    .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                        cx.stop_propagation();
-                    })
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        this.close_search(window, cx);
-                    })),
-            )
-            .into_any_element()
+        in_page_search::render_search_bar(
+            search,
+            t,
+            cx,
+            SearchBarCallbacks {
+                on_next: Rc::new(|this: &mut Self, cx| this.next_search_match(cx)),
+                on_prev: Rc::new(|this: &mut Self, cx| this.prev_search_match(cx)),
+                on_toggle_case: Rc::new(|this: &mut Self, cx| {
+                    this.toggle_search_case_sensitive(cx)
+                }),
+                on_close: Rc::new(|this: &mut Self, window, cx| this.close_search(window, cx)),
+            },
+        )
     }
 }

--- a/crates/okena-files/src/in_page_search.rs
+++ b/crates/okena-files/src/in_page_search.rs
@@ -1,0 +1,350 @@
+//! Shared, view-agnostic in-page search ("search in page" / find-in-content).
+//!
+//! Used by the file viewer, the git diff viewer, and the content-search preview
+//! pane. The engine is deliberately dumb: it searches a flat list of **cells**
+//! (each cell is a line of text identified by an opaque `usize` chosen by the
+//! host) and tracks the current match. The host owns all view semantics — what a
+//! cell maps to (a line index, or a side-by-side row/column) and how to scroll
+//! to it.
+//!
+//! Typical host wiring:
+//! 1. On open: `InPageSearch::new(...)`, then `cx.subscribe(&search.input, ...)`
+//!    to a `recompute` wrapper, and run `recompute` once.
+//! 2. `recompute`: read the query from `search.input`, call [`compute_matches`]
+//!    over the host's cell texts into a local `Vec`, then [`InPageSearch::set_matches`]
+//!    (this two-step keeps the `search` borrow separate from the content borrow).
+//! 3. Per rendered line/cell: merge [`InPageSearch::ranges_for_cell`] into the
+//!    background ranges passed to `build_styled_text_with_backgrounds`.
+//! 4. Render [`render_search_bar`] above the content with [`SearchBarCallbacks`].
+
+use std::ops::Range;
+use std::rc::Rc;
+
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+use okena_core::theme::ThemeColors;
+use okena_ui::icon_button::icon_button_sized;
+use okena_ui::simple_input::{SimpleInput, SimpleInputState};
+use okena_ui::tokens::ui_text_md;
+
+/// A single match location: byte range `[start, end)` within cell `cell`.
+pub struct SearchMatch {
+    pub cell: usize,
+    pub start: usize,
+    pub end: usize,
+}
+
+/// View-agnostic in-page search state.
+pub struct InPageSearch {
+    /// The query input box. Owned here; the host subscribes to its
+    /// `InputChangedEvent` and re-runs its `recompute`.
+    pub input: Entity<SimpleInputState>,
+    matches: Vec<SearchMatch>,
+    current: Option<usize>,
+    case_sensitive: bool,
+}
+
+impl InPageSearch {
+    /// Create the search state, building & focusing the query input.
+    ///
+    /// `prefill` pre-populates the query (e.g. from the current text selection);
+    /// only its first line is used.
+    pub fn new<V: 'static>(
+        prefill: Option<&str>,
+        window: &mut Window,
+        cx: &mut Context<V>,
+    ) -> Self {
+        let input = cx.new(|cx| {
+            let mut state = SimpleInputState::new(cx)
+                .placeholder("Search...")
+                .icon("icons/search.svg");
+            if let Some(text) = prefill {
+                let first_line = text.lines().next().unwrap_or("");
+                if !first_line.is_empty() {
+                    state.set_value(first_line, cx);
+                }
+            }
+            state
+        });
+        input.update(cx, |input, cx| input.focus(window, cx));
+        Self {
+            input,
+            matches: Vec::new(),
+            current: None,
+            case_sensitive: false,
+        }
+    }
+
+    /// Replace the match set (after the query, case mode, or content changed).
+    /// Resets the current match to the first one.
+    pub fn set_matches(&mut self, matches: Vec<SearchMatch>) {
+        self.current = if matches.is_empty() { None } else { Some(0) };
+        self.matches = matches;
+    }
+
+    pub fn case_sensitive(&self) -> bool {
+        self.case_sensitive
+    }
+
+    /// Toggle case sensitivity. The host is responsible for recomputing matches.
+    pub fn toggle_case(&mut self) {
+        self.case_sensitive = !self.case_sensitive;
+    }
+
+    pub fn match_count(&self) -> usize {
+        self.matches.len()
+    }
+
+    /// 1-based index of the current match (0 when there are none), for the
+    /// "n/N" counter.
+    pub fn current_1based(&self) -> usize {
+        self.current.map(|i| i + 1).unwrap_or(0)
+    }
+
+    /// Cell of the current match, if any. The host scrolls to it.
+    pub fn current_cell(&self) -> Option<usize> {
+        self.current
+            .and_then(|i| self.matches.get(i))
+            .map(|m| m.cell)
+    }
+
+    /// Advance to the next match (wrapping); returns the new current cell.
+    pub fn next_match(&mut self) -> Option<usize> {
+        if self.matches.is_empty() {
+            return None;
+        }
+        let next = match self.current {
+            Some(i) => (i + 1) % self.matches.len(),
+            None => 0,
+        };
+        self.current = Some(next);
+        self.current_cell()
+    }
+
+    /// Step to the previous match (wrapping); returns the new current cell.
+    pub fn prev_match(&mut self) -> Option<usize> {
+        if self.matches.is_empty() {
+            return None;
+        }
+        let prev = match self.current {
+            Some(0) => self.matches.len() - 1,
+            Some(i) => i - 1,
+            None => self.matches.len() - 1,
+        };
+        self.current = Some(prev);
+        self.current_cell()
+    }
+
+    /// Background highlight ranges for `cell` — bright for the current match,
+    /// dim for the rest. Feed the result to `build_styled_text_with_backgrounds`.
+    pub fn ranges_for_cell(&self, cell: usize, t: &ThemeColors) -> Vec<(Range<usize>, Hsla)> {
+        let match_bg = color_with_alpha(t.search_match_bg, 0.4);
+        let current_bg = color_with_alpha(t.search_current_bg, 0.7);
+        let current = self.current;
+        self.matches
+            .iter()
+            .enumerate()
+            .filter(|(_, m)| m.cell == cell)
+            .map(|(i, m)| {
+                let color = if Some(i) == current {
+                    current_bg
+                } else {
+                    match_bg
+                };
+                (m.start..m.end, color)
+            })
+            .collect()
+    }
+}
+
+/// Compute literal-substring matches over a sequence of cells.
+///
+/// `cells` yields the plain text of each cell in host order; the cell id is the
+/// iteration index. Returns byte-offset ranges. An empty query yields no
+/// matches.
+pub fn compute_matches<'a>(
+    query: &str,
+    case_sensitive: bool,
+    cells: impl Iterator<Item = &'a str>,
+) -> Vec<SearchMatch> {
+    if query.is_empty() {
+        return Vec::new();
+    }
+    let needle = if case_sensitive {
+        query.to_string()
+    } else {
+        query.to_lowercase()
+    };
+    let mut matches = Vec::new();
+    for (cell, text) in cells.enumerate() {
+        let haystack = if case_sensitive {
+            text.to_string()
+        } else {
+            text.to_lowercase()
+        };
+        let mut start = 0;
+        while let Some(pos) = haystack[start..].find(&needle) {
+            let abs = start + pos;
+            matches.push(SearchMatch {
+                cell,
+                start: abs,
+                end: abs + query.len(),
+            });
+            start = abs + 1;
+        }
+    }
+    matches
+}
+
+/// Convert a `0xRRGGBB` theme color to `Hsla` with the given alpha.
+fn color_with_alpha(rgb: u32, alpha: f32) -> Hsla {
+    Hsla::from(Rgba {
+        r: ((rgb >> 16) & 0xFF) as f32 / 255.0,
+        g: ((rgb >> 8) & 0xFF) as f32 / 255.0,
+        b: (rgb & 0xFF) as f32 / 255.0,
+        a: alpha,
+    })
+}
+
+/// A search-bar callback invoked with the host view and its context.
+pub type SearchCallback<V> = Rc<dyn Fn(&mut V, &mut Context<V>)>;
+/// A search-bar callback that also needs the window (e.g. to move focus).
+pub type SearchCallbackWin<V> = Rc<dyn Fn(&mut V, &mut Window, &mut Context<V>)>;
+
+/// Host callbacks for the shared search bar. Each closure receives the host
+/// view; the host bridges to its own engine + scroll glue. `Rc` because some
+/// callbacks are wired to both a keystroke and a button.
+pub struct SearchBarCallbacks<V> {
+    pub on_next: SearchCallback<V>,
+    pub on_prev: SearchCallback<V>,
+    pub on_toggle_case: SearchCallback<V>,
+    pub on_close: SearchCallbackWin<V>,
+}
+
+/// Render the shared search bar (input + case toggle + "n/N" counter + prev/next
+/// + close).
+///
+/// Handles Enter / Shift+Enter (next/prev) on the query input and stops key
+/// propagation so typed keys never leak into host shortcuts. Escape is left to
+/// the host's own root `Cancel` action (each host closes search first if open),
+/// which keeps the bar free of any crate-specific action dependency.
+pub fn render_search_bar<V: 'static>(
+    search: &InPageSearch,
+    t: &ThemeColors,
+    cx: &mut Context<V>,
+    cb: SearchBarCallbacks<V>,
+) -> AnyElement {
+    let match_count = search.match_count();
+    let match_text = if match_count > 0 {
+        format!("{}/{}", search.current_1based(), match_count)
+    } else {
+        "0/0".to_string()
+    };
+    let case_sensitive = search.case_sensitive();
+    let input = &search.input;
+
+    let on_next_key = cb.on_next.clone();
+    let on_prev_key = cb.on_prev.clone();
+
+    div()
+        .id("in-page-search-bar")
+        .h(px(36.0))
+        .px(px(8.0))
+        .flex()
+        .items_center()
+        .gap(px(8.0))
+        .bg(rgb(t.bg_header))
+        .border_b_1()
+        .border_color(rgb(t.border))
+        .child(
+            div()
+                .id("in-page-search-input-wrapper")
+                .key_context("InPageSearch")
+                .flex_1()
+                .min_w(px(100.0))
+                .max_w(px(300.0))
+                .bg(rgb(t.bg_secondary))
+                .border_1()
+                .border_color(rgb(t.border_active))
+                .rounded(px(4.0))
+                .child(SimpleInput::new(input).text_size(ui_text_md(cx)))
+                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                .on_key_down(cx.listener(move |this, event: &KeyDownEvent, _window, cx| {
+                    let key = event.keystroke.key.as_str();
+                    // Let Escape bubble to the host's root handler (Cancel action
+                    // or key handler) so it can close search. Everything else is
+                    // stopped so typed keys never leak into host shortcuts.
+                    if key == "escape" {
+                        return;
+                    }
+                    cx.stop_propagation();
+                    if key == "enter" {
+                        if event.keystroke.modifiers.shift {
+                            (on_prev_key)(this, cx);
+                        } else {
+                            (on_next_key)(this, cx);
+                        }
+                    }
+                })),
+        )
+        .child({
+            let on_toggle = cb.on_toggle_case.clone();
+            div()
+                .id("in-page-search-case-btn")
+                .cursor_pointer()
+                .w(px(24.0))
+                .h(px(24.0))
+                .flex()
+                .items_center()
+                .justify_center()
+                .rounded(px(4.0))
+                .when(case_sensitive, |s| s.bg(rgb(t.bg_selection)))
+                .hover(|s| s.bg(rgb(t.bg_hover)))
+                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                .on_click(cx.listener(move |this, _, _window, cx| (on_toggle)(this, cx)))
+                .child(
+                    div()
+                        .text_size(ui_text_md(cx))
+                        .font_weight(FontWeight::BOLD)
+                        .text_color(if case_sensitive {
+                            rgb(t.text_primary)
+                        } else {
+                            rgb(t.text_secondary)
+                        })
+                        .child("Aa"),
+                )
+        })
+        .child(
+            div()
+                .text_size(ui_text_md(cx))
+                .text_color(rgb(t.text_secondary))
+                .min_w(px(40.0))
+                .child(match_text),
+        )
+        .child({
+            let on_prev = cb.on_prev.clone();
+            icon_button_sized("in-page-search-prev-btn", "icons/chevron-up.svg", 24.0, 14.0, t)
+                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                .on_click(cx.listener(move |this, _, _window, cx| (on_prev)(this, cx)))
+        })
+        .child({
+            let on_next = cb.on_next.clone();
+            icon_button_sized(
+                "in-page-search-next-btn",
+                "icons/chevron-down.svg",
+                24.0,
+                14.0,
+                t,
+            )
+            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .on_click(cx.listener(move |this, _, _window, cx| (on_next)(this, cx)))
+        })
+        .child({
+            let on_close = cb.on_close.clone();
+            icon_button_sized("in-page-search-close-btn", "icons/close.svg", 24.0, 14.0, t)
+                .hover(|s| s.bg(gpui::rgba(0xf14c4c99)))
+                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                .on_click(cx.listener(move |this, _, window, cx| (on_close)(this, window, cx)))
+        })
+        .into_any_element()
+}

--- a/crates/okena-files/src/lib.rs
+++ b/crates/okena-files/src/lib.rs
@@ -8,6 +8,7 @@ pub mod content_search_dialog;
 pub mod file_search;
 pub mod file_tree;
 pub mod file_viewer;
+pub mod in_page_search;
 pub mod list_directory;
 pub mod list_overlay;
 pub mod selection;

--- a/crates/okena-views-git/src/diff_viewer/line_render.rs
+++ b/crates/okena-views-git/src/diff_viewer/line_render.rs
@@ -276,7 +276,9 @@ impl DiffViewer {
 
         let (line_bg, _, accent_color) = self.line_colors(line.line_type, t);
 
-        let bg_ranges = selection_bg_ranges(&self.selection, line_index, line.plain_text.len());
+        let mut bg_ranges = selection_bg_ranges(&self.selection, line_index, line.plain_text.len());
+        // In-page search highlights (cell id = item index in unified view).
+        bg_ranges.extend(self.search_ranges_unified(line_index, t));
 
         let plain_text = line.plain_text.clone();
         let line_len = line.plain_text.len();

--- a/crates/okena-views-git/src/diff_viewer/mod.rs
+++ b/crates/okena-views-git/src/diff_viewer/mod.rs
@@ -10,6 +10,7 @@ mod nav;
 pub mod provider;
 mod render;
 mod scrollbar;
+mod search;
 mod selection_ops;
 mod side_by_side;
 mod syntax;
@@ -34,6 +35,22 @@ gpui::actions!(okena_git, [Cancel]);
 
 /// Type alias for diff selection (line index, column).
 type Selection = SelectionState<(usize, usize)>;
+
+/// Signature the in-page search matches were last computed for. Lets render
+/// recompute only when content-affecting state, the query, or case mode change:
+/// `(file_index, commit_index, diff_mode, ignore_whitespace, view_mode,
+/// items_len, sbs_len, query, case_sensitive)`.
+type DiffSearchSig = (
+    usize,
+    usize,
+    DiffMode,
+    bool,
+    DiffViewMode,
+    usize,
+    usize,
+    String,
+    bool,
+);
 
 /// Width of file tree sidebar.
 const SIDEBAR_WIDTH: f32 = 240.0;
@@ -107,6 +124,10 @@ pub struct DiffViewer {
     pub(super) commit_hash_menu: Option<context_menu::CommitHashContextMenu>,
     /// Right-click context menu over a non-empty text selection.
     pub(super) selection_context_menu: Option<Point<Pixels>>,
+    /// In-page search ("search in page", Cmd/Ctrl+F) over the diff content.
+    pub(super) search: Option<okena_files::in_page_search::InPageSearch>,
+    /// See [`DiffSearchSig`].
+    pub(super) search_sig: Option<DiffSearchSig>,
 }
 
 impl DiffViewer {
@@ -167,6 +188,8 @@ impl DiffViewer {
             is_detached: false,
             commit_hash_menu: None,
             selection_context_menu: None,
+            search: None,
+            search_sig: None,
         };
 
         if !provider.is_git_repo() {

--- a/crates/okena-views-git/src/diff_viewer/render.rs
+++ b/crates/okena-views-git/src/diff_viewer/render.rs
@@ -505,15 +505,10 @@ impl DiffViewer {
         let side_by_side_count = self.side_by_side_lines.len();
 
         // For new/deleted files, always use unified view (no point in split)
-        let current_stats = self.file_stats.get(self.selected_file_index);
-        let is_new_or_deleted = current_stats
-            .map(|f| f.is_new || f.is_deleted)
-            .unwrap_or(false);
-        let view_mode = if is_new_or_deleted {
-            DiffViewMode::Unified
-        } else {
-            self.view_mode
-        };
+        let view_mode = self.effective_view_mode();
+
+        // In-page search bar (recomputes matches when content/query/case change).
+        let search_bar = self.build_search_bar(view_mode, t, cx);
 
         // Horizontal scrollbar
         let scroll_x = self.scroll_x;
@@ -545,6 +540,8 @@ impl DiffViewer {
                     .text_color(rgb(t.text_secondary))
                     .child(file_path),
             )
+            // In-page search bar (Cmd/Ctrl+F)
+            .children(search_bar)
             .when(is_binary, |d| {
                 d.child(
                     div()
@@ -990,7 +987,11 @@ impl Render for DiffViewer {
         outer
             .track_focus(&focus_handle)
             .key_context("DiffViewer")
-            .on_action(cx.listener(|this, _: &Cancel, _window, cx| {
+            .on_action(cx.listener(|this, _: &Cancel, window, cx| {
+                if this.search.is_some() {
+                    this.close_search(window, cx);
+                    return;
+                }
                 if this.dismiss_transient_ui(cx) {
                     return;
                 }
@@ -1002,11 +1003,14 @@ impl Render for DiffViewer {
                     this.close(cx);
                 }
             }))
-            .on_key_down(cx.listener(|this, event: &KeyDownEvent, _window, cx| {
+            .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
                 let key = event.keystroke.key.as_str();
                 let modifiers = &event.keystroke.modifiers;
 
                 match key {
+                    "f" if modifiers.platform || modifiers.control => {
+                        this.open_search(window, cx);
+                    }
                     "tab" => this.toggle_mode(cx),
                     "s" => this.toggle_view_mode(cx),
                     "w" => this.toggle_ignore_whitespace(cx),

--- a/crates/okena-views-git/src/diff_viewer/scrollbar.rs
+++ b/crates/okena-views-git/src/diff_viewer/scrollbar.rs
@@ -122,7 +122,7 @@ impl DiffViewer {
     }
 
     /// Effective view mode (forced unified for new/deleted files).
-    fn effective_view_mode(&self) -> super::types::DiffViewMode {
+    pub(super) fn effective_view_mode(&self) -> super::types::DiffViewMode {
         let is_new_or_deleted = self
             .file_stats
             .get(self.selected_file_index)

--- a/crates/okena-views-git/src/diff_viewer/search.rs
+++ b/crates/okena-views-git/src/diff_viewer/search.rs
@@ -1,0 +1,199 @@
+//! In-page search ("search in page") for the diff viewer — thin glue over the
+//! shared [`okena_files::in_page_search`] engine.
+//!
+//! Cell scheme (the host owns the cell → view mapping):
+//! - **Unified**: one cell per `current_file.items` entry; cell id = item index =
+//!   `uniform_list` scroll item. Expanders contribute an empty (never-matching)
+//!   cell so indices stay aligned with the rendered list.
+//! - **Side-by-side**: two cells per row — `row*2 + 0` (left), `row*2 + 1`
+//!   (right); scroll item = `cell / 2`.
+
+use gpui::*;
+use okena_core::theme::ThemeColors;
+use okena_core::types::DiffViewMode;
+use okena_files::in_page_search::{self, InPageSearch, SearchBarCallbacks, SearchMatch};
+use okena_ui::simple_input::InputChangedEvent;
+use std::ops::Range;
+use std::rc::Rc;
+
+use super::types::{DisplayItem, SideBySideSide};
+use super::DiffViewer;
+
+impl DiffViewer {
+    /// Open (or refocus) the in-page search bar.
+    pub(super) fn open_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(ref search) = self.search {
+            search.input.update(cx, |input, cx| {
+                input.select_all(cx);
+                input.focus(window, cx);
+            });
+            return;
+        }
+        let search = InPageSearch::new(None, window, cx);
+        cx.subscribe(
+            &search.input,
+            |_this: &mut Self, _, _: &InputChangedEvent, cx| {
+                // Recompute happens in render via the signature check; just
+                // request a re-render here.
+                cx.notify();
+            },
+        )
+        .detach();
+        self.search = Some(search);
+        self.search_sig = None;
+        cx.notify();
+    }
+
+    /// Close search and return focus to the diff viewer.
+    pub(super) fn close_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.search = None;
+        self.search_sig = None;
+        window.focus(&self.focus_handle, cx);
+        cx.notify();
+    }
+
+    pub(super) fn next_search_match(&mut self, cx: &mut Context<Self>) {
+        if let Some(search) = self.search.as_mut() {
+            search.next_match();
+        }
+        self.scroll_to_search_match();
+        cx.notify();
+    }
+
+    pub(super) fn prev_search_match(&mut self, cx: &mut Context<Self>) {
+        if let Some(search) = self.search.as_mut() {
+            search.prev_match();
+        }
+        self.scroll_to_search_match();
+        cx.notify();
+    }
+
+    pub(super) fn toggle_search_case(&mut self, cx: &mut Context<Self>) {
+        if let Some(search) = self.search.as_mut() {
+            search.toggle_case();
+        }
+        self.search_sig = None; // case is part of the signature
+        cx.notify();
+    }
+
+    fn scroll_to_search_match(&self) {
+        let Some(search) = self.search.as_ref() else {
+            return;
+        };
+        let Some(cell) = search.current_cell() else {
+            return;
+        };
+        let item = match self.effective_view_mode() {
+            DiffViewMode::Unified => cell,
+            DiffViewMode::SideBySide => cell / 2,
+        };
+        self.scroll_handle.scroll_to_item(item, ScrollStrategy::Center);
+    }
+
+    /// Recompute matches if content / query / case changed, then render the bar.
+    /// Returns `None` when search is closed.
+    pub(super) fn build_search_bar(
+        &mut self,
+        view_mode: DiffViewMode,
+        t: &ThemeColors,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
+        let (query, case) = self
+            .search
+            .as_ref()
+            .map(|s| (s.input.read(cx).value().to_string(), s.case_sensitive()))?;
+
+        let items_len = self.current_file.as_ref().map(|f| f.items.len()).unwrap_or(0);
+        let sbs_len = self.side_by_side_lines.len();
+        let sig = (
+            self.selected_file_index,
+            self.commit_index,
+            self.diff_mode.clone(),
+            self.ignore_whitespace,
+            view_mode,
+            items_len,
+            sbs_len,
+            query.clone(),
+            case,
+        );
+        if self.search_sig.as_ref() != Some(&sig) {
+            let matches = self.compute_matches(view_mode, &query, case);
+            if let Some(search) = self.search.as_mut() {
+                search.set_matches(matches);
+            }
+            self.search_sig = Some(sig);
+        }
+
+        let search = self.search.as_ref()?;
+        Some(in_page_search::render_search_bar(
+            search,
+            t,
+            cx,
+            SearchBarCallbacks {
+                on_next: Rc::new(|this: &mut Self, cx| this.next_search_match(cx)),
+                on_prev: Rc::new(|this: &mut Self, cx| this.prev_search_match(cx)),
+                on_toggle_case: Rc::new(|this: &mut Self, cx| this.toggle_search_case(cx)),
+                on_close: Rc::new(|this: &mut Self, window, cx| this.close_search(window, cx)),
+            },
+        ))
+    }
+
+    fn compute_matches(&self, view_mode: DiffViewMode, query: &str, case: bool) -> Vec<SearchMatch> {
+        match view_mode {
+            DiffViewMode::Unified => {
+                let items = self
+                    .current_file
+                    .as_ref()
+                    .map(|f| f.items.as_slice())
+                    .unwrap_or(&[]);
+                in_page_search::compute_matches(
+                    query,
+                    case,
+                    items.iter().map(|it| match it {
+                        DisplayItem::Line(l) => l.plain_text.as_str(),
+                        DisplayItem::Expander(_) => "",
+                    }),
+                )
+            }
+            DiffViewMode::SideBySide => in_page_search::compute_matches(
+                query,
+                case,
+                self.side_by_side_lines.iter().flat_map(|sbs| {
+                    [
+                        sbs.left.as_ref().map(|c| c.plain_text.as_str()).unwrap_or(""),
+                        sbs.right.as_ref().map(|c| c.plain_text.as_str()).unwrap_or(""),
+                    ]
+                }),
+            ),
+        }
+    }
+
+    /// Search highlight ranges for a unified line (cell id = item index).
+    pub(super) fn search_ranges_unified(
+        &self,
+        item_index: usize,
+        t: &ThemeColors,
+    ) -> Vec<(Range<usize>, Hsla)> {
+        self.search
+            .as_ref()
+            .map(|s| s.ranges_for_cell(item_index, t))
+            .unwrap_or_default()
+    }
+
+    /// Search highlight ranges for a side-by-side cell (cell id = row*2 + side).
+    pub(super) fn search_ranges_sbs(
+        &self,
+        sbs_line_index: usize,
+        side: SideBySideSide,
+        t: &ThemeColors,
+    ) -> Vec<(Range<usize>, Hsla)> {
+        let side_idx = match side {
+            SideBySideSide::Left => 0,
+            SideBySideSide::Right => 1,
+        };
+        self.search
+            .as_ref()
+            .map(|s| s.ranges_for_cell(sbs_line_index * 2 + side_idx, t))
+            .unwrap_or_default()
+    }
+}

--- a/crates/okena-views-git/src/diff_viewer/side_by_side.rs
+++ b/crates/okena-views-git/src/diff_viewer/side_by_side.rs
@@ -303,6 +303,9 @@ impl DiffViewer {
                 let has_selection = self.selection_side == Some(side)
                     && self.selection.line_has_selection(sbs_line_index);
 
+                // In-page search highlights for this cell (row*2 + side).
+                let search_bg = self.search_ranges_sbs(sbs_line_index, side, t);
+
                 let (content_div, text_layout) = if has_selection {
                     self.render_spans_with_combined_highlight(
                         &c.spans,
@@ -310,6 +313,7 @@ impl DiffViewer {
                         word_bg,
                         &c.plain_text,
                         sbs_line_index,
+                        &search_bg,
                         line_height,
                     )
                 } else {
@@ -317,6 +321,7 @@ impl DiffViewer {
                         &c.spans,
                         &c.changed_ranges,
                         word_bg,
+                        &search_bg,
                         line_height,
                     )
                 };
@@ -452,14 +457,17 @@ impl DiffViewer {
         spans: &[super::types::HighlightedSpan],
         changed_ranges: &[ChangedRange],
         word_bg: Option<Rgba>,
+        extra_bg: &[(std::ops::Range<usize>, Hsla)],
         line_height: f32,
     ) -> (Div, TextLayout) {
-        let bg_ranges = self.compute_word_bg_ranges(spans, changed_ranges, word_bg);
+        let mut bg_ranges = self.compute_word_bg_ranges(spans, changed_ranges, word_bg);
+        bg_ranges.extend_from_slice(extra_bg);
         self.render_scrollable_content(spans, &bg_ranges, line_height)
     }
 
     /// Render spans with both word-level diff and selection highlighting merged.
     /// Returns `(Div, TextLayout)` for position-to-index mapping.
+    #[allow(clippy::too_many_arguments)]
     fn render_spans_with_combined_highlight(
         &self,
         spans: &[super::types::HighlightedSpan],
@@ -467,10 +475,12 @@ impl DiffViewer {
         word_bg: Option<Rgba>,
         plain_text: &str,
         line_index: usize,
+        extra_bg: &[(std::ops::Range<usize>, Hsla)],
         line_height: f32,
     ) -> (Div, TextLayout) {
         let mut bg_ranges = selection_bg_ranges(&self.selection, line_index, plain_text.len());
         bg_ranges.extend(self.compute_word_bg_ranges(spans, changed_ranges, word_bg));
+        bg_ranges.extend_from_slice(extra_bg);
 
         self.render_scrollable_content(spans, &bg_ranges, line_height)
     }


### PR DESCRIPTION
## Context

Okena renders file/text content line-by-line in three places, but only one let you find text inside it:

| View | Renders content | In-page find (Cmd/Ctrl+F) before |
|------|-----------------|----------------------------------|
| File viewer | yes | **yes** |
| Git diff viewer (unified + side-by-side) | yes | no |
| Content Search dialog **preview pane** | yes | no |

The file viewer's find lived entirely inside `impl FileViewer` (~340 lines, ~130 of which was the search-bar UI). Copying it twice would triple the bug surface and the UI drift — already visible in an inconsistency: the file viewer hardcoded its highlight colors while the content-search preview already read theme colors.

## What this does

Extracts the find logic + search-bar UI into one shared, view-agnostic module and drives all three viewers from it.

### Shared module — `crates/okena-files/src/in_page_search.rs` (new)
- `InPageSearch` engine: searches a flat list of host-defined **cells** (text + opaque `usize` id), tracks the current match, navigation, case toggle, and theme-colored `ranges_for_cell()`. The host owns all view semantics (what a cell maps to, how to scroll to it).
- Generic `render_search_bar<V>` + `SearchBarCallbacks<V>`: the full bar (input, `Aa` case toggle, `n/N` counter, prev/next, close). Handles Enter / Shift+Enter and stops key propagation so typed keys never leak into host shortcuts; Escape flows to each host's existing root `Cancel` handler (which closes search first).

### Hosts
- **File viewer** — refactored onto the shared engine. Behavior-preserving; also unifies the previously hardcoded highlight colors onto theme colors.
- **Git diff viewer** — in-page search added for **both** unified and side-by-side layouts. Cell scheme: unified = item index (expanders get an empty cell so indices line up with the `uniform_list`); side-by-side = `row*2 + side`, scroll item = `cell / 2`. Matches recompute on file switch / view-mode toggle / whitespace toggle / query / case change via a signature check.
- **Content Search dialog** — in-page search over the preview pane (Cmd/Ctrl+F), layered on top of the existing grep-match highlights.

## Verification
- `cargo build --workspace` — OK (incl. the `okena` binary and `okena-app`)
- `cargo test --workspace` — all pass, 0 failures
- `cargo clippy -p okena-files -p okena-views-git` — clean

Manual GUI verification of the three views (interactive find/highlight/scroll, both diff layouts) still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)