### PR TITLE
chore: ignore agent-created symlinked files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ web/dist/
 # claude
 .claude/settings.local.json
 
+# agents ignore symlinks from .claude and CLADUE.md
+.agents
+AGENTS.md
+
 # Ralph loop runtime artifacts
 plans/observer-*.log
 plans/overseer-*.log


### PR DESCRIPTION
## Summary

Update `.gitignore` to ignore symlinked files created by other agents.

## Changes

- Adds 4 ignore entries for agent-created symlinks so they don't show up as untracked changes in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
