### PR TITLE
fix: project switcher Tab, keep project in place on unfocus, clearer git header

### DIFF
--- a/crates/okena-app/src/app/extras.rs
+++ b/crates/okena-app/src/app/extras.rs
@@ -412,6 +412,10 @@ impl Okena {
             },
         };
 
+        // Mark this as an explicit jump so the target window centers the
+        // project (arrow/click switches only ensure visibility).
+        view.update(cx, |v, _| v.request_center_on_next_navigation());
+
         // Point that window's FocusManager at the first visible terminal.
         let focus_manager = view.read(cx).focus_manager();
         let pid = project_id.to_string();

--- a/crates/okena-app/src/keybindings/mod.rs
+++ b/crates/okena-app/src/keybindings/mod.rs
@@ -39,6 +39,7 @@ actions!(
         ShowFileSearch,
         ShowContentSearch,
         ShowProjectSwitcher,
+        JumpToProjectTerminal,
         ShowDiffViewer,
         ReviewChanges,
         CheckForUpdates,
@@ -131,6 +132,9 @@ pub fn reload_keybindings(cx: &mut App) {
     cx.bind_keys([
         KeyBinding::new("tab", SendTab, Some("TerminalPane")),
         KeyBinding::new("shift-tab", SendBacktab, Some("TerminalPane")),
+        // Override gpui-component Root's global `tab` → focus_next so the
+        // project switcher can use Tab to jump into a project's terminal.
+        KeyBinding::new("tab", JumpToProjectTerminal, Some("ProjectSwitcher")),
     ]);
 
     cx.bind_keys([
@@ -195,6 +199,9 @@ pub fn register_keybindings(cx: &mut App) {
     cx.bind_keys([
         KeyBinding::new("tab", SendTab, Some("TerminalPane")),
         KeyBinding::new("shift-tab", SendBacktab, Some("TerminalPane")),
+        // Override gpui-component Root's global `tab` → focus_next so the
+        // project switcher can use Tab to jump into a project's terminal.
+        KeyBinding::new("tab", JumpToProjectTerminal, Some("ProjectSwitcher")),
     ]);
 
     // Register sidebar navigation keybindings (not user-configurable)

--- a/crates/okena-app/src/views/overlays/project_switcher.rs
+++ b/crates/okena-app/src/views/overlays/project_switcher.rs
@@ -5,7 +5,7 @@
 //! - Space: Toggle project overview visibility
 //! - Type to filter projects
 
-use crate::keybindings::Cancel;
+use crate::keybindings::{Cancel, JumpToProjectTerminal};
 use crate::theme::{theme, with_alpha};
 use crate::ui::tokens::{ui_text, ui_text_ms};
 use crate::views::components::list_overlay::FilterResult;
@@ -479,16 +479,22 @@ impl Render for ProjectSwitcher {
         modal_backdrop("project-switcher-backdrop", &t)
             .track_focus(&focus_handle)
             .key_context("ProjectSwitcher")
-            .items_start()
-            .pt(px(80.0))
+            .items_center()
             .on_action(cx.listener(|this, _: &Cancel, _window, cx| {
                 this.close(cx);
+            }))
+            // Tab is captured by a dedicated keybinding in the "ProjectSwitcher"
+            // context (mod.rs), because gpui-component's Root binds `tab` to
+            // focus navigation globally and would otherwise swallow it before it
+            // reaches the on_key_down handler below.
+            .on_action(cx.listener(|this, _: &JumpToProjectTerminal, _window, cx| {
+                this.jump_into_selected(cx);
             }))
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, _window, cx| {
                 match handle_list_overlay_key(
                     &mut this.state,
                     event,
-                    &[("space", "toggle"), ("tab", "jump")],
+                    &[("space", "toggle")],
                 ) {
                     ListOverlayAction::Close => this.close(cx),
                     ListOverlayAction::SelectPrev | ListOverlayAction::SelectNext => {
@@ -502,9 +508,6 @@ impl Render for ProjectSwitcher {
                     }
                     ListOverlayAction::Custom(action) if action == "toggle" => {
                         this.toggle_visibility_selected(cx);
-                    }
-                    ListOverlayAction::Custom(action) if action == "jump" => {
-                        this.jump_into_selected(cx);
                     }
                     _ => {}
                 }

--- a/crates/okena-app/src/views/panels/project_column.rs
+++ b/crates/okena-app/src/views/panels/project_column.rs
@@ -422,6 +422,7 @@ impl ProjectColumn {
                         // Not carried over the wire yet; remote projects don't
                         // surface the "Review changes" chip.
                         review_base: None,
+                        default_branch: None,
                     })
             });
 

--- a/crates/okena-app/src/views/panels/project_column.rs
+++ b/crates/okena-app/src/views/panels/project_column.rs
@@ -689,6 +689,10 @@ impl ProjectColumn {
                 .on_mouse_down(MouseButton::Right, context_menu_handler)
                 .child(
                     h_flex()
+                        // Fill the row so the git status row can right-align its
+                        // base-compare chip via its internal flex spacer.
+                        .flex_1()
+                        .min_w_0()
                         .gap(px(6.0))
                         .overflow_hidden()
                         .child(worktree_dot)

--- a/crates/okena-app/src/views/window/mod.rs
+++ b/crates/okena-app/src/views/window/mod.rs
@@ -147,8 +147,14 @@ pub struct WindowView {
     last_scroll_project: Option<String>,
     /// Whether a project was zoomed/focused in the last observation (for detecting unfocus)
     was_project_focused: bool,
-    /// Project ID to center-scroll to after the next layout pass
+    /// Project ID whose grid scroll position should be restored after the next
+    /// layout pass (set when exiting project focus). The overview is re-expanded
+    /// asynchronously, so the restore is deferred until the grid reports overflow.
     pending_center_scroll: Option<String>,
+    /// Grid scroll offset captured when entering project focus, restored on exit
+    /// so the project stays in the same place rather than jumping to center.
+    /// (The offset is otherwise clamped to 0 while a single project is zoomed.)
+    saved_grid_offset: Option<Point<Pixels>>,
     /// Last-known on-disk paths per local project, used to detect renames
     /// so we can refresh cached git providers / service paths.
     last_project_paths: HashMap<String, String>,
@@ -330,6 +336,7 @@ impl WindowView {
             last_scroll_project: None,
             was_project_focused: false,
             pending_center_scroll: None,
+            saved_grid_offset: None,
             last_project_paths: HashMap::new(),
             last_data_replacement_epoch,
         };
@@ -370,7 +377,15 @@ impl WindowView {
                 .focused_terminal_state()
                 .map(|f| f.project_id.clone());
 
-            // When project zoom is cleared, defer centering until after next layout pass
+            // Entering project zoom: capture the grid scroll position now (before
+            // the zoomed single-project layout clamps it to 0) so it can be
+            // restored on exit.
+            if !this.was_project_focused && is_project_focused {
+                this.saved_grid_offset = Some(this.projects_scroll_handle.offset());
+            }
+
+            // When project zoom is cleared, defer the scroll restore until after
+            // the next layout pass (the overview re-expands asynchronously).
             if this.was_project_focused && !is_project_focused {
                 this.last_scroll_project = focused_terminal_project.clone();
                 this.pending_center_scroll = focused_terminal_project;
@@ -378,7 +393,7 @@ impl WindowView {
             // When the active terminal changes project, ensure it's visible
             else if focused_terminal_project != this.last_scroll_project && focused_terminal_project.is_some() {
                 this.last_scroll_project = focused_terminal_project.clone();
-                this.scroll_to_focused_project(focused_terminal_project.as_deref(), false, cx);
+                this.scroll_to_focused_project(focused_terminal_project.as_deref(), cx);
             }
 
             this.was_project_focused = is_project_focused;

--- a/crates/okena-app/src/views/window/mod.rs
+++ b/crates/okena-app/src/views/window/mod.rs
@@ -393,7 +393,7 @@ impl WindowView {
             // When the active terminal changes project, ensure it's visible
             else if focused_terminal_project != this.last_scroll_project && focused_terminal_project.is_some() {
                 this.last_scroll_project = focused_terminal_project.clone();
-                this.scroll_to_focused_project(focused_terminal_project.as_deref(), cx);
+                this.scroll_to_focused_project(focused_terminal_project.as_deref(), true, cx);
             }
 
             this.was_project_focused = is_project_focused;

--- a/crates/okena-app/src/views/window/mod.rs
+++ b/crates/okena-app/src/views/window/mod.rs
@@ -155,6 +155,10 @@ pub struct WindowView {
     /// so the project stays in the same place rather than jumping to center.
     /// (The offset is otherwise clamped to 0 while a single project is zoomed.)
     saved_grid_offset: Option<Point<Pixels>>,
+    /// Set by an explicit "jump to project" (project switcher Tab) so the next
+    /// focus-change observation centers the target. Other project switches
+    /// (cmd+alt+arrow, mouse click) leave it unset and only ensure visibility.
+    center_next_navigation: bool,
     /// Last-known on-disk paths per local project, used to detect renames
     /// so we can refresh cached git providers / service paths.
     last_project_paths: HashMap<String, String>,
@@ -337,6 +341,7 @@ impl WindowView {
             was_project_focused: false,
             pending_center_scroll: None,
             saved_grid_offset: None,
+            center_next_navigation: false,
             last_project_paths: HashMap::new(),
             last_data_replacement_epoch,
         };
@@ -376,6 +381,9 @@ impl WindowView {
             let focused_terminal_project = fm
                 .focused_terminal_state()
                 .map(|f| f.project_id.clone());
+            // Consumed once per observation: an explicit jump (switcher Tab)
+            // centers the target; other switches just ensure it's visible.
+            let center_navigation = std::mem::take(&mut this.center_next_navigation);
 
             // Entering project zoom: capture the grid scroll position now (before
             // the zoomed single-project layout clamps it to 0) so it can be
@@ -393,7 +401,7 @@ impl WindowView {
             // When the active terminal changes project, ensure it's visible
             else if focused_terminal_project != this.last_scroll_project && focused_terminal_project.is_some() {
                 this.last_scroll_project = focused_terminal_project.clone();
-                this.scroll_to_focused_project(focused_terminal_project.as_deref(), true, cx);
+                this.scroll_to_focused_project(focused_terminal_project.as_deref(), center_navigation, cx);
             }
 
             this.was_project_focused = is_project_focused;
@@ -455,6 +463,13 @@ impl WindowView {
     /// supplied via `focus_manager.update(cx, |fm, cx| ws.method(fm, ...))`.
     pub fn focus_manager(&self) -> Entity<FocusManager> {
         self.focus_manager.clone()
+    }
+
+    /// Request that the next focus-change observation center the focused project
+    /// in the overview. Used for explicit "jump to project" (project switcher
+    /// Tab); arrow/click switches leave this unset and only ensure visibility.
+    pub fn request_center_on_next_navigation(&mut self) {
+        self.center_next_navigation = true;
     }
 
     /// Set the git watcher entity (called by Okena after creation).

--- a/crates/okena-app/src/views/window/render.rs
+++ b/crates/okena-app/src/views/window/render.rs
@@ -32,9 +32,14 @@ impl WindowView {
     }
 
     /// Scroll the projects grid horizontally to ensure the focused project column is visible.
-    /// Scroll the project grid just enough to bring the focused project into
-    /// view (no-op if it is already visible). Never re-centers.
-    pub(super) fn scroll_to_focused_project(&self, focused_id: Option<&str>, cx: &Context<Self>) {
+    /// Scroll the project grid to reveal the focused project.
+    ///
+    /// `center: true` centers it in the viewport — used when actively
+    /// navigating to a project (project switcher Tab, switching the active
+    /// project) so it lands in the middle rather than flush against an edge.
+    /// `center: false` scrolls the minimum needed and is a no-op when the
+    /// project is already fully visible.
+    pub(super) fn scroll_to_focused_project(&self, focused_id: Option<&str>, center: bool, cx: &Context<Self>) {
         let focused_id = match focused_id {
             Some(id) => id,
             None => return,
@@ -85,7 +90,11 @@ impl WindowView {
             f32::from(if is_rows { o.y } else { o.x })
         };
 
-        let new_offset = {
+        let new_offset = if center {
+            // Center the focused project in the viewport.
+            let col_center = col_lead + pixel_widths[focused_idx] / 2.0;
+            -(col_center - container_size / 2.0)
+        } else {
             let col_trail = col_lead + pixel_widths[focused_idx];
             let viewport_lead = -current_offset_axis;
             let viewport_trail = viewport_lead + container_size;
@@ -138,7 +147,7 @@ impl WindowView {
                 } else {
                     // No saved position (e.g. focus entered before this window
                     // observed it) — fall back to just ensuring it's visible.
-                    self.scroll_to_focused_project(Some(&project_id), cx);
+                    self.scroll_to_focused_project(Some(&project_id), false, cx);
                 }
             } else {
                 // Layout hasn't updated yet — re-queue for next frame

--- a/crates/okena-app/src/views/window/render.rs
+++ b/crates/okena-app/src/views/window/render.rs
@@ -32,7 +32,9 @@ impl WindowView {
     }
 
     /// Scroll the projects grid horizontally to ensure the focused project column is visible.
-    pub(super) fn scroll_to_focused_project(&self, focused_id: Option<&str>, center: bool, cx: &Context<Self>) {
+    /// Scroll the project grid just enough to bring the focused project into
+    /// view (no-op if it is already visible). Never re-centers.
+    pub(super) fn scroll_to_focused_project(&self, focused_id: Option<&str>, cx: &Context<Self>) {
         let focused_id = match focused_id {
             Some(id) => id,
             None => return,
@@ -83,11 +85,7 @@ impl WindowView {
             f32::from(if is_rows { o.y } else { o.x })
         };
 
-        let new_offset = if center {
-            // Center the focused project in the viewport
-            let col_center = col_lead + pixel_widths[focused_idx] / 2.0;
-            -(col_center - container_size / 2.0)
-        } else {
+        let new_offset = {
             let col_trail = col_lead + pixel_widths[focused_idx];
             let viewport_lead = -current_offset_axis;
             let viewport_trail = viewport_lead + container_size;
@@ -112,9 +110,11 @@ impl WindowView {
     }
 
     pub(super) fn render_projects_grid(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
-        // Execute pending center-scroll (deferred from unfocus to let layout update first).
-        // We wait until the scroll handle reports overflow (max_offset > 0), which means
-        // the layout has been recalculated with all projects visible.
+        // Restore the grid scroll position saved when project focus was entered,
+        // deferred from unfocus so the overview can re-expand first. We wait until
+        // the scroll handle reports overflow (max_offset > 0), which means the
+        // layout has been recalculated with all projects visible. This keeps the
+        // unfocused project in the same place instead of jumping it to center.
         if let Some(project_id) = self.pending_center_scroll.take() {
             let workspace = self.workspace.read(cx);
             let fm = self.focus_manager.read(cx);
@@ -125,9 +125,21 @@ impl WindowView {
             let max_offset = self.projects_scroll_handle.max_offset();
             let axis_overflow = if is_rows { max_offset.y } else { max_offset.x };
             if is_zoomed || num_visible <= 1 {
-                // Still zoomed or only one project — no centering needed
+                // Still zoomed or only one project — nothing to restore.
+                self.saved_grid_offset = None;
             } else if axis_overflow > px(0.0) {
-                self.scroll_to_focused_project(Some(&project_id), true, cx);
+                if let Some(saved) = self.saved_grid_offset.take() {
+                    // Re-clamp against the freshly recomputed max offset.
+                    let off = point(
+                        saved.x.clamp(-max_offset.x, px(0.0)),
+                        saved.y.clamp(-max_offset.y, px(0.0)),
+                    );
+                    self.projects_scroll_handle.set_offset(off);
+                } else {
+                    // No saved position (e.g. focus entered before this window
+                    // observed it) — fall back to just ensuring it's visible.
+                    self.scroll_to_focused_project(Some(&project_id), cx);
+                }
             } else {
                 // Layout hasn't updated yet — re-queue for next frame
                 self.pending_center_scroll = Some(project_id);

--- a/crates/okena-git/src/lib.rs
+++ b/crates/okena-git/src/lib.rs
@@ -105,6 +105,11 @@ pub struct GitStatus {
     /// is on the default branch, or no default branch is resolvable).
     #[serde(default)]
     pub review_base: Option<String>,
+    /// The repository's default branch (e.g. `main`). Used to suppress the
+    /// redundant base label on the ahead/behind chip when the review base is
+    /// the default branch (the common case). `None` when unresolved.
+    #[serde(default)]
+    pub default_branch: Option<String>,
 }
 
 /// Per-file diff summary for popover display
@@ -234,6 +239,7 @@ pub fn warm_branch_cache(path: &Path) {
             behind: None,
             unpushed: None,
             review_base: None,
+            default_branch: None,
         }));
     });
 }

--- a/crates/okena-git/src/repository/status.rs
+++ b/crates/okena-git/src/repository/status.rs
@@ -32,6 +32,11 @@ pub fn get_status(path: &Path) -> StatusFetch {
     };
     let unpushed = count_unpushed_commits(path);
     let review_base = super::branch::resolve_review_base(path);
+    // Only needed to decide whether the base label is redundant (base == default);
+    // skip the lookup when there's no base chip to render.
+    let default_branch = review_base
+        .as_ref()
+        .and_then(|_| super::branch::get_default_branch(path));
     // Ahead/behind are measured against the review base (`origin/<default>`),
     // not the branch's configured upstream — so the count is consistent
     // regardless of how `@{u}` is set and matches the "review changes" diff.
@@ -54,6 +59,7 @@ pub fn get_status(path: &Path) -> StatusFetch {
         behind,
         unpushed,
         review_base,
+        default_branch,
     }))
 }
 

--- a/crates/okena-views-git/src/git_header/status_pill.rs
+++ b/crates/okena-views-git/src/git_header/status_pill.rs
@@ -231,6 +231,7 @@ impl GitHeader {
                                 status.ahead,
                                 status.behind,
                                 base,
+                                status.default_branch.as_deref(),
                                 t,
                             )
                             .map(|badge| (base.to_string(), badge))

--- a/crates/okena-views-git/src/git_header/status_pill.rs
+++ b/crates/okena-views-git/src/git_header/status_pill.rs
@@ -42,7 +42,10 @@ impl GitHeader {
                 let review_head = status.branch.clone();
 
                 h_flex()
-                    .flex_shrink_0()
+                    // Grow to fill the header row so the base-compare chip can
+                    // be pushed to the right edge (via the flex spacer below).
+                    .flex_1()
+                    .min_w_0()
                     .items_center()
                     .gap(px(4.0))
                     .text_size(ui_text_sm(cx))
@@ -209,24 +212,30 @@ impl GitHeader {
                                 ).absolute().size_full())
                         )
                     })
-                    // Ahead/behind vs the review base. When a base exists this
-                    // doubles as the "review changes" affordance: a leading
-                    // pull-request glyph + clicking opens a three-dot diff of
+                    // Commits to push (vs origin/<branch>): the standard green
+                    // ↑N arrow. Standalone — not part of the review action.
+                    .when_some(
+                        project_header::render_unpushed_badge(status.unpushed, t),
+                        |d, badge| d.child(badge),
+                    )
+                    // Flexible spacer: pushes the base-compare chip to the right
+                    // edge of the header row.
+                    .child(div().flex_1().min_w(px(8.0)))
+                    // Branch-vs-base comparison, shown only when a base exists,
+                    // as a labeled `⎇ main +N −M` chip. Doubles as the "review
+                    // changes" affordance: clicking opens a three-dot diff of
                     // the branch against its base (e.g. origin/main).
                     .when_some(
-                        project_header::render_ahead_behind_badge(
-                            status.ahead,
-                            status.behind,
-                            status.unpushed,
-                            review_base.as_deref(),
-                            t,
-                        ),
-                        |d, badge| {
-                            let Some(base) = review_base.clone() else {
-                                // No base (HEAD on the default branch): show the
-                                // badge (e.g. unpushed) without the review action.
-                                return d.child(badge);
-                            };
+                        review_base.as_deref().and_then(|base| {
+                            project_header::render_base_compare_badge(
+                                status.ahead,
+                                status.behind,
+                                base,
+                                t,
+                            )
+                            .map(|badge| (base.to_string(), badge))
+                        }),
+                        |d, (base, badge)| {
                             let request_broker = self.request_broker.clone();
                             let project_id_for_review = self.project_id.clone();
                             let head = review_head.clone().unwrap_or_else(|| "HEAD".to_string());
@@ -262,7 +271,7 @@ impl GitHeader {
                                     }))
                                     .child(
                                         svg()
-                                            .path("icons/git-pull-request.svg")
+                                            .path("icons/git-branch.svg")
                                             .size(px(10.0))
                                             .text_color(rgb(t.text_muted)),
                                     )

--- a/crates/okena-views-git/src/project_header.rs
+++ b/crates/okena-views-git/src/project_header.rs
@@ -81,48 +81,14 @@ pub(crate) fn tint(color: u32, alpha: f32) -> Rgba {
 
 // ── Standalone badges ───────────────────────────────────────────────────────
 
-/// Tooltip text describing ahead/behind/unpushed counts.
-///
-/// `ahead`/`behind` are relative to the upstream tracking branch (which for
-/// worktree branches off `origin/main` may be `origin/main` itself, not the
-/// branch's own remote). `unpushed` counts commits missing from
-/// `origin/<branch>` specifically — `None` when that ref doesn't exist.
-///
-/// Returns `None` when there is nothing meaningful to show.
-pub fn ahead_behind_tooltip(
-    ahead: Option<usize>,
-    behind: Option<usize>,
-    unpushed: Option<usize>,
-    base: Option<&str>,
-) -> Option<String> {
-    let a = ahead.unwrap_or(0);
-    let b = behind.unwrap_or(0);
-    let u = unpushed.unwrap_or(0);
-    let plural = |n: usize| if n == 1 { "" } else { "s" };
-    let base_label = base.unwrap_or("base");
+/// Strip a leading `origin/` so a base ref reads as a plain branch name
+/// (`origin/main` → `main`) in the comparison chip.
+pub(crate) fn base_short_name(base: &str) -> &str {
+    base.strip_prefix("origin/").unwrap_or(base)
+}
 
-    // When unpushed differs from ahead, the branch's own remote isn't the base
-    // (typical worktree case). Surface both numbers so the user can tell
-    // "ahead of base" from "not pushed to origin/<branch>".
-    let show_unpushed = unpushed.is_some() && Some(a) != unpushed;
-
-    let mut parts: Vec<String> = Vec::new();
-    if a > 0 {
-        // The ahead count is the clickable "review" affordance when we have a base.
-        let hint = if base.is_some() { " — click to review" } else { "" };
-        parts.push(format!("{a} commit{} ahead of {base_label}{hint}", plural(a)));
-    }
-    if b > 0 {
-        parts.push(format!("{b} commit{} behind {base_label}", plural(b)));
-    }
-    if show_unpushed {
-        parts.push(format!(
-            "{u} commit{} not pushed to origin/<branch>",
-            plural(u)
-        ));
-    }
-
-    if parts.is_empty() { None } else { Some(parts.join("\n")) }
+fn plural(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
 }
 
 /// Render a single "<sign> <count>" pair where the sign character is rendered
@@ -143,47 +109,76 @@ fn render_sign_count(sign: &str, count: usize, color: u32, alpha: f32) -> Div {
         )
 }
 
-/// Render an ahead/behind/unpushed indicator.
+/// Render the "commits to push" indicator: a green `↑N` counting commits not
+/// yet on `origin/<branch>`. This is the standard git convention (matches the
+/// upstream-sync arrow in VS Code, lazygit, etc.) — it drops to 0 after a push.
 ///
-/// - `↑N` (green) — commits ahead of the review base (`origin/<default>`)
-/// - `↓M` (yellow) — commits behind the review base (branch is stale)
-/// - `↟K` (cyan, double-headed) — commits not on `origin/<branch>`. Only
-///   shown when the count differs from `ahead` (i.e. the branch's own remote
-///   isn't the base — typical worktree case), so it doesn't double up in the
-///   common case where `↑N` already means "to push".
+/// Returns `None` when nothing is unpushed (or the upstream ref is unknown).
+pub fn render_unpushed_badge(unpushed: Option<usize>, t: &ThemeColors) -> Option<AnyElement> {
+    let u = unpushed.filter(|&u| u > 0)?;
+    let tooltip = format!("{u} commit{} to push (not on origin/<branch>)", plural(u));
+    Some(
+        div()
+            .id("unpushed-badge")
+            .flex()
+            .items_center()
+            .px(px(3.0))
+            .child(render_sign_count("\u{2191}", u, t.term_green, 0.7))
+            .tooltip(move |window, cx| Tooltip::new(tooltip.clone()).build(window, cx))
+            .into_any_element(),
+    )
+}
+
+/// Render the branch-vs-base comparison content: the base name followed by
+/// ahead (`+N`) and behind (`−M`) commit counts, e.g. `main +2 −1`. This is
+/// explicitly labeled with the base so it doesn't read as push state; the
+/// caller pairs it with a branch glyph and the click-to-review affordance.
 ///
-/// `base` is the base ref name (e.g. `origin/main`) used in the tooltip.
-/// Zero-count sides are hidden. Returns `None` when nothing is worth showing.
-pub fn render_ahead_behind_badge(
+/// Zero-count sides are hidden. Returns `None` when the branch is level with
+/// its base (nothing to review).
+pub fn render_base_compare_badge(
     ahead: Option<usize>,
     behind: Option<usize>,
-    unpushed: Option<usize>,
-    base: Option<&str>,
+    base: &str,
     t: &ThemeColors,
 ) -> Option<AnyElement> {
-    let tooltip_text = ahead_behind_tooltip(ahead, behind, unpushed, base)?;
     let a = ahead.unwrap_or(0);
     let b = behind.unwrap_or(0);
-    let u = unpushed.unwrap_or(0);
-    let show_unpushed = unpushed.is_some() && Some(a) != unpushed && u > 0;
+    if a == 0 && b == 0 {
+        return None;
+    }
+
+    let base_label = base_short_name(base).to_string();
+    let tooltip = {
+        let mut parts = Vec::new();
+        if a > 0 {
+            parts.push(format!("{a} commit{} ahead of {base_label}", plural(a)));
+        }
+        if b > 0 {
+            parts.push(format!("{b} commit{} behind {base_label}", plural(b)));
+        }
+        parts.push("click to review".to_string());
+        parts.join("\n")
+    };
 
     Some(
         div()
-            .id("ahead-behind-badge")
+            .id("base-compare-badge")
             .flex()
             .items_center()
-            .gap(px(5.0))
-            .px(px(3.0))
+            .gap(px(4.0))
+            .child(
+                div()
+                    .text_color(rgb(t.text_muted))
+                    .child(base_label.clone()),
+            )
             .when(a > 0, |d| {
-                d.child(render_sign_count("\u{2191}", a, t.term_green, 0.7))
+                d.child(render_sign_count("+", a, t.term_green, 0.7))
             })
             .when(b > 0, |d| {
-                d.child(render_sign_count("\u{2193}", b, t.term_yellow, 0.7))
+                d.child(render_sign_count("\u{2212}", b, t.term_yellow, 0.7))
             })
-            .when(show_unpushed, |d| {
-                d.child(render_sign_count("\u{219F}", u, t.term_cyan, 0.7))
-            })
-            .tooltip(move |window, cx| Tooltip::new(tooltip_text.clone()).build(window, cx))
+            .tooltip(move |window, cx| Tooltip::new(tooltip.clone()).build(window, cx))
             .into_any_element(),
     )
 }

--- a/crates/okena-views-git/src/project_header.rs
+++ b/crates/okena-views-git/src/project_header.rs
@@ -129,10 +129,11 @@ pub fn render_unpushed_badge(unpushed: Option<usize>, t: &ThemeColors) -> Option
     )
 }
 
-/// Render the branch-vs-base comparison content: the base name followed by
-/// ahead (`+N`) and behind (`−M`) commit counts, e.g. `main +2 −1`. This is
-/// explicitly labeled with the base so it doesn't read as push state; the
-/// caller pairs it with a branch glyph and the click-to-review affordance.
+/// Render the branch-vs-base comparison content: ahead (`+N`) and behind (`−M`)
+/// commit counts, e.g. `main +2 −1`. The base name is shown only when it isn't
+/// the repository's default branch (`default_branch`) — comparing against the
+/// default is the common case, so its name would be redundant noise. The
+/// caller pairs this with a branch glyph and the click-to-review affordance.
 ///
 /// Zero-count sides are hidden. Returns `None` when the branch is level with
 /// its base (nothing to review).
@@ -140,6 +141,7 @@ pub fn render_base_compare_badge(
     ahead: Option<usize>,
     behind: Option<usize>,
     base: &str,
+    default_branch: Option<&str>,
     t: &ThemeColors,
 ) -> Option<AnyElement> {
     let a = ahead.unwrap_or(0);
@@ -149,6 +151,9 @@ pub fn render_base_compare_badge(
     }
 
     let base_label = base_short_name(base).to_string();
+    // Hide the label when the base is the default branch (the redundant case);
+    // show it only for a non-default base so it carries information.
+    let show_label = default_branch.is_none_or(|d| d != base_label);
     let tooltip = {
         let mut parts = Vec::new();
         if a > 0 {
@@ -167,11 +172,13 @@ pub fn render_base_compare_badge(
             .flex()
             .items_center()
             .gap(px(4.0))
-            .child(
-                div()
-                    .text_color(rgb(t.text_muted))
-                    .child(base_label.clone()),
-            )
+            .when(show_label, |d| {
+                d.child(
+                    div()
+                        .text_color(rgb(t.text_muted))
+                        .child(base_label.clone()),
+                )
+            })
             .when(a > 0, |d| {
                 d.child(render_sign_count("+", a, t.term_green, 0.7))
             })


### PR DESCRIPTION
## Summary

Project-navigation and git-header fixes that surfaced while using okena on macOS.

### 1. Tab in the Project Switcher did nothing → jump to terminal
gpui-component's `Root` binds `tab` → `focus_next` **globally**, so the keystroke was consumed before the switcher's `on_key_down` ever saw it. Enter/Space/arrows worked because they have no such global binding.

- New `JumpToProjectTerminal` action, bound to `tab` in the **`ProjectSwitcher`** context (deeper context wins — the same trick `TerminalPane` already uses to capture Tab). Handled via `on_action`.
- Also centers the modal vertically (`items_center`) instead of top-anchoring it.

### 2. Exiting project focus jumped the project to center
Zooming a project collapses the overview to one full-width column, and GPUI clamps the grid scroll offset to `0` while zoomed (`clamp_scroll_position` mutates the stored offset). On exit the code re-centered the project, moving it from where it was.

- Capture the grid scroll offset when **entering** focus (before the zoom layout clamps it) and **restore** it (re-clamped) once the overview re-expands — so the project stays in place.

### 3. Jumping to a project (switcher Tab) now centers it
Complementary to #2: an explicit jump only scrolled the project just into view, leaving it flush against the left/right edge.

- `scroll_to_focused_project` gets a `center` mode. It's used **only for the explicit "jump to project" (project switcher Tab)** — via a one-shot flag set on the target window and consumed by the focus observer. Other project switches (cmd+alt+arrow, mouse click) keep the previous ensure-visible behavior, and exiting a zoom still restores the prior position. Centering is a no-op when everything already fits (no overflow).

### 4. Git header: green ↑ now means "unpushed", ahead/behind is labeled
The green `↑N` counted commits **ahead of the review base** (`main`), which reads like "to push" everywhere else (VS Code, lazygit, git CLI) and never dropped after a push — confusing the count.

- Green `↑N` now = commits not on `origin/<branch>` (the standard "to push" arrow; drops to 0 after push).
- Ahead/behind vs the review base moved to a labeled `⎇ main +N −M` chip that opens the three-dot diff-vs-base on click.
- Right-aligns the base-compare chip to the header edge via a flex spacer.

### 5. Git header: hide the base label when it's the default branch
The review base is always the repo's default branch, so spelling out `main` is redundant noise.

- Carry the default branch on `GitStatus` and show the base label only when it differs from the default — common case reads `⎇ +2`, a non-default base still shows its name. The tooltip keeps the full "ahead of <base>" wording.

## Files
- `crates/okena-app/src/keybindings/mod.rs`
- `crates/okena-app/src/views/overlays/project_switcher.rs`
- `crates/okena-app/src/views/window/mod.rs`
- `crates/okena-app/src/views/window/render.rs`
- `crates/okena-app/src/views/panels/project_column.rs`
- `crates/okena-app/src/app/extras.rs`
- `crates/okena-git/src/lib.rs`
- `crates/okena-git/src/repository/status.rs`
- `crates/okena-views-git/src/project_header.rs`
- `crates/okena-views-git/src/git_header/status_pill.rs`

## Testing
Builds clean (`cargo build`). These are GPUI keystroke-dispatch, scroll-layout, and render changes that aren't meaningfully unit-testable; verified by building and live use. Best confirmed in-app: Tab in the switcher (centers the target), arrow/click project switches (just ensure visible), zoom/unzoom a project in an overflowing overview (stays put on exit), and the git header chip on pushed vs unpushed and default vs non-default-base branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)