### PR TITLE
feat(window): enable platform-native titlebar drag-to-move on macOS

### DIFF
--- a/crates/okena-app/src/views/chrome/title_bar.rs
+++ b/crates/okena-app/src/views/chrome/title_bar.rs
@@ -20,8 +20,8 @@ pub struct TitleBar {
     title: SharedString,
     menu_open: bool,
     sidebar_open: bool,
-    /// Flag for Linux compositor-driven window move (set on mouse-down, consumed on mouse-move)
-    #[cfg(target_os = "linux")]
+    /// Flag for platform-driven window move (set on mouse-down, consumed on mouse-move).
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     should_move: bool,
 }
 
@@ -33,7 +33,7 @@ impl TitleBar {
             title: title.into(),
             menu_open: false,
             sidebar_open: true,
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             should_move: false,
         }
     }
@@ -263,38 +263,40 @@ impl Render for TitleBar {
             .border_b_1()
             .border_color(rgb(t.border))
             // Mark titlebar as drag region - GPUI maps this to HTCAPTION on Windows
-            // (enabling native snap gestures, unmaximize-on-drag) and platform-native
-            // drag on other platforms.
+            // (enabling native snap gestures and unmaximize-on-drag).
             .window_control_area(WindowControlArea::Drag)
-            // On Linux, WindowControlArea::Drag is a no-op (GPUI doesn't wire
-            // the hit-test callback), so use a mouse-down → mouse-move pattern
-            // to start a compositor-native window move. The move is deferred to
-            // mouse-move so that double-click to maximize still works.
-            .when(cfg!(target_os = "linux"), |d| {
+            // On macOS and Linux, WindowControlArea::Drag is not wired through
+            // the platform hit-test callback, so start a platform-native window
+            // move from mouse movement after the initial press. Deferring the
+            // move keeps double-click behavior available.
+            .when(cfg!(any(target_os = "linux", target_os = "macos")), |d| {
                 d
                     .on_mouse_down(MouseButton::Left, cx.listener(|this, _, _, _cx| {
-                        #[cfg(target_os = "linux")]
+                        #[cfg(any(target_os = "linux", target_os = "macos"))]
                         { this.should_move = true; }
-                        #[cfg(not(target_os = "linux"))]
+                        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
                         { let _ = this; }
                     }))
                     .on_mouse_up(MouseButton::Left, cx.listener(|this, _, _, _cx| {
-                        #[cfg(target_os = "linux")]
+                        #[cfg(any(target_os = "linux", target_os = "macos"))]
                         { this.should_move = false; }
-                        #[cfg(not(target_os = "linux"))]
+                        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
                         { let _ = this; }
                     }))
                     .on_mouse_move(cx.listener(|this, _, window, _cx| {
-                        #[cfg(target_os = "linux")]
+                        #[cfg(any(target_os = "linux", target_os = "macos"))]
                         if this.should_move {
                             this.should_move = false;
                             window.start_window_move();
                         }
-                        #[cfg(not(target_os = "linux"))]
+                        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
                         { let _ = (this, window); }
                     }))
                     .on_click(|event: &ClickEvent, window, _| {
                         if event.click_count() == 2 {
+                            #[cfg(target_os = "macos")]
+                            window.titlebar_double_click();
+                            #[cfg(target_os = "linux")]
                             window.zoom_window();
                         }
                     })

--- a/crates/okena-app/src/views/chrome/title_bar.rs
+++ b/crates/okena-app/src/views/chrome/title_bar.rs
@@ -277,6 +277,15 @@ impl Render for TitleBar {
                         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
                         { let _ = this; }
                     }))
+                    // Clear a pending move if the press ends elsewhere (mouse-up
+                    // missed off-element), so a later bare hover can't trigger a
+                    // spurious window move. Mirrors Zed's own title bar.
+                    .on_mouse_down_out(cx.listener(|this, _, _, _cx| {
+                        #[cfg(any(target_os = "linux", target_os = "macos"))]
+                        { this.should_move = false; }
+                        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+                        { let _ = this; }
+                    }))
                     .on_mouse_up(MouseButton::Left, cx.listener(|this, _, _, _cx| {
                         #[cfg(any(target_os = "linux", target_os = "macos"))]
                         { this.should_move = false; }

--- a/crates/okena-ui/src/modal.rs
+++ b/crates/okena-ui/src/modal.rs
@@ -42,9 +42,8 @@ pub fn fullscreen_panel(id: impl Into<SharedString>, t: &ThemeColors) -> Statefu
 
 /// A spacer that always fills remaining flex space. When `enabled` is true
 /// the spacer also acts as a drag handle for window move, mirroring the
-/// main app titlebar: `WindowControlArea::Drag` (HTCAPTION on Windows,
-/// platform-native drag on macOS) plus a Linux mouse-move fallback since
-/// `WindowControlArea::Drag` is a no-op there.
+/// main app titlebar: `WindowControlArea::Drag` (HTCAPTION on Windows)
+/// plus an explicit platform move fallback on macOS and Linux.
 pub fn window_drag_spacer(enabled: bool) -> Stateful<Div> {
     div()
         .id("window-drag-spacer")
@@ -52,7 +51,7 @@ pub fn window_drag_spacer(enabled: bool) -> Stateful<Div> {
         .h_full()
         .when(enabled, |d| {
             d.window_control_area(WindowControlArea::Drag)
-                .when(cfg!(target_os = "linux"), |d| {
+                .when(cfg!(any(target_os = "linux", target_os = "macos")), |d| {
                     d.on_mouse_down(MouseButton::Left, |_, window, _cx| {
                         window.start_window_move();
                     })

--- a/crates/okena-views-terminal/src/overlays/detached_terminal.rs
+++ b/crates/okena-views-terminal/src/overlays/detached_terminal.rs
@@ -186,9 +186,9 @@ impl Render for DetachedTerminalView {
             .child(
                 // Header bar - draggable for window move. Mirrors the main app
                 // titlebar: WindowControlArea::Drag handles Windows (HTCAPTION,
-                // enabling native snap and unmaximize-on-drag) and macOS;
-                // start_window_move is a Linux-only fallback since the
-                // hit-test callback isn't wired there.
+                // enabling native snap and unmaximize-on-drag); start_window_move
+                // is the macOS/Linux fallback since their hit-test callback
+                // doesn't consume WindowControlArea::Drag.
                 div()
                     .h(px(35.0))
                     .pl(traffic_light_padding)
@@ -200,7 +200,7 @@ impl Render for DetachedTerminalView {
                     .border_b_1()
                     .border_color(rgb(t.border))
                     .window_control_area(WindowControlArea::Drag)
-                    .when(cfg!(target_os = "linux"), |d| {
+                    .when(cfg!(any(target_os = "linux", target_os = "macos")), |d| {
                         d.on_mouse_down(MouseButton::Left, |_, window, _cx| {
                             window.start_window_move();
                         })


### PR DESCRIPTION
## Summary

Enable platform-native titlebar drag-to-move on macOS.

## Changes

- Extend the Linux mouse-move window-move fallback to macOS in the title bar, modal spacer, and detached terminal.
- Use `titlebar_double_click` on macOS (`zoom_window` on Linux) for double-click behaviour.

## Files

- `crates/okena-app/src/views/chrome/title_bar.rs`
- `crates/okena-ui/src/modal.rs`
- `crates/okena-app/src/overlays/detached_terminal.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
