### PR TITLE
feat(terminal): OSC shell-integration sequences + kitty keyboard protocol (level 1)

### DIFF
--- a/crates/okena-app-core/src/settings.rs
+++ b/crates/okena-app-core/src/settings.rs
@@ -130,6 +130,12 @@ impl SettingsState {
         self.save_and_notify(cx);
     }
 
+    /// Allow or deny terminal apps reading the system clipboard via OSC 52.
+    pub fn set_allow_clipboard_read(&mut self, value: bool, cx: &mut Context<Self>) {
+        self.settings.allow_clipboard_read = value;
+        self.save_and_notify(cx);
+    }
+
     /// Set file finder "show ignored" preference (persisted default for future opens).
     pub fn set_file_finder_show_ignored(&mut self, value: bool, cx: &mut Context<Self>) {
         self.settings.file_finder.show_ignored = value;

--- a/crates/okena-app/src/app/mod.rs
+++ b/crates/okena-app/src/app/mod.rs
@@ -922,6 +922,9 @@ impl Okena {
                         // Stamp project activity for any command that finished
                         // this batch (OSC 133 ;D), independent of bell/OSC alerts.
                         this.process_command_finished_activity(&dirty_terminal_ids, cx);
+                        // Answer (or, when disabled, drop) OSC 52 clipboard
+                        // read requests queued by these terminals.
+                        this.process_clipboard_reads(&dirty_terminal_ids, cx);
                     }
 
                     if !exit_events.is_empty() {

--- a/crates/okena-app/src/app/notifications.rs
+++ b/crates/okena-app/src/app/notifications.rs
@@ -229,6 +229,67 @@ impl Okena {
         self.bump_activity_for_terminals(finished.iter().map(|s| s.as_str()), cx);
     }
 
+    /// Answer (or silently deny) OSC 52 clipboard *read* requests
+    /// (`OSC 52 ; c ; ?`) queued by terminals that produced output this batch.
+    /// Runs here, in the PTY event loop, because this is where the opt-in
+    /// setting and the system clipboard are reachable — the event listener
+    /// that enqueues the requests has neither.
+    ///
+    /// Clipboard read is gated behind `allow_clipboard_read` (off by default):
+    /// a program reading the clipboard can exfiltrate whatever the user has
+    /// copied. When allowed, every requesting terminal gets the current
+    /// clipboard contents; when not, the requests are dropped without a reply
+    /// so the per-terminal queues stay bounded.
+    pub(super) fn process_clipboard_reads(
+        &mut self,
+        dirty_terminal_ids: &[String],
+        cx: &mut Context<Self>,
+    ) {
+        // Collect the terminals that actually have a queued read. Almost every
+        // batch has none, so we bail before touching settings or the clipboard.
+        let pending: Vec<String> = {
+            let reg = self.terminals.lock();
+            dirty_terminal_ids
+                .iter()
+                .filter(|tid| reg.get(*tid).is_some_and(|t| t.has_pending_clipboard_reads()))
+                .cloned()
+                .collect()
+        };
+        if pending.is_empty() {
+            return;
+        }
+
+        // Read the opt-in setting once for the whole batch.
+        let allow = crate::settings::settings_entity(cx)
+            .read(cx)
+            .get()
+            .allow_clipboard_read;
+
+        if allow {
+            // Read the system clipboard once; hand the same contents to every
+            // requesting terminal. An empty/imageless clipboard answers "".
+            let content = cx
+                .read_from_clipboard()
+                .and_then(|item| item.text())
+                .unwrap_or_default();
+            let reg = self.terminals.lock();
+            for tid in &pending {
+                if let Some(term) = reg.get(tid) {
+                    term.answer_clipboard_reads(&content);
+                }
+            }
+        } else {
+            // Silently deny: drop the queued requests without replying so the
+            // queue stays bounded while the feature is off.
+            let reg = self.terminals.lock();
+            for tid in &pending {
+                if let Some(term) = reg.get(tid) {
+                    term.drop_clipboard_reads();
+                }
+            }
+        }
+    }
+
     /// Resolve each terminal id to its owning project and bump that project's
     /// activity timestamp once. Deduplicates projects so a batch touching
     /// several terminals of the same project only notifies/persists once.

--- a/crates/okena-app/src/keybindings/config.rs
+++ b/crates/okena-app/src/keybindings/config.rs
@@ -289,6 +289,15 @@ impl KeybindingConfig {
         );
 
         bindings.insert(
+            "JumpToPreviousFailedCommand".to_string(),
+            vec![KeybindingEntry::new("cmd-shift-up", Some("TerminalPane"))],
+        );
+        bindings.insert(
+            "JumpToNextFailedCommand".to_string(),
+            vec![KeybindingEntry::new("cmd-shift-down", Some("TerminalPane"))],
+        );
+
+        bindings.insert(
             "TogglePaneSwitcher".to_string(),
             vec![
                 KeybindingEntry::new("cmd-`", None),

--- a/crates/okena-app/src/keybindings/descriptions.rs
+++ b/crates/okena-app/src/keybindings/descriptions.rs
@@ -5,7 +5,7 @@ use super::{
     AddTab, Cancel, CheckForUpdates, ClearFocus, CloseSearch, CloseTerminal, Copy,
     CreateWorktree, FocusActiveProject, FocusDown, FocusLeft, FocusNextTerminal, FocusPrevTerminal, FocusRight,
     FocusSidebar, FocusUp, FullscreenNextTerminal, FullscreenPrevTerminal, InstallUpdate,
-    JumpToNextPrompt, JumpToPreviousPrompt,
+    JumpToNextFailedCommand, JumpToNextPrompt, JumpToPreviousFailedCommand, JumpToPreviousPrompt,
     MinimizeTerminal, NewProject, NewWindow, OpenSettingsFile, Paste, Quit, ResetZoom, ScrollDown, ScrollUp,
     Search, SearchNext, SearchPrev, SendEscape, ShowCommandPalette, ShowDiffViewer, ReviewChanges,
     ShowContentSearch, ShowFileSearch, ShowHookLog, ShowLogConsole, ShowKeybindings, ShowProjectSwitcher, ShowSessionManager,
@@ -246,6 +246,24 @@ pub fn get_action_descriptions() -> HashMap<&'static str, ActionDescription> {
             description: "Scroll forward to the next shell prompt (OSC 133)",
             category: "Terminal",
             factory: || Box::new(JumpToNextPrompt),
+        },
+    );
+    map.insert(
+        "JumpToPreviousFailedCommand",
+        ActionDescription {
+            name: "Jump to Previous Failed Command",
+            description: "Scroll to the previous command that exited with a non-zero status (OSC 133)",
+            category: "Terminal",
+            factory: || Box::new(JumpToPreviousFailedCommand),
+        },
+    );
+    map.insert(
+        "JumpToNextFailedCommand",
+        ActionDescription {
+            name: "Jump to Next Failed Command",
+            description: "Scroll forward to the next command that exited with a non-zero status (OSC 133)",
+            category: "Terminal",
+            factory: || Box::new(JumpToNextFailedCommand),
         },
     );
 

--- a/crates/okena-app/src/keybindings/mod.rs
+++ b/crates/okena-app/src/keybindings/mod.rs
@@ -67,6 +67,7 @@ pub use okena_views_terminal::actions::{
     SendTab, SendBacktab, ZoomIn, ZoomOut, ResetZoom,
     ToggleFullscreen, FullscreenNextTerminal, FullscreenPrevTerminal,
     JumpToPreviousPrompt, JumpToNextPrompt,
+    JumpToPreviousFailedCommand, JumpToNextFailedCommand,
 };
 
 // Sidebar-specific actions (defined in okena-views-sidebar crate)
@@ -299,6 +300,8 @@ fn create_keybinding(action: &str, keystroke: &str, context: Option<&str>) -> Op
         "SearchPrev" => Some(KeyBinding::new(keystroke, SearchPrev, context)),
         "JumpToPreviousPrompt" => Some(KeyBinding::new(keystroke, JumpToPreviousPrompt, context)),
         "JumpToNextPrompt" => Some(KeyBinding::new(keystroke, JumpToNextPrompt, context)),
+        "JumpToPreviousFailedCommand" => Some(KeyBinding::new(keystroke, JumpToPreviousFailedCommand, context)),
+        "JumpToNextFailedCommand" => Some(KeyBinding::new(keystroke, JumpToNextFailedCommand, context)),
         "CloseSearch" => Some(KeyBinding::new(keystroke, CloseSearch, context)),
         "ShowKeybindings" => Some(KeyBinding::new(keystroke, ShowKeybindings, context)),
         "ShowSessionManager" => Some(KeyBinding::new(keystroke, ShowSessionManager, context)),

--- a/crates/okena-app/src/views/overlays/settings_panel/render_general.rs
+++ b/crates/okena-app/src/views/overlays/settings_panel/render_general.rs
@@ -192,6 +192,17 @@ impl SettingsPanel {
                         ))
                     })
             })
+            .child(section_header("Clipboard", &t, cx))
+            .child(
+                section_container(&t).child(self.render_toggle(
+                    "clipboard-read",
+                    "Allow Clipboard Read (OSC 52)",
+                    s.allow_clipboard_read,
+                    false,
+                    |state, val, cx| state.set_allow_clipboard_read(val, cx),
+                    cx,
+                )),
+            )
     }
 
     fn render_header_density_row(

--- a/crates/okena-terminal/src/input.rs
+++ b/crates/okena-terminal/src/input.rs
@@ -19,12 +19,34 @@ pub struct KeyEvent {
     pub modifiers: KeyModifiers,
 }
 
+/// Active kitty keyboard protocol enhancement flags (read from the terminal mode).
+/// Only `disambiguate_escape_codes` is honored today; the other progressive-
+/// enhancement levels are a follow-up, so this struct intentionally carries
+/// just that one flag for now.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct KittyKeyboardFlags {
+    pub disambiguate_escape_codes: bool,
+}
+
 /// Convert a key event to terminal input bytes.
 ///
 /// `app_cursor_mode`: When true, arrow keys send SS3 sequences (\x1bOA) instead of CSI (\x1b[A).
 /// This should be true when the terminal is in application cursor keys mode (DECCKM),
 /// which is used by applications like less, vim, htop, etc.
-pub fn key_to_bytes(event: &KeyEvent, app_cursor_mode: bool) -> Option<Vec<u8>> {
+///
+/// `kitty`: Active kitty keyboard protocol flags. When `disambiguate_escape_codes`
+/// is set, the ambiguous keys (Esc, ctrl/alt+key, modified Enter/Tab/Backspace) are
+/// reported as `CSI u` sequences before the legacy logic runs.
+pub fn key_to_bytes(
+    event: &KeyEvent,
+    app_cursor_mode: bool,
+    kitty: KittyKeyboardFlags,
+) -> Option<Vec<u8>> {
+    if kitty.disambiguate_escape_codes
+        && let Some(bytes) = kitty_disambiguate_bytes(event) {
+        return Some(bytes);
+    }
+
     let mods = &event.modifiers;
 
     // Handle Ctrl+key combinations for letters (produces control characters)
@@ -168,4 +190,176 @@ pub fn key_to_bytes(event: &KeyEvent, app_cursor_mode: bool) -> Option<Vec<u8>> 
 
     log::warn!("No input generated for key: {:?}", event.key);
     None
+}
+
+/// Encode a key as a `CSI u` sequence: `CSI code u` when unmodified, or
+/// `CSI code ; kmod u` when modifiers are held.
+fn csi_u(code: u32, kmod: u32) -> Vec<u8> {
+    if kmod == 1 {
+        format!("\x1b[{code}u").into_bytes()
+    } else {
+        format!("\x1b[{code};{kmod}u").into_bytes()
+    }
+}
+
+/// Kitty keyboard protocol level 1 ("Disambiguate escape codes").
+///
+/// Returns the `CSI u` encoding for the keys the disambiguate level rewrites:
+/// Esc (always), modified Enter/Tab/Backspace, and ctrl/alt printable keys.
+/// Returns `None` for everything else so the caller falls through to the
+/// legacy logic, which already matches kitty for arrows/Home/End and produces
+/// text for plain keys.
+fn kitty_disambiguate_bytes(event: &KeyEvent) -> Option<Vec<u8>> {
+    let mods = &event.modifiers;
+    // Kitty modifier value: 1 + bitmask (shift=1, alt=2, ctrl=4, super=8).
+    let kmod = 1
+        + (if mods.shift { 1 } else { 0 })
+        + (if mods.alt { 2 } else { 0 })
+        + (if mods.control { 4 } else { 0 })
+        + (if mods.platform { 8 } else { 0 });
+    let has_mods = kmod > 1;
+
+    match event.key.as_str() {
+        // Plain Esc is reported as `CSI 27 u` so apps can tell it from the
+        // start of an escape sequence.
+        "escape" => Some(csi_u(27, kmod)),
+        // Plain Enter stays legacy `\r`; modified Enter is disambiguated.
+        "enter" | "return" | "kp_enter" => has_mods.then(|| csi_u(13, kmod)),
+        // Plain Tab stays legacy `\t`; Shift+Tab → `\x1b[9;2u`.
+        "tab" => has_mods.then(|| csi_u(9, kmod)),
+        // Plain Backspace stays legacy; modified Backspace is disambiguated.
+        "backspace" => has_mods.then(|| csi_u(127, kmod)),
+        key => {
+            // ctrl/alt + a single printable char (ctrl+letter, alt+key,
+            // ctrl+alt+key, shift+alt+key). Plain super+key is a higher level.
+            if (mods.control || mods.alt)
+                && key.chars().count() == 1
+                && let Some(c) = key.chars().next()
+                && !c.is_control()
+            {
+                let cp = if c.is_ascii_alphabetic() {
+                    c.to_ascii_lowercase() as u32
+                } else {
+                    c as u32
+                };
+                Some(csi_u(cp, kmod))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(key: &str, key_char: Option<&str>, mods: KeyModifiers) -> KeyEvent {
+        KeyEvent {
+            key: key.to_string(),
+            key_char: key_char.map(|s| s.to_string()),
+            modifiers: mods,
+        }
+    }
+
+    fn ctrl() -> KeyModifiers {
+        KeyModifiers { control: true, ..Default::default() }
+    }
+
+    fn shift() -> KeyModifiers {
+        KeyModifiers { shift: true, ..Default::default() }
+    }
+
+    fn on() -> KittyKeyboardFlags {
+        KittyKeyboardFlags { disambiguate_escape_codes: true }
+    }
+
+    #[test]
+    fn flag_off_keeps_legacy_bytes() {
+        let off = KittyKeyboardFlags::default();
+        assert_eq!(
+            key_to_bytes(&ev("a", None, ctrl()), false, off),
+            Some(vec![0x01])
+        );
+        assert_eq!(
+            key_to_bytes(&ev("tab", None, KeyModifiers::default()), false, off),
+            Some(b"\t".to_vec())
+        );
+        assert_eq!(
+            key_to_bytes(&ev("escape", None, KeyModifiers::default()), false, off),
+            Some(b"\x1b".to_vec())
+        );
+    }
+
+    #[test]
+    fn escape_is_disambiguated() {
+        assert_eq!(
+            key_to_bytes(&ev("escape", None, KeyModifiers::default()), false, on()),
+            Some(b"\x1b[27u".to_vec())
+        );
+        assert_eq!(
+            key_to_bytes(&ev("escape", None, ctrl()), false, on()),
+            Some(b"\x1b[27;5u".to_vec())
+        );
+    }
+
+    #[test]
+    fn ctrl_letters_are_disambiguated() {
+        assert_eq!(
+            key_to_bytes(&ev("i", None, ctrl()), false, on()),
+            Some(b"\x1b[105;5u".to_vec())
+        );
+        assert_eq!(
+            key_to_bytes(&ev("a", None, ctrl()), false, on()),
+            Some(b"\x1b[97;5u".to_vec())
+        );
+    }
+
+    #[test]
+    fn tab_disambiguation() {
+        assert_eq!(
+            key_to_bytes(&ev("tab", None, shift()), false, on()),
+            Some(b"\x1b[9;2u".to_vec())
+        );
+        assert_eq!(
+            key_to_bytes(&ev("tab", None, KeyModifiers::default()), false, on()),
+            Some(b"\t".to_vec())
+        );
+    }
+
+    #[test]
+    fn enter_disambiguation() {
+        assert_eq!(
+            key_to_bytes(&ev("enter", None, ctrl()), false, on()),
+            Some(b"\x1b[13;5u".to_vec())
+        );
+        assert_eq!(
+            key_to_bytes(&ev("enter", None, KeyModifiers::default()), false, on()),
+            Some(b"\r".to_vec())
+        );
+    }
+
+    #[test]
+    fn ctrl_backspace_is_disambiguated() {
+        assert_eq!(
+            key_to_bytes(&ev("backspace", None, ctrl()), false, on()),
+            Some(b"\x1b[127;5u".to_vec())
+        );
+    }
+
+    #[test]
+    fn plain_char_falls_through_to_text() {
+        assert_eq!(
+            key_to_bytes(&ev("a", Some("a"), KeyModifiers::default()), false, on()),
+            None
+        );
+    }
+
+    #[test]
+    fn plain_arrow_is_not_stolen() {
+        assert_eq!(
+            key_to_bytes(&ev("up", None, KeyModifiers::default()), false, on()),
+            Some(b"\x1b[A".to_vec())
+        );
+    }
 }

--- a/crates/okena-terminal/src/terminal/event_listener.rs
+++ b/crates/okena-terminal/src/terminal/event_listener.rs
@@ -4,6 +4,23 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::transport::TerminalTransport;
+use super::types::ClipboardReadResponder;
+
+/// The two OSC 52 clipboard queues the listener shares with `Terminal`.
+///
+/// Both are `Arc`-shared with the owning `Terminal` (which holds the same
+/// `Arc`s as separate fields) and pushed here during `process_output`, then
+/// drained on the GPUI thread. They are grouped into one struct so the
+/// listener constructor stays compact as more shared state is added.
+pub(super) struct ClipboardQueues {
+    /// Pending OSC 52 clipboard writes to be picked up by the GPUI thread.
+    pub writes: Arc<Mutex<Vec<String>>>,
+    /// Pending OSC 52 clipboard *read* requests (`OSC 52 ; c ; ?`), each
+    /// carrying a formatter that turns clipboard text into the PTY reply.
+    /// Drained on the GPUI thread, where the system clipboard and the opt-in
+    /// setting gating reads are reachable.
+    pub reads: Arc<Mutex<Vec<ClipboardReadResponder>>>,
+}
 
 /// Event listener for alacritty_terminal that captures title changes, bell, and PTY write requests
 pub struct ZedEventListener {
@@ -15,8 +32,8 @@ pub struct ZedEventListener {
     /// event loop to fire a desktop notification exactly once per bell rather
     /// than on every batch while `has_bell` stays set.
     bell_pending: Arc<AtomicBool>,
-    /// Pending OSC 52 clipboard writes to be picked up by the GPUI thread
-    pending_clipboard: Arc<Mutex<Vec<String>>>,
+    /// Pending OSC 52 clipboard write/read queues, shared with `Terminal`.
+    clipboard: ClipboardQueues,
     /// Current theme palette, pushed from the GPUI thread on each render.
     /// Used to answer OSC 10/11/12/4 color queries from apps.
     palette: Arc<Mutex<Option<okena_core::theme::ThemeColors>>>,
@@ -27,16 +44,24 @@ pub struct ZedEventListener {
 }
 
 impl ZedEventListener {
-    pub fn new(
+    pub(super) fn new(
         title: Arc<Mutex<Option<String>>>,
         has_bell: Arc<Mutex<bool>>,
         bell_pending: Arc<AtomicBool>,
-        pending_clipboard: Arc<Mutex<Vec<String>>>,
+        clipboard: ClipboardQueues,
         palette: Arc<Mutex<Option<okena_core::theme::ThemeColors>>>,
         transport: Arc<dyn TerminalTransport>,
         terminal_id: String,
     ) -> Self {
-        Self { title, has_bell, bell_pending, pending_clipboard, palette, transport, terminal_id }
+        Self {
+            title,
+            has_bell,
+            bell_pending,
+            clipboard,
+            palette,
+            transport,
+            terminal_id,
+        }
     }
 
     /// Resolve a color index (as passed by alacritty on a color query) to an
@@ -119,7 +144,17 @@ impl EventListener for ZedEventListener {
                 self.bell_pending.store(true, Ordering::Relaxed);
             }
             TermEvent::ClipboardStore(_, text) => {
-                self.pending_clipboard.lock().push(text);
+                self.clipboard.writes.lock().push(text);
+            }
+            TermEvent::ClipboardLoad(_ty, formatter) => {
+                // An app asked to READ the clipboard (`OSC 52 ; c ; ?`). We
+                // can't read the system clipboard here (no `cx` on this
+                // thread), so queue the formatter; the GPUI thread drains it
+                // later, gated behind the opt-in `allow_clipboard_read`
+                // setting. The `ClipboardType` is ignored — primary-selection
+                // requests are answered from the regular clipboard like the
+                // rest, which matches what most terminals do.
+                self.clipboard.reads.lock().push(formatter);
             }
             TermEvent::ColorRequest(index, response_fn) => {
                 if let Some((r, g, b)) = self.resolve_color(index) {

--- a/crates/okena-terminal/src/terminal/event_listener.rs
+++ b/crates/okena-terminal/src/terminal/event_listener.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::transport::TerminalTransport;
-use super::types::ClipboardReadResponder;
+use super::types::{ClipboardReadResponder, ResizeState};
 
 /// The two OSC 52 clipboard queues the listener shares with `Terminal`.
 ///
@@ -22,6 +22,23 @@ pub(super) struct ClipboardQueues {
     pub reads: Arc<Mutex<Vec<ClipboardReadResponder>>>,
 }
 
+/// The current terminal state the listener reads to answer terminal queries.
+///
+/// Both fields are `Arc`-shared with the owning `Terminal` (which holds the
+/// same `Arc`s) and read here during `process_output` to compose replies:
+/// `palette` answers OSC 10/11/12/4 color queries, `resize_state` answers the
+/// `CSI 14 t` (XTWINOPS) text-area-size-in-pixels query. They are grouped into
+/// one struct so the listener constructor stays compact as more shared state
+/// is added.
+pub(super) struct CurrentState {
+    /// Current theme palette, pushed from the GPUI thread on each render.
+    /// Used to answer OSC 10/11/12/4 color queries from apps.
+    pub palette: Arc<Mutex<Option<okena_core::theme::ThemeColors>>>,
+    /// Current terminal size, kept up to date by `resize`. Read to answer the
+    /// `CSI 14 t` XTWINOPS query (report text-area size in pixels).
+    pub resize_state: Arc<Mutex<ResizeState>>,
+}
+
 /// Event listener for alacritty_terminal that captures title changes, bell, and PTY write requests
 pub struct ZedEventListener {
     /// Shared title storage - OSC 0/1/2 sequences update this
@@ -34,9 +51,9 @@ pub struct ZedEventListener {
     bell_pending: Arc<AtomicBool>,
     /// Pending OSC 52 clipboard write/read queues, shared with `Terminal`.
     clipboard: ClipboardQueues,
-    /// Current theme palette, pushed from the GPUI thread on each render.
-    /// Used to answer OSC 10/11/12/4 color queries from apps.
-    palette: Arc<Mutex<Option<okena_core::theme::ThemeColors>>>,
+    /// Current state the listener reads to answer terminal queries (theme
+    /// palette for color queries, size for the XTWINOPS size query).
+    state: CurrentState,
     /// Transport for writing responses back to the terminal
     transport: Arc<dyn TerminalTransport>,
     /// Terminal ID for PTY write operations
@@ -49,7 +66,7 @@ impl ZedEventListener {
         has_bell: Arc<Mutex<bool>>,
         bell_pending: Arc<AtomicBool>,
         clipboard: ClipboardQueues,
-        palette: Arc<Mutex<Option<okena_core::theme::ThemeColors>>>,
+        state: CurrentState,
         transport: Arc<dyn TerminalTransport>,
         terminal_id: String,
     ) -> Self {
@@ -58,7 +75,7 @@ impl ZedEventListener {
             has_bell,
             bell_pending,
             clipboard,
-            palette,
+            state,
             transport,
             terminal_id,
         }
@@ -83,7 +100,7 @@ impl ZedEventListener {
             return Some(xterm_256_grayscale_rgb(index));
         }
 
-        let palette = self.palette.lock();
+        let palette = self.state.palette.lock();
         let colors = palette.as_ref()?;
         let hex = match index {
             0 => colors.term_black,
@@ -162,6 +179,21 @@ impl EventListener for ZedEventListener {
                         response_fn(alacritty_terminal::vte::ansi::Rgb { r, g, b });
                     self.transport.send_input(&self.terminal_id, reply.as_bytes());
                 }
+            }
+            TermEvent::TextAreaSizeRequest(formatter) => {
+                // Answer `CSI 14 t` (report text-area size in pixels). alacritty
+                // hands us the formatter; we supply the current geometry. Cell
+                // dims are f32 pixels in TerminalSize; round to the nearest whole
+                // pixel (min 1) for the u16 WindowSize.
+                let size = self.state.resize_state.lock().size;
+                let window_size = alacritty_terminal::event::WindowSize {
+                    num_lines: size.rows,
+                    num_cols: size.cols,
+                    cell_width: (size.cell_width.round() as u16).max(1),
+                    cell_height: (size.cell_height.round() as u16).max(1),
+                };
+                let reply = formatter(window_size);
+                self.transport.send_input(&self.terminal_id, reply.as_bytes());
             }
             TermEvent::PtyWrite(data) => {
                 // Write response back to PTY (e.g., cursor position report)

--- a/crates/okena-terminal/src/terminal/io.rs
+++ b/crates/okena-terminal/src/terminal/io.rs
@@ -206,6 +206,45 @@ impl Terminal {
         self.transport.send_input(&self.terminal_id, data);
     }
 
+    /// Send a named special key (Esc / Tab / Shift+Tab) the way the running app
+    /// expects, honoring app-cursor and kitty-keyboard modes.
+    ///
+    /// These keys are delivered via dedicated GPUI actions (so they take part
+    /// in context routing — e.g. Esc closes search in the search bar but goes
+    /// to the PTY here) instead of the raw `on_key_down` path, so they bypass
+    /// the encoder unless routed back through it here. Reusing `key_to_bytes`
+    /// keeps them in lockstep with normal key handling (notably the kitty
+    /// `CSI u` disambiguation: `Esc` → `CSI 27 u`, `Shift+Tab` → `CSI 9 ; 2 u`).
+    fn send_named_key(&self, key: &str, shift: bool) {
+        let event = crate::input::KeyEvent {
+            key: key.to_string(),
+            key_char: None,
+            modifiers: crate::input::KeyModifiers { shift, ..Default::default() },
+        };
+        if let Some(bytes) = crate::input::key_to_bytes(
+            &event,
+            self.is_app_cursor_mode(),
+            self.kitty_keyboard_flags(),
+        ) {
+            self.send_bytes(&bytes);
+        }
+    }
+
+    /// Send the Escape key (kitty-aware: `CSI 27 u` in disambiguate mode).
+    pub fn send_escape(&self) {
+        self.send_named_key("escape", false);
+    }
+
+    /// Send the Tab key (plain `\t`; unchanged by kitty level 1).
+    pub fn send_tab(&self) {
+        self.send_named_key("tab", false);
+    }
+
+    /// Send Shift+Tab / backtab (kitty-aware: `CSI 9 ; 2 u` in disambiguate mode).
+    pub fn send_backtab(&self) {
+        self.send_named_key("tab", true);
+    }
+
     /// Clear the terminal screen by sending the clear sequence
     pub fn clear(&self) {
         // Send ANSI escape sequence to clear screen and move cursor to home

--- a/crates/okena-terminal/src/terminal/io.rs
+++ b/crates/okena-terminal/src/terminal/io.rs
@@ -51,6 +51,7 @@ impl Terminal {
         // New output disengages the prompt-jump walker so the next
         // Above jump starts from the newest prompt again.
         *self.prompt_jump_index.lock() = None;
+        *self.failed_jump_index.lock() = None;
 
         self.dirty.store(true, Ordering::Relaxed);
         self.content_generation.fetch_add(1, Ordering::Relaxed);

--- a/crates/okena-terminal/src/terminal/meta.rs
+++ b/crates/okena-terminal/src/terminal/meta.rs
@@ -19,6 +19,37 @@ impl Terminal {
         std::mem::take(&mut *self.pending_clipboard.lock())
     }
 
+    /// Whether the running app has queued any OSC 52 clipboard *read* requests
+    /// (`OSC 52 ; c ; ?`) since the last drain. The PTY event loop checks this
+    /// per dirty terminal before deciding whether to read the system clipboard
+    /// (only when the opt-in setting is on) or silently drop the requests.
+    pub fn has_pending_clipboard_reads(&self) -> bool {
+        !self.pending_clipboard_reads.lock().is_empty()
+    }
+
+    /// Answer all queued OSC 52 clipboard *read* requests with `content`,
+    /// draining the queue. For each queued formatter we build the reply
+    /// (`OSC 52 ; c ; <base64> ST`) and write it straight back to the PTY via
+    /// the transport — not `send_bytes` — so a clipboard read doesn't set
+    /// `had_user_input` or scroll the view, mirroring how color-query replies
+    /// are written directly in the event listener. Only call this when the
+    /// user has opted into clipboard reads.
+    pub fn answer_clipboard_reads(&self, content: &str) {
+        let responders = std::mem::take(&mut *self.pending_clipboard_reads.lock());
+        for responder in responders {
+            let reply = responder(content);
+            self.transport.send_input(&self.terminal_id, reply.as_bytes());
+        }
+    }
+
+    /// Drop all queued OSC 52 clipboard *read* requests without replying.
+    /// Used when the `allow_clipboard_read` setting is off: the request is
+    /// silently denied (the app gets no response), but the queue is still
+    /// cleared so it stays bounded across batches.
+    pub fn drop_clipboard_reads(&self) {
+        self.pending_clipboard_reads.lock().clear();
+    }
+
     /// Take any pending `OSC 9` / `OSC 777` notifications. The GPUI thread
     /// drains these in the PTY event loop to surface native desktop
     /// notifications for background panes whose command finished or needs

--- a/crates/okena-terminal/src/terminal/meta.rs
+++ b/crates/okena-terminal/src/terminal/meta.rs
@@ -27,6 +27,14 @@ impl Terminal {
         std::mem::take(&mut *self.pending_notifications.lock())
     }
 
+    /// Active `OSC 9 ; 4` (ConEmu / Windows Terminal) progress report, or
+    /// `None` when the running program isn't reporting progress (it never
+    /// started one, or sent `st=0` to clear it). Read each render to drive a
+    /// per-tab / per-pane progress indicator.
+    pub fn progress(&self) -> Option<super::TerminalProgress> {
+        *self.progress.lock()
+    }
+
     /// Push the active theme palette so the event listener can answer
     /// OSC 10/11/12/4 color queries with real theme colors. Called from the
     /// render loop on every frame; writes are cheap and uncontested.

--- a/crates/okena-terminal/src/terminal/mod.rs
+++ b/crates/okena-terminal/src/terminal/mod.rs
@@ -328,6 +328,13 @@ impl Terminal {
                 shape: VteCursorShape::HollowBlock,
                 blinking: false,
             },
+            // Enable the kitty keyboard protocol. alacritty gates ALL of its
+            // keyboard-mode handling (push/pop/set/report of `CSI u` mode
+            // sequences) behind this flag — with it off, an app's request to
+            // enable the protocol is silently ignored and `term.mode()` never
+            // reflects it, so `kitty_keyboard_flags()` would always read false
+            // and our encoder (see `input::key_to_bytes`) would never fire.
+            kitty_keyboard: true,
             // Accept OSC 52 *read* (paste) sequences in addition to writes.
             // alacritty's default `OnlyCopy` silently drops `OSC 52 ; c ; ?`
             // and never emits `ClipboardLoad`; `CopyPaste` makes it emit the

--- a/crates/okena-terminal/src/terminal/mod.rs
+++ b/crates/okena-terminal/src/terminal/mod.rs
@@ -39,13 +39,13 @@ pub use resize_authority::{
 };
 pub use transport::TerminalTransport;
 pub use types::{
-    AppCursorShape, DetectedLink, PromptMark, PromptMarkKind, ResizeState, SelectionState,
-    TerminalProgress, TerminalProgressState, TerminalSize,
+    AppCursorShape, ClipboardReadResponder, DetectedLink, PromptMark, PromptMarkKind, ResizeState,
+    SelectionState, TerminalProgress, TerminalProgressState, TerminalSize,
 };
 
 pub use osc_sidecar::TerminalNotification;
 
-use event_listener::ZedEventListener;
+use event_listener::{ClipboardQueues, ZedEventListener};
 use osc_sidecar::OscSidecar;
 use prompt_marks::{PromptSidecar, PromptTracker};
 use types::FocusReportState;
@@ -163,6 +163,15 @@ pub struct Terminal {
     /// drained by the GPUI render path via `drain_clipboard_writes`.
     /// GPUI thread only.
     pub(super) pending_clipboard: Arc<Mutex<Vec<String>>>,
+
+    /// Pending OSC 52 clipboard *read* requests (`OSC 52 ; c ; ?`) from the
+    /// running app, each carrying the formatter that turns clipboard text
+    /// into the PTY reply. `Arc` shared with `ZedEventListener`: pushed on
+    /// `ClipboardLoad` during `process_output`, drained on the GPUI thread
+    /// (in the PTY event loop, where the settings gate and the system
+    /// clipboard are reachable) via `answer_clipboard_reads` /
+    /// `drop_clipboard_reads`. GPUI thread only.
+    pub(super) pending_clipboard_reads: Arc<Mutex<Vec<ClipboardReadResponder>>>,
 
     /// Theme palette used to answer OSC 10/11/12/4 color queries from
     /// terminal apps. `Arc` shared with `ZedEventListener`: the render path
@@ -319,6 +328,14 @@ impl Terminal {
                 shape: VteCursorShape::HollowBlock,
                 blinking: false,
             },
+            // Accept OSC 52 *read* (paste) sequences in addition to writes.
+            // alacritty's default `OnlyCopy` silently drops `OSC 52 ; c ; ?`
+            // and never emits `ClipboardLoad`; `CopyPaste` makes it emit the
+            // event so Okena can queue the request and decide whether to
+            // answer it based on the opt-in `allow_clipboard_read` setting
+            // (off by default). The actual security gate lives in Okena, not
+            // here — alacritty just hands us the request.
+            osc52: alacritty_terminal::term::Osc52::CopyPaste,
             ..TermConfig::default()
         };
         let term_size = TermSize::new(size.cols as usize, size.rows as usize);
@@ -328,12 +345,16 @@ impl Terminal {
         let has_bell = Arc::new(Mutex::new(false));
         let bell_pending = Arc::new(AtomicBool::new(false));
         let pending_clipboard = Arc::new(Mutex::new(Vec::new()));
+        let pending_clipboard_reads = Arc::new(Mutex::new(Vec::new()));
         let palette = Arc::new(Mutex::new(None));
         let event_listener = ZedEventListener::new(
             title.clone(),
             has_bell.clone(),
             bell_pending.clone(),
-            pending_clipboard.clone(),
+            ClipboardQueues {
+                writes: pending_clipboard.clone(),
+                reads: pending_clipboard_reads.clone(),
+            },
             palette.clone(),
             transport.clone(),
             terminal_id.clone(),
@@ -364,6 +385,7 @@ impl Terminal {
             bell_pending,
             has_notification: AtomicBool::new(false),
             pending_clipboard,
+            pending_clipboard_reads,
             palette,
             pending_output: Mutex::new(Vec::new()),
             dirty: AtomicBool::new(false),

--- a/crates/okena-terminal/src/terminal/mod.rs
+++ b/crates/okena-terminal/src/terminal/mod.rs
@@ -45,7 +45,7 @@ pub use types::{
 
 pub use osc_sidecar::TerminalNotification;
 
-use event_listener::{ClipboardQueues, ZedEventListener};
+use event_listener::{ClipboardQueues, CurrentState, ZedEventListener};
 use osc_sidecar::OscSidecar;
 use prompt_marks::{PromptSidecar, PromptTracker};
 use types::FocusReportState;
@@ -347,6 +347,7 @@ impl Terminal {
         let pending_clipboard = Arc::new(Mutex::new(Vec::new()));
         let pending_clipboard_reads = Arc::new(Mutex::new(Vec::new()));
         let palette = Arc::new(Mutex::new(None));
+        let resize_state = Arc::new(Mutex::new(ResizeState::new(size)));
         let event_listener = ZedEventListener::new(
             title.clone(),
             has_bell.clone(),
@@ -355,7 +356,10 @@ impl Terminal {
                 writes: pending_clipboard.clone(),
                 reads: pending_clipboard_reads.clone(),
             },
-            palette.clone(),
+            CurrentState {
+                palette: palette.clone(),
+                resize_state: resize_state.clone(),
+            },
             transport.clone(),
             terminal_id.clone(),
         );
@@ -376,7 +380,7 @@ impl Terminal {
             term: Arc::new(Mutex::new(term)),
             processor: Mutex::new(Processor::new()),
             terminal_id,
-            resize_state: Arc::new(Mutex::new(ResizeState::new(size))),
+            resize_state,
             transport,
             selection_state: Mutex::new(SelectionState::default()),
             scroll_offset: Mutex::new(0),

--- a/crates/okena-terminal/src/terminal/mod.rs
+++ b/crates/okena-terminal/src/terminal/mod.rs
@@ -40,7 +40,7 @@ pub use resize_authority::{
 pub use transport::TerminalTransport;
 pub use types::{
     AppCursorShape, DetectedLink, PromptMark, PromptMarkKind, ResizeState, SelectionState,
-    TerminalSize,
+    TerminalProgress, TerminalProgressState, TerminalSize,
 };
 
 pub use osc_sidecar::TerminalNotification;
@@ -181,6 +181,12 @@ pub struct Terminal {
     /// thread in the PTY event loop via `take_pending_notifications`. GPUI
     /// thread only.
     pub(super) pending_notifications: Arc<Mutex<Vec<TerminalNotification>>>,
+
+    /// Active `OSC 9 ; 4` (ConEmu / Windows Terminal) progress report, or
+    /// `None` when no progress is being shown. `Arc` shared with `OscSidecar`:
+    /// the sidecar overwrites it on each `OSC 9 ; 4` (and clears it to `None`
+    /// on `st=0`), GPUI reads via `progress`. GPUI thread only.
+    pub(super) progress: Arc<Mutex<Option<TerminalProgress>>>,
 
     /// Per-renderer focus state for DEC focus reports. A terminal can appear
     /// in multiple windows, so focus reports are derived from the aggregate
@@ -328,9 +334,11 @@ impl Terminal {
 
         let reported_cwd = Arc::new(Mutex::new(None));
         let pending_notifications = Arc::new(Mutex::new(Vec::new()));
+        let progress = Arc::new(Mutex::new(None));
         let osc_sidecar = Mutex::new(OscSidecar::new(
             reported_cwd.clone(),
             pending_notifications.clone(),
+            progress.clone(),
             transport.clone(),
             terminal_id.clone(),
         ));
@@ -355,6 +363,7 @@ impl Terminal {
             initial_cwd,
             reported_cwd,
             pending_notifications,
+            progress,
             focus_report_state: Mutex::new(FocusReportState::default()),
             osc_sidecar,
             prompt_sidecar: Mutex::new(PromptSidecar::new()),

--- a/crates/okena-terminal/src/terminal/mod.rs
+++ b/crates/okena-terminal/src/terminal/mod.rs
@@ -224,6 +224,14 @@ pub struct Terminal {
     /// GPUI thread only.
     pub(super) prompt_jump_index: Mutex<Option<usize>>,
 
+    /// Reverse index into the current list of prompts that produced a
+    /// non-zero exit code (0 = newest failure). `Some` while the user is
+    /// walking through failed commands with
+    /// `jump_to_prev/next_failed_command`; reset to `None` on any output or
+    /// scroll so the next walk starts from the most recent failure again.
+    /// GPUI thread only.
+    pub(super) failed_jump_index: Mutex<Option<usize>>,
+
     /// Shell process PID. Set by `set_shell_pid` (called from GPUI thread
     /// after PTY spawn), read by `shell_pid` and `has_running_child`.
     /// GPUI thread only.
@@ -370,6 +378,7 @@ impl Terminal {
             prompt_tracker: Mutex::new(PromptTracker::new()),
             command_finished_pending: AtomicBool::new(false),
             prompt_jump_index: Mutex::new(None),
+            failed_jump_index: Mutex::new(None),
             last_output_time: Arc::new(Mutex::new(Instant::now())),
             shell_pid: Mutex::new(None),
             waiting_for_input: AtomicBool::new(false),

--- a/crates/okena-terminal/src/terminal/modes.rs
+++ b/crates/okena-terminal/src/terminal/modes.rs
@@ -25,6 +25,19 @@ impl Terminal {
         term.mode().contains(TermMode::APP_CURSOR)
     }
 
+    /// Active kitty keyboard protocol enhancement flags requested by the app.
+    /// Only the level-1 "disambiguate escape codes" flag is honored today; the
+    /// higher progressive-enhancement levels are a follow-up.
+    pub fn kitty_keyboard_flags(&self) -> crate::input::KittyKeyboardFlags {
+        crate::input::KittyKeyboardFlags {
+            disambiguate_escape_codes: self
+                .term
+                .lock()
+                .mode()
+                .contains(TermMode::DISAMBIGUATE_ESC_CODES),
+        }
+    }
+
     /// Check if terminal is using the alternate screen buffer.
     /// TUI apps (vim, less, htop, Claude Code CLI) use alternate screen.
     pub fn is_alt_screen(&self) -> bool {

--- a/crates/okena-terminal/src/terminal/osc_sidecar.rs
+++ b/crates/okena-terminal/src/terminal/osc_sidecar.rs
@@ -217,6 +217,31 @@ impl Perform for SidecarPerform {
                     *self.reported_cwd.lock() = Some(path);
                 }
             }
+            b"1337" => {
+                // iTerm2's proprietary `OSC 1337 ; key=value` channel. We only
+                // honour `CurrentDir=<path>`, which some shell integrations emit
+                // instead of `OSC 7`; it feeds the *same* `reported_cwd` so the
+                // sidebar / "new tab here" / cwd tracking work regardless of
+                // which sequence the shell speaks. All other 1337 subcommands
+                // (RemoteHost, SetUserVar, File, …) have no consumer here and
+                // are deliberately ignored rather than parsed into dead code.
+                //
+                // Unlike OSC 7, the value is a raw filesystem path — not a
+                // `file://` URI and not percent-encoded. A path may legitimately
+                // contain `;`, so rejoin the split tail like the OSC 7 / 777
+                // arms in case the parser broke the value apart.
+                let payload: String = params[1..]
+                    .iter()
+                    .filter_map(|p| std::str::from_utf8(p).ok())
+                    .collect::<Vec<_>>()
+                    .join(";");
+                if let Some(value) = payload.strip_prefix("CurrentDir=") {
+                    let path = value.trim();
+                    if !path.is_empty() {
+                        *self.reported_cwd.lock() = Some(path.to_string());
+                    }
+                }
+            }
             b"9" => {
                 // iTerm2-style notification: `OSC 9 ; <message>`. ConEmu's
                 // `OSC 9 ; 4 ; state ; progress` progress-bar subtype is

--- a/crates/okena-terminal/src/terminal/osc_sidecar.rs
+++ b/crates/okena-terminal/src/terminal/osc_sidecar.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use super::app_version::app_version;
 use super::transport::TerminalTransport;
+use super::types::{TerminalProgress, TerminalProgressState};
 
 /// A desktop notification requested by the shell via an OSC escape.
 ///
@@ -54,6 +55,7 @@ impl OscSidecar {
     pub(super) fn new(
         reported_cwd: Arc<Mutex<Option<String>>>,
         pending_notifications: Arc<Mutex<Vec<TerminalNotification>>>,
+        progress: Arc<Mutex<Option<TerminalProgress>>>,
         transport: Arc<dyn TerminalTransport>,
         terminal_id: String,
     ) -> Self {
@@ -62,6 +64,7 @@ impl OscSidecar {
             perform: SidecarPerform {
                 reported_cwd,
                 pending_notifications,
+                progress,
                 transport,
                 terminal_id,
                 osc99_pending: HashMap::new(),
@@ -79,6 +82,10 @@ struct SidecarPerform {
     /// `OSC 9` / `OSC 777` / `OSC 99` notifications, drained by the GPUI thread
     /// in the PTY event loop (same model as `pending_clipboard`).
     pending_notifications: Arc<Mutex<Vec<TerminalNotification>>>,
+    /// Active `OSC 9 ; 4` (ConEmu / Windows Terminal) progress report, or
+    /// `None` when cleared (`st=0`). Overwritten on each progress sequence and
+    /// read by the GPUI thread via `Terminal::progress`.
+    progress: Arc<Mutex<Option<TerminalProgress>>>,
     transport: Arc<dyn TerminalTransport>,
     terminal_id: String,
     /// In-progress `OSC 99` notifications keyed by `i=` id, awaiting their
@@ -195,6 +202,62 @@ impl SidecarPerform {
         };
         self.pending_notifications.lock().push(notification);
     }
+
+    /// Handle the ConEmu / Windows Terminal progress protocol
+    /// `OSC 9 ; 4 ; st ; pr` (also spoken by WezTerm, Ghostty, Kitty, …).
+    ///
+    /// `st` selects the state and `pr` an optional 0..=100 percentage:
+    /// - `st=0` → clear progress (`pr` ignored).
+    /// - `st=1` → [`TerminalProgressState::Normal`] at `pr` percent
+    ///   (clamped to `0..=100`).
+    /// - `st=2` → [`TerminalProgressState::Error`]; `pr` optional, keeping the
+    ///   previous percent when absent.
+    /// - `st=3` → [`TerminalProgressState::Indeterminate`] (`pr` ignored).
+    /// - `st=4` → [`TerminalProgressState::Paused`]; `pr` optional like `st=2`.
+    ///
+    /// A missing or unparseable `st` (or any value outside `0..=4`) leaves the
+    /// current progress untouched, so a malformed sequence can never panic or
+    /// spuriously clear an active bar. `params[2]` is `st`, `params[3]` is `pr`.
+    fn handle_osc9_progress(&mut self, params: &[&[u8]]) {
+        let Some(st) = params
+            .get(2)
+            .and_then(|p| std::str::from_utf8(p).ok())
+            .and_then(|s| s.trim().parse::<u8>().ok())
+        else {
+            return;
+        };
+        // `pr` is optional and only meaningful for some states.
+        let pr = params
+            .get(3)
+            .and_then(|p| std::str::from_utf8(p).ok())
+            .and_then(|s| s.trim().parse::<u8>().ok());
+
+        let mut slot = self.progress.lock();
+        let previous = slot.map(|p| p.value).unwrap_or(0);
+        *slot = match st {
+            // `st=0` removes the progress entirely.
+            0 => None,
+            1 => Some(TerminalProgress {
+                state: TerminalProgressState::Normal,
+                value: pr.unwrap_or(0).min(100),
+            }),
+            // Error / paused keep the previous percent when `pr` is omitted.
+            2 => Some(TerminalProgress {
+                state: TerminalProgressState::Error,
+                value: pr.unwrap_or(previous).min(100),
+            }),
+            3 => Some(TerminalProgress {
+                state: TerminalProgressState::Indeterminate,
+                value: 0,
+            }),
+            4 => Some(TerminalProgress {
+                state: TerminalProgressState::Paused,
+                value: pr.unwrap_or(previous).min(100),
+            }),
+            // Unknown state — ignore gracefully, leaving the bar as-is.
+            _ => return,
+        };
+    }
 }
 
 impl Perform for SidecarPerform {
@@ -243,10 +306,14 @@ impl Perform for SidecarPerform {
                 }
             }
             b"9" => {
-                // iTerm2-style notification: `OSC 9 ; <message>`. ConEmu's
-                // `OSC 9 ; 4 ; state ; progress` progress-bar subtype is
-                // treated as a plain-text message for now — we can split
-                // off subtypes when there's a UI for them.
+                // `OSC 9` is overloaded. The `OSC 9 ; 4 ; st ; pr` subtype is
+                // ConEmu's / Windows Terminal's progress-bar protocol; route it
+                // to the progress handler. Everything else is an iTerm2-style
+                // notification: `OSC 9 ; <message>`.
+                if params.get(1).copied() == Some(b"4".as_slice()) {
+                    self.handle_osc9_progress(params);
+                    return;
+                }
                 let message: String = params[1..]
                     .iter()
                     .filter_map(|p| std::str::from_utf8(p).ok())

--- a/crates/okena-terminal/src/terminal/prompt_jump.rs
+++ b/crates/okena-terminal/src/terminal/prompt_jump.rs
@@ -63,11 +63,85 @@ impl Terminal {
         };
 
         let target = prompts[prompts.len() - 1 - new_index];
+        self.scroll_to_prompt_mark(target);
+        true
+    }
+
+    /// Scroll the viewport so the next older prompt whose command finished
+    /// with a non-zero exit code lands at visual row 0. Mirrors
+    /// [`Terminal::jump_to_prompt_above`] but only visits failures.
+    pub fn jump_to_prev_failed_command(&self) -> bool {
+        self.jump_to_failed(JumpDirection::Above)
+    }
+
+    /// Reverse of [`Terminal::jump_to_prev_failed_command`]: walks one
+    /// failure forward toward the live bottom. Returns `false` when the
+    /// walker is already sitting on the newest failure or hasn't started
+    /// walking yet.
+    pub fn jump_to_next_failed_command(&self) -> bool {
+        self.jump_to_failed(JumpDirection::Below)
+    }
+
+    fn jump_to_failed(&self, direction: JumpDirection) -> bool {
+        let marks = self.prompt_tracker.lock().snapshot();
+        // Build the ordered list of prompts that produced a failure: walk
+        // marks chronologically tracking the most recent `PromptStart`, and
+        // whenever a `CommandFinished` reports a non-zero exit code, record
+        // the prompt that started that command. Marks with an unknown exit
+        // code (`None`) or a zero exit are not failures.
+        let mut last_prompt: Option<&PromptMark> = None;
+        let mut prompts: Vec<&PromptMark> = Vec::new();
+        for mark in &marks {
+            match mark.kind {
+                PromptMarkKind::PromptStart => last_prompt = Some(mark),
+                PromptMarkKind::CommandFinished {
+                    exit_code: Some(code),
+                } if code != 0 => {
+                    if let Some(prompt) = last_prompt {
+                        prompts.push(prompt);
+                    }
+                }
+                _ => {}
+            }
+        }
+        if prompts.is_empty() {
+            return false;
+        }
+
+        // `failed_jump_index` is a reverse index into `prompts`: 0 = newest
+        // failure, 1 = one older, etc. `None` means "walker is not engaged;
+        // an Above jump should land on the newest failure". Storing a
+        // reverse index keeps the walk scroll-invariant — scrolling rebases
+        // line values on every mark, but the relative order and count don't
+        // change.
+        let new_index: usize = {
+            let mut state = self.failed_jump_index.lock();
+            let next = match (direction, *state) {
+                (JumpDirection::Above, None) => 0,
+                (JumpDirection::Above, Some(n)) => {
+                    if n + 1 >= prompts.len() {
+                        return false;
+                    }
+                    n + 1
+                }
+                (JumpDirection::Below, Some(n)) if n > 0 => n - 1,
+                (JumpDirection::Below, _) => return false,
+            };
+            *state = Some(next);
+            next
+        };
+
+        let target = prompts[prompts.len() - 1 - new_index];
+        self.scroll_to_prompt_mark(target);
+        true
+    }
+
+    /// Scroll the viewport so `target` lands at visual row 0, bypassing
+    /// `self.scroll` so the jump walker state isn't cleared — `self.scroll`
+    /// is reserved for externally-driven scrolling which resets the walker.
+    fn scroll_to_prompt_mark(&self, target: &PromptMark) {
         let target_offset = (-target.line).max(0);
 
-        // Scroll inline (bypassing self.scroll) so the jump walker state
-        // isn't cleared — self.scroll() is reserved for externally-driven
-        // scrolling which resets the walker.
         let mut term = self.term.lock();
         let current = term.grid().display_offset() as i32;
         let delta = target_offset - current;
@@ -77,6 +151,5 @@ impl Terminal {
             *self.scroll_offset.lock() += delta;
             self.content_generation.fetch_add(1, Ordering::Relaxed);
         }
-        true
     }
 }

--- a/crates/okena-terminal/src/terminal/scroll.rs
+++ b/crates/okena-terminal/src/terminal/scroll.rs
@@ -37,6 +37,7 @@ impl Terminal {
         // implicit reference point has moved, so the next Above jump
         // should start over from the newest prompt.
         *self.prompt_jump_index.lock() = None;
+        *self.failed_jump_index.lock() = None;
     }
 
     /// Scroll up by lines

--- a/crates/okena-terminal/src/terminal/tests/kitty.rs
+++ b/crates/okena-terminal/src/terminal/tests/kitty.rs
@@ -1,0 +1,68 @@
+//! Integration tests for the kitty keyboard protocol: the full chain from an
+//! app pushing a mode (`CSI > flags u`) through alacritty's `TermMode` to
+//! `Terminal::kitty_keyboard_flags()` and on into the key encoder. The
+//! `input::tests` unit tests exercise the encoder with hand-built flags; these
+//! tests guard the wiring those bypass — in particular that
+//! `TermConfig::kitty_keyboard` stays enabled (without it alacritty silently
+//! ignores every keyboard-mode sequence and the flag never flips).
+
+use super::super::Terminal;
+use super::super::types::TerminalSize;
+use super::NullTransport;
+use crate::input::{KeyEvent, KeyModifiers, key_to_bytes};
+use std::sync::Arc;
+
+fn term() -> Terminal {
+    Terminal::new(
+        "test-id".to_string(),
+        TerminalSize::default(),
+        Arc::new(NullTransport),
+        "/tmp".to_string(),
+    )
+}
+
+#[test]
+fn push_and_pop_toggle_disambiguate_flag() {
+    let t = term();
+    assert!(
+        !t.kitty_keyboard_flags().disambiguate_escape_codes,
+        "disambiguate must start off"
+    );
+
+    // `CSI > 1 u` — push the disambiguate-escape-codes flag.
+    t.process_output(b"\x1b[>1u");
+    assert!(
+        t.kitty_keyboard_flags().disambiguate_escape_codes,
+        "push must set the flag (regression guard for TermConfig.kitty_keyboard)"
+    );
+
+    // `CSI < u` — pop one level off the stack, back to no modes.
+    t.process_output(b"\x1b[<u");
+    assert!(
+        !t.kitty_keyboard_flags().disambiguate_escape_codes,
+        "pop must clear the flag"
+    );
+}
+
+#[test]
+fn escape_encodes_as_csi_u_only_after_push() {
+    let t = term();
+    let esc = KeyEvent {
+        key: "escape".to_string(),
+        key_char: None,
+        modifiers: KeyModifiers::default(),
+    };
+
+    // Before the app enables the protocol: legacy bare ESC.
+    assert_eq!(
+        key_to_bytes(&esc, false, t.kitty_keyboard_flags()),
+        Some(b"\x1b".to_vec())
+    );
+
+    // After `CSI > 1 u`: the encoder reads the live flag and emits `CSI 27 u`.
+    t.process_output(b"\x1b[>1u");
+    assert_eq!(
+        key_to_bytes(&esc, false, t.kitty_keyboard_flags()),
+        Some(b"\x1b[27u".to_vec())
+    );
+}

--- a/crates/okena-terminal/src/terminal/tests/kitty.rs
+++ b/crates/okena-terminal/src/terminal/tests/kitty.rs
@@ -8,7 +8,7 @@
 
 use super::super::Terminal;
 use super::super::types::TerminalSize;
-use super::NullTransport;
+use super::{CapturingTransport, NullTransport};
 use crate::input::{KeyEvent, KeyModifiers, key_to_bytes};
 use std::sync::Arc;
 
@@ -65,4 +65,34 @@ fn escape_encodes_as_csi_u_only_after_push() {
         key_to_bytes(&esc, false, t.kitty_keyboard_flags()),
         Some(b"\x1b[27u".to_vec())
     );
+}
+
+#[test]
+fn send_escape_and_backtab_actions_are_kitty_aware() {
+    // Esc / Tab / Shift+Tab arrive via dedicated GPUI actions that bypass the
+    // on_key_down path; `Terminal::send_escape` / `send_backtab` route them back
+    // through the encoder. Guard that they honor the live kitty flag.
+    let transport = Arc::new(CapturingTransport::new());
+    let t = Terminal::new(
+        "test-id".to_string(),
+        TerminalSize::default(),
+        transport.clone(),
+        "/tmp".to_string(),
+    );
+
+    // Legacy before the protocol is enabled.
+    t.send_escape();
+    t.send_backtab();
+    assert_eq!(transport.writes(), vec![b"\x1b".to_vec(), b"\x1b[Z".to_vec()]);
+
+    // After the app pushes disambiguate, the same actions emit CSI u.
+    t.process_output(b"\x1b[>1u");
+    t.send_escape();
+    t.send_backtab();
+    let writes = transport.writes();
+    assert_eq!(&writes[2..], &[b"\x1b[27u".to_vec(), b"\x1b[9;2u".to_vec()]);
+
+    // Plain Tab is never disambiguated at level 1.
+    t.send_tab();
+    assert_eq!(transport.writes().last().unwrap(), b"\t");
 }

--- a/crates/okena-terminal/src/terminal/tests/mod.rs
+++ b/crates/okena-terminal/src/terminal/tests/mod.rs
@@ -1,5 +1,6 @@
 mod focus_report;
 mod helpers;
+mod kitty;
 mod osc;
 mod prompt_jump;
 mod resize_authority;

--- a/crates/okena-terminal/src/terminal/tests/osc.rs
+++ b/crates/okena-terminal/src/terminal/tests/osc.rs
@@ -162,6 +162,79 @@ fn test_osc7_invalid_scheme_ignored() {
 }
 
 #[test]
+fn test_osc1337_current_dir_bel_terminated() {
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new(
+        "t".into(),
+        TerminalSize::default(),
+        transport,
+        "/tmp".into(),
+    );
+
+    assert_eq!(terminal.reported_cwd(), None);
+
+    // iTerm2 shell integration: OSC 1337 ; CurrentDir=<raw path> BEL. The path
+    // is a plain filesystem path — no file:// scheme, no percent-encoding.
+    terminal.process_output(b"\x1b]1337;CurrentDir=/home/matej/projects/okena\x07");
+
+    assert_eq!(
+        terminal.reported_cwd().as_deref(),
+        Some("/home/matej/projects/okena"),
+    );
+    assert_eq!(terminal.current_cwd(), "/home/matej/projects/okena");
+}
+
+#[test]
+fn test_osc1337_current_dir_st_terminated() {
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new(
+        "t".into(),
+        TerminalSize::default(),
+        transport,
+        "/tmp".into(),
+    );
+
+    // ST-terminated form (ESC \) is equally valid.
+    terminal.process_output(b"\x1b]1337;CurrentDir=/var/www\x1b\\");
+
+    assert_eq!(terminal.reported_cwd().as_deref(), Some("/var/www"));
+}
+
+#[test]
+fn test_osc1337_empty_current_dir_ignored() {
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new(
+        "t".into(),
+        TerminalSize::default(),
+        transport,
+        "/tmp".into(),
+    );
+
+    // An empty / whitespace-only path must not overwrite the cwd.
+    terminal.process_output(b"\x1b]1337;CurrentDir=\x07");
+    terminal.process_output(b"\x1b]1337;CurrentDir=   \x07");
+
+    assert_eq!(terminal.reported_cwd(), None);
+}
+
+#[test]
+fn test_osc1337_non_current_dir_subcommand_ignored() {
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new(
+        "t".into(),
+        TerminalSize::default(),
+        transport,
+        "/tmp".into(),
+    );
+
+    // 1337 carries many subcommands; only CurrentDir is ours. RemoteHost (and
+    // the rest) must leave the cwd untouched.
+    terminal.process_output(b"\x1b]1337;RemoteHost=matej@myhost\x07");
+
+    assert_eq!(terminal.reported_cwd(), None);
+}
+
+#[test]
 fn test_parse_osc7_file_uri() {
     assert_eq!(
         parse_osc7_file_uri("file:///home/user").as_deref(),

--- a/crates/okena-terminal/src/terminal/tests/osc.rs
+++ b/crates/okena-terminal/src/terminal/tests/osc.rs
@@ -633,6 +633,111 @@ fn test_bell_edge_is_one_shot() {
 }
 
 #[test]
+fn test_osc52_read_request_queues_responder() {
+    let transport = Arc::new(CapturingTransport::new());
+    let terminal = Terminal::new(
+        "t".into(),
+        TerminalSize::default(),
+        transport.clone(),
+        "/tmp".into(),
+    );
+
+    assert!(!terminal.has_pending_clipboard_reads(), "nothing queued yet");
+
+    // OSC 52 ; c ; ? — the app asks to READ the clipboard.
+    terminal.process_output(b"\x1b]52;c;?\x07");
+
+    assert!(
+        terminal.has_pending_clipboard_reads(),
+        "a read request must be queued",
+    );
+    // Queuing the request must not write anything to the PTY on its own —
+    // the reply is only sent once answered with clipboard contents.
+    assert!(
+        transport.writes().is_empty(),
+        "no PTY reply until answered: {:?}",
+        transport.writes(),
+    );
+}
+
+#[test]
+fn test_osc52_answer_clipboard_reads_replies_and_drains() {
+    let transport = Arc::new(CapturingTransport::new());
+    let terminal = Terminal::new(
+        "t".into(),
+        TerminalSize::default(),
+        transport.clone(),
+        "/tmp".into(),
+    );
+
+    terminal.process_output(b"\x1b]52;c;?\x07");
+    assert!(terminal.has_pending_clipboard_reads());
+
+    terminal.answer_clipboard_reads("hi");
+
+    // The queue is drained once answered.
+    assert!(
+        !terminal.has_pending_clipboard_reads(),
+        "queue must be empty after answering",
+    );
+    // A non-empty OSC 52 response was written back to the PTY.
+    let writes = transport.writes();
+    assert_eq!(writes.len(), 1, "expected exactly one PTY reply");
+    assert!(!writes[0].is_empty(), "reply must not be empty");
+    let body = std::str::from_utf8(&writes[0]).unwrap();
+    assert!(body.contains("52;"), "reply should be an OSC 52 sequence: {body:?}");
+}
+
+#[test]
+fn test_osc52_drop_clipboard_reads_clears_without_reply() {
+    let transport = Arc::new(CapturingTransport::new());
+    let terminal = Terminal::new(
+        "t".into(),
+        TerminalSize::default(),
+        transport.clone(),
+        "/tmp".into(),
+    );
+
+    terminal.process_output(b"\x1b]52;c;?\x07");
+    assert!(terminal.has_pending_clipboard_reads());
+
+    // Silent deny: drop the request without writing anything to the PTY.
+    terminal.drop_clipboard_reads();
+
+    assert!(!terminal.has_pending_clipboard_reads(), "queue must be cleared");
+    assert!(
+        transport.writes().is_empty(),
+        "dropping must not reply: {:?}",
+        transport.writes(),
+    );
+}
+
+#[test]
+fn test_osc52_write_does_not_enqueue_read() {
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new(
+        "t".into(),
+        TerminalSize::default(),
+        transport,
+        "/tmp".into(),
+    );
+
+    // A plain OSC 52 *write* (base64 "hi" == "aGk=") stores clipboard text and
+    // must NOT enqueue a read request.
+    terminal.process_output(b"\x1b]52;c;aGk=\x07");
+
+    assert!(
+        !terminal.has_pending_clipboard_reads(),
+        "a write must not enqueue a read",
+    );
+    assert_eq!(
+        terminal.take_pending_clipboard_writes(),
+        vec!["hi".to_string()],
+        "the write text must reach the clipboard-write queue",
+    );
+}
+
+#[test]
 fn test_xtversion_responds_with_okena_name() {
     set_app_version("0.20.0-test");
 

--- a/crates/okena-terminal/src/terminal/tests/osc.rs
+++ b/crates/okena-terminal/src/terminal/tests/osc.rs
@@ -2,7 +2,9 @@ use super::super::Terminal;
 use super::super::TerminalNotification;
 use super::super::app_version::set_app_version;
 use super::super::osc_sidecar::parse_osc7_file_uri;
-use super::super::types::{PromptMarkKind, TerminalSize};
+use super::super::types::{
+    PromptMarkKind, TerminalProgress, TerminalProgressState, TerminalSize,
+};
 use super::{CapturingTransport, NullTransport};
 use std::sync::Arc;
 
@@ -367,6 +369,128 @@ fn test_osc9_st_terminator() {
     assert_eq!(
         terminal.take_pending_notifications(),
         vec![body("hello")],
+    );
+}
+
+#[test]
+fn test_osc9_4_st1_sets_normal_progress() {
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new("t".into(), TerminalSize::default(), transport, "/tmp".into());
+
+    assert_eq!(terminal.progress(), None);
+
+    // OSC 9 ; 4 ; 1 ; 42 → normal progress at 42%.
+    terminal.process_output(b"\x1b]9;4;1;42\x07");
+
+    assert_eq!(
+        terminal.progress(),
+        Some(TerminalProgress { state: TerminalProgressState::Normal, value: 42 }),
+    );
+    // Progress is sticky (not drained on read).
+    assert_eq!(
+        terminal.progress(),
+        Some(TerminalProgress { state: TerminalProgressState::Normal, value: 42 }),
+    );
+}
+
+#[test]
+fn test_osc9_4_st0_clears_progress() {
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new("t".into(), TerminalSize::default(), transport, "/tmp".into());
+
+    terminal.process_output(b"\x1b]9;4;1;50\x07");
+    assert!(terminal.progress().is_some());
+
+    // st=0 removes the bar; pr is ignored.
+    terminal.process_output(b"\x1b]9;4;0;\x07");
+    assert_eq!(terminal.progress(), None);
+}
+
+#[test]
+fn test_osc9_4_st3_indeterminate_ignores_value() {
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new("t".into(), TerminalSize::default(), transport, "/tmp".into());
+
+    // st=3 is a spinner — pr is meaningless and normalised to 0.
+    terminal.process_output(b"\x1b]9;4;3;77\x07");
+
+    assert_eq!(
+        terminal.progress(),
+        Some(TerminalProgress { state: TerminalProgressState::Indeterminate, value: 0 }),
+    );
+}
+
+#[test]
+fn test_osc9_4_clamps_value_over_100() {
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new("t".into(), TerminalSize::default(), transport, "/tmp".into());
+
+    // pr above 100 is clamped to 100.
+    terminal.process_output(b"\x1b]9;4;1;255\x07");
+
+    assert_eq!(
+        terminal.progress(),
+        Some(TerminalProgress { state: TerminalProgressState::Normal, value: 100 }),
+    );
+}
+
+#[test]
+fn test_osc9_4_st2_error_keeps_previous_value() {
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new("t".into(), TerminalSize::default(), transport, "/tmp".into());
+
+    // Set a baseline, then signal an error without an explicit percent.
+    terminal.process_output(b"\x1b]9;4;1;30\x07");
+    terminal.process_output(b"\x1b]9;4;2;\x07");
+
+    assert_eq!(
+        terminal.progress(),
+        Some(TerminalProgress { state: TerminalProgressState::Error, value: 30 }),
+    );
+
+    // An explicit pr on the error state overrides the kept value.
+    terminal.process_output(b"\x1b]9;4;2;80\x07");
+    assert_eq!(
+        terminal.progress(),
+        Some(TerminalProgress { state: TerminalProgressState::Error, value: 80 }),
+    );
+}
+
+#[test]
+fn test_osc9_4_garbage_st_ignored() {
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new("t".into(), TerminalSize::default(), transport, "/tmp".into());
+
+    terminal.process_output(b"\x1b]9;4;1;25\x07");
+    // A non-numeric / out-of-range st must leave the current bar untouched and
+    // must never produce a notification.
+    terminal.process_output(b"\x1b]9;4;abc;5\x07");
+    terminal.process_output(b"\x1b]9;4;9;5\x07");
+
+    assert_eq!(
+        terminal.progress(),
+        Some(TerminalProgress { state: TerminalProgressState::Normal, value: 25 }),
+    );
+    assert!(terminal.take_pending_notifications().is_empty());
+}
+
+#[test]
+fn test_osc9_4_does_not_produce_notification() {
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new("t".into(), TerminalSize::default(), transport, "/tmp".into());
+
+    // The progress subtype must NOT be treated as notification text...
+    terminal.process_output(b"\x1b]9;4;1;42\x07");
+    assert!(terminal.take_pending_notifications().is_empty());
+    assert!(terminal.progress().is_some());
+
+    // ...while a plain OSC 9 message still produces a notification and leaves
+    // progress untouched (no regression).
+    terminal.process_output(b"\x1b]9;Build complete\x07");
+    assert_eq!(terminal.take_pending_notifications(), vec![body("Build complete")]);
+    assert_eq!(
+        terminal.progress(),
+        Some(TerminalProgress { state: TerminalProgressState::Normal, value: 42 }),
     );
 }
 

--- a/crates/okena-terminal/src/terminal/tests/osc.rs
+++ b/crates/okena-terminal/src/terminal/tests/osc.rs
@@ -738,6 +738,48 @@ fn test_osc52_write_does_not_enqueue_read() {
 }
 
 #[test]
+fn test_xtwinops_14t_reports_text_area_size_in_pixels() {
+    // Explicit size so the pixel math is unambiguous: 80 cols x 24 rows at
+    // 8x16 px cells → text area is 640 px wide and 384 px tall.
+    let size = TerminalSize {
+        cols: 80,
+        rows: 24,
+        cell_width: 8.0,
+        cell_height: 16.0,
+    };
+    let transport = Arc::new(CapturingTransport::new());
+    let terminal = Terminal::new("t".into(), size, transport.clone(), "/tmp".into());
+
+    // CSI 14 t — report text-area size in pixels.
+    terminal.process_output(b"\x1b[14t");
+
+    let writes = transport.writes();
+    assert_eq!(writes.len(), 1, "expected exactly one PTY reply");
+    // Reply is `CSI 4 ; <height> ; <width> t` = rows*cell_height ; cols*cell_width.
+    assert_eq!(writes[0], b"\x1b[4;384;640t");
+}
+
+#[test]
+fn test_xtwinops_18t_still_reports_size_in_cells() {
+    // No regression: CSI 18 t (size in cells) keeps replying via PtyWrite.
+    let size = TerminalSize {
+        cols: 80,
+        rows: 24,
+        cell_width: 8.0,
+        cell_height: 16.0,
+    };
+    let transport = Arc::new(CapturingTransport::new());
+    let terminal = Terminal::new("t".into(), size, transport.clone(), "/tmp".into());
+
+    terminal.process_output(b"\x1b[18t");
+
+    let writes = transport.writes();
+    assert_eq!(writes.len(), 1, "expected exactly one PTY reply");
+    // Reply is `CSI 8 ; <rows> ; <cols> t`.
+    assert_eq!(writes[0], b"\x1b[8;24;80t");
+}
+
+#[test]
 fn test_xtversion_responds_with_okena_name() {
     set_app_version("0.20.0-test");
 

--- a/crates/okena-terminal/src/terminal/tests/prompt_jump.rs
+++ b/crates/okena-terminal/src/terminal/tests/prompt_jump.rs
@@ -163,3 +163,85 @@ fn test_jump_to_prompt_ignores_non_prompt_kinds() {
 
     assert!(!terminal.jump_to_prompt_above());
 }
+
+#[test]
+fn test_jump_to_failed_returns_false_without_failures() {
+    let size = TerminalSize {
+        cols: 20,
+        rows: 5,
+        cell_width: 8.0,
+        cell_height: 16.0,
+    };
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new("t".into(), size, transport, "/tmp".into());
+
+    // Two prompts that both succeed (exit code 0) — no failures to visit.
+    terminal.process_output(b"\x1b]133;A\x1b\\$ a\r\nout\r\n\x1b]133;D;0\x1b\\");
+    terminal.process_output(b"\x1b]133;A\x1b\\$ b\r\nout\r\n\x1b]133;D;0\x1b\\");
+
+    assert!(!terminal.jump_to_prev_failed_command());
+    assert!(!terminal.jump_to_next_failed_command());
+}
+
+#[test]
+fn test_jump_to_failed_jumps_to_failure() {
+    let size = TerminalSize {
+        cols: 20,
+        rows: 5,
+        cell_width: 8.0,
+        cell_height: 16.0,
+    };
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new("t".into(), size, transport, "/tmp".into());
+
+    // A single prompt whose command fails (exit code 1), then a fresh
+    // prompt with enough output to scroll the failure into history.
+    terminal.process_output(
+        b"\x1b]133;A\x1b\\$ boom\r\nerr\r\nmore\r\n\x1b]133;D;1\x1b\\",
+    );
+    terminal.process_output(b"\x1b]133;A\x1b\\$ ok\r\n");
+
+    // First Above press engages the walker and lands on the failure.
+    assert!(terminal.jump_to_prev_failed_command());
+    // Nothing older to visit.
+    assert!(!terminal.jump_to_prev_failed_command());
+}
+
+#[test]
+fn test_jump_to_failed_visits_only_failures() {
+    let size = TerminalSize {
+        cols: 20,
+        rows: 5,
+        cell_width: 8.0,
+        cell_height: 16.0,
+    };
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new("t".into(), size, transport, "/tmp".into());
+
+    // Three commands: fail, succeed, fail. Only the two failures are
+    // walkable — a third Above press must fail.
+    terminal.process_output(b"\x1b]133;A\x1b\\$ a\r\nout\r\n\x1b]133;D;2\x1b\\");
+    terminal.process_output(b"\x1b]133;A\x1b\\$ b\r\nout\r\n\x1b]133;D;0\x1b\\");
+    terminal.process_output(b"\x1b]133;A\x1b\\$ c\r\nout\r\n\x1b]133;D;1\x1b\\");
+
+    assert!(terminal.jump_to_prev_failed_command()); // newest failure (c)
+    assert!(terminal.jump_to_prev_failed_command()); // older failure (a)
+    assert!(!terminal.jump_to_prev_failed_command()); // success (b) skipped, no more
+}
+
+#[test]
+fn test_jump_to_failed_ignores_zero_exit() {
+    let size = TerminalSize {
+        cols: 20,
+        rows: 5,
+        cell_width: 8.0,
+        cell_height: 16.0,
+    };
+    let transport = Arc::new(NullTransport);
+    let terminal = Terminal::new("t".into(), size, transport, "/tmp".into());
+
+    // Exit code 0 is success, not a failure — jumping must be a no-op.
+    terminal.process_output(b"\x1b]133;A\x1b\\$ a\r\nout\r\n\x1b]133;D;0\x1b\\");
+
+    assert!(!terminal.jump_to_prev_failed_command());
+}

--- a/crates/okena-terminal/src/terminal/types.rs
+++ b/crates/okena-terminal/src/terminal/types.rs
@@ -1,3 +1,14 @@
+/// Formatter for an OSC 52 clipboard *read* request.
+///
+/// `alacritty_terminal` hands us this closure with the
+/// `Event::ClipboardLoad` event: given the current clipboard text, it
+/// returns the full escape sequence (`OSC 52 ; c ; <base64> ST`) to write
+/// back to the PTY so the requesting app receives the contents. We can't
+/// run it inline (the listener has no access to the system clipboard on the
+/// GPUI thread), so the closure is queued and invoked later once the
+/// clipboard has been read with a `cx`.
+pub type ClipboardReadResponder = std::sync::Arc<dyn Fn(&str) -> String + Send + Sync>;
+
 /// Terminal size in cells and pixels
 #[derive(Clone, Copy, Debug)]
 pub struct TerminalSize {

--- a/crates/okena-terminal/src/terminal/types.rs
+++ b/crates/okena-terminal/src/terminal/types.rs
@@ -63,6 +63,39 @@ pub struct PromptMark {
     pub column: usize,
 }
 
+/// Progress state reported via the ConEmu / Windows Terminal protocol
+/// `OSC 9 ; 4 ; st ; pr` (also spoken by WezTerm, Ghostty, Kitty, …).
+///
+/// Programs like npm, cargo, and downloaders emit this to drive a taskbar /
+/// tab progress indicator. The `st` field selects the variant; `pr` carries
+/// the 0..=100 percentage where applicable (see [`TerminalProgress`]). The
+/// `st=0` "remove" state has no variant here — it clears the progress to
+/// `None` rather than being represented as a state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TerminalProgressState {
+    /// `st=1` — a normal, determinate progress bar at `value` percent.
+    Normal,
+    /// `st=2` — an error occurred; `value` keeps the last/explicit percent.
+    Error,
+    /// `st=3` — indeterminate work (a spinner); `value` is meaningless.
+    Indeterminate,
+    /// `st=4` — paused or warning; `value` keeps the last/explicit percent.
+    Paused,
+}
+
+/// Active progress reported by the running program via `OSC 9 ; 4`.
+///
+/// The owning [`Terminal`](super::Terminal) holds `Option<TerminalProgress>`:
+/// `None` means no progress is being reported (the program never started one
+/// or sent `st=0` to clear it).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TerminalProgress {
+    pub state: TerminalProgressState,
+    /// Percentage in `0..=100`. Ignored for
+    /// [`TerminalProgressState::Indeterminate`].
+    pub value: u8,
+}
+
 /// Cursor shape requested by the terminal application via DECSCUSR.
 ///
 /// Maps onto the three shapes Okena's renderer knows how to paint.

--- a/crates/okena-views-terminal/src/actions.rs
+++ b/crates/okena-views-terminal/src/actions.rs
@@ -35,5 +35,7 @@ gpui::actions!(
         FullscreenPrevTerminal,
         JumpToPreviousPrompt,
         JumpToNextPrompt,
+        JumpToPreviousFailedCommand,
+        JumpToNextFailedCommand,
     ]
 );

--- a/crates/okena-views-terminal/src/layout/tabs/mod.rs
+++ b/crates/okena-views-terminal/src/layout/tabs/mod.rs
@@ -12,6 +12,7 @@ use okena_ui::header_buttons::{header_button_base, ButtonSize, HeaderAction};
 use crate::layout::layout_container::{LayoutContainer, is_renaming, rename_input};
 use crate::layout::pane_drag::{PaneDrag, PaneDragView};
 use crate::simple_input::SimpleInput;
+use okena_terminal::terminal::TerminalProgressState;
 use okena_workspace::state::{LayoutNode, SplitDirection};
 use gpui::*;
 use gpui_component::{h_flex, v_flex};
@@ -380,13 +381,14 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                 _ => None,
             };
 
-            let (is_waiting, idle_label) = terminal_id.as_ref().map_or((false, None), |tid| {
+            let (is_waiting, idle_label, progress) = terminal_id.as_ref().map_or((false, None, None), |tid| {
                 let guard = terminals.lock();
-                guard.get(tid).map_or((false, None), |t| {
+                guard.get(tid).map_or((false, None, None), |t| {
+                    let progress = t.progress();
                     if t.is_waiting_for_input() {
-                        (true, Some(t.idle_duration_display()))
+                        (true, Some(t.idle_duration_display()), progress)
                     } else {
-                        (false, None)
+                        (false, None, progress)
                     }
                 })
             });
@@ -496,6 +498,36 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                             .into_any_element()
                     }
                 })
+                .children(progress.map(|p| {
+                    // Color the bar by reported progress state.
+                    let fill_color = match p.state {
+                        TerminalProgressState::Normal => t.border_active,
+                        TerminalProgressState::Error => t.error,
+                        TerminalProgressState::Paused => t.warning,
+                        TerminalProgressState::Indeterminate => t.border_active,
+                    };
+                    // Determinate states fill `value`%; an indeterminate "busy"
+                    // bar is rendered full width at a reduced alpha (no animation).
+                    let (fill_fraction, fill_alpha) = match p.state {
+                        TerminalProgressState::Indeterminate => (1.0_f32, 0.5_f32),
+                        _ => (p.value.min(100) as f32 / 100.0, 1.0_f32),
+                    };
+                    // Absolutely-positioned track pinned to the bottom edge,
+                    // overlaying the tab's bottom border.
+                    div()
+                        .absolute()
+                        .bottom_0()
+                        .left_0()
+                        .right_0()
+                        .h(px(2.0))
+                        .bg(with_alpha(t.border_active, 0.15))
+                        .child(
+                            div()
+                                .h_full()
+                                .w(relative(fill_fraction))
+                                .bg(with_alpha(fill_color, fill_alpha)),
+                        )
+                }))
                 .on_mouse_down(MouseButton::Right, {
                     let project_id = project_id.clone();
                     let layout_path = layout_path.clone();

--- a/crates/okena-views-terminal/src/layout/tabs/mod.rs
+++ b/crates/okena-views-terminal/src/layout/tabs/mod.rs
@@ -495,6 +495,24 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                             .children(idle_label.as_ref().map(|d| {
                                 div().text_size(ui_text_sm(cx)).text_color(rgb(t.border_idle)).child(d.clone())
                             }))
+                            // Determinate OSC 9;4 progress also shows a percentage in
+                            // the label, so it reads even when the bar is a thin sliver.
+                            // Indeterminate progress has no meaningful value, so it's
+                            // bar-only.
+                            .children(
+                                progress
+                                    .and_then(|p| match p.state {
+                                        TerminalProgressState::Indeterminate => None,
+                                        _ => Some(p.value.min(100)),
+                                    })
+                                    .map(|pct| {
+                                        div()
+                                            .flex_shrink_0()
+                                            .text_size(ui_text_sm(cx))
+                                            .text_color(rgb(t.text_muted))
+                                            .child(format!("{pct}%"))
+                                    }),
+                            )
                             .into_any_element()
                     }
                 })
@@ -519,7 +537,7 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                         .bottom_0()
                         .left_0()
                         .right_0()
-                        .h(px(2.0))
+                        .h(px(3.0))
                         .bg(with_alpha(t.border_active, 0.15))
                         .child(
                             div()

--- a/crates/okena-views-terminal/src/layout/terminal_pane/actions.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/actions.rs
@@ -162,6 +162,20 @@ impl<D: ActionDispatch + Send + Sync> TerminalPane<D> {
             }
     }
 
+    pub(super) fn handle_jump_prev_failed(&mut self, cx: &mut Context<Self>) {
+        if let Some(ref terminal) = self.terminal
+            && terminal.jump_to_prev_failed_command() {
+                cx.notify();
+            }
+    }
+
+    pub(super) fn handle_jump_next_failed(&mut self, cx: &mut Context<Self>) {
+        if let Some(ref terminal) = self.terminal
+            && terminal.jump_to_next_failed_command() {
+                cx.notify();
+            }
+    }
+
     pub(super) fn handle_file_drop(&mut self, paths: &ExternalPaths, _cx: &mut Context<Self>) {
         let Some(ref terminal) = self.terminal else {
             return;

--- a/crates/okena-views-terminal/src/layout/terminal_pane/navigation.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/navigation.rs
@@ -210,6 +210,7 @@ impl<D: ActionDispatch + Send + Sync> TerminalPane<D> {
                     }
 
             let app_cursor_mode = terminal.is_app_cursor_mode();
+            let kitty = terminal.kitty_keyboard_flags();
             let key_event = KeyEvent {
                 key: event.keystroke.key.clone(),
                 key_char: event.keystroke.key_char.clone(),
@@ -220,7 +221,7 @@ impl<D: ActionDispatch + Send + Sync> TerminalPane<D> {
                     platform: event.keystroke.modifiers.platform,
                 },
             };
-            if let Some(input) = key_to_bytes(&key_event, app_cursor_mode) {
+            if let Some(input) = key_to_bytes(&key_event, app_cursor_mode, kitty) {
                 terminal.send_bytes(&input);
             }
         }

--- a/crates/okena-views-terminal/src/layout/terminal_pane/render.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/render.rs
@@ -152,9 +152,9 @@ impl<D: ActionDispatch + Send + Sync> Render for TerminalPane<D> {
             .on_action(cx.listener(|this, _: &FocusDown, window, cx| { this.handle_navigation(NavigationDirection::Down, window, cx); }))
             .on_action(cx.listener(|this, _: &FocusNextTerminal, window, cx| { this.handle_sequential_navigation(true, window, cx); }))
             .on_action(cx.listener(|this, _: &FocusPrevTerminal, window, cx| { this.handle_sequential_navigation(false, window, cx); }))
-            .on_action(cx.listener(|this, _: &SendTab, _window, _cx| { if let Some(ref terminal) = this.terminal { terminal.send_bytes(b"\t"); } }))
-            .on_action(cx.listener(|this, _: &SendBacktab, _window, _cx| { if let Some(ref terminal) = this.terminal { terminal.send_bytes(b"\x1b[Z"); } }))
-            .on_action(cx.listener(|this, _: &SendEscape, _window, _cx| { if let Some(ref terminal) = this.terminal { terminal.send_bytes(b"\x1b"); } }))
+            .on_action(cx.listener(|this, _: &SendTab, _window, _cx| { if let Some(ref terminal) = this.terminal { terminal.send_tab(); } }))
+            .on_action(cx.listener(|this, _: &SendBacktab, _window, _cx| { if let Some(ref terminal) = this.terminal { terminal.send_backtab(); } }))
+            .on_action(cx.listener(|this, _: &SendEscape, _window, _cx| { if let Some(ref terminal) = this.terminal { terminal.send_escape(); } }))
             .on_action(cx.listener(|this, _: &ZoomIn, _window, cx| {
                 let current = this.workspace.read(cx).get_terminal_zoom(&this.project_id, &this.layout_path);
                 let new_zoom = (current + 0.1).clamp(0.5, 3.0);

--- a/crates/okena-views-terminal/src/layout/terminal_pane/render.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/render.rs
@@ -5,7 +5,8 @@ use okena_core::api::ActionRequest;
 use crate::actions::{
     AddTab, CloseSearch, CloseTerminal, Copy, FocusDown, FocusLeft, FocusNextTerminal,
     FocusPrevTerminal, FocusRight, FocusUp, FullscreenNextTerminal, FullscreenPrevTerminal,
-    JumpToNextPrompt, JumpToPreviousPrompt, MinimizeTerminal, Paste, ResetZoom, Search,
+    JumpToNextFailedCommand, JumpToNextPrompt, JumpToPreviousFailedCommand, JumpToPreviousPrompt,
+    MinimizeTerminal, Paste, ResetZoom, Search,
     SearchNext, SearchPrev, SendBacktab, SendEscape, SendTab, SplitHorizontal, SplitVertical,
     ToggleFullscreen, ZoomIn, ZoomOut,
 };
@@ -143,6 +144,8 @@ impl<D: ActionDispatch + Send + Sync> Render for TerminalPane<D> {
             .on_action(cx.listener(|this, _: &SearchPrev, _window, cx| { this.prev_match(cx); }))
             .on_action(cx.listener(|this, _: &JumpToPreviousPrompt, _window, cx| { this.handle_jump_prev_prompt(cx); }))
             .on_action(cx.listener(|this, _: &JumpToNextPrompt, _window, cx| { this.handle_jump_next_prompt(cx); }))
+            .on_action(cx.listener(|this, _: &JumpToPreviousFailedCommand, _window, cx| { this.handle_jump_prev_failed(cx); }))
+            .on_action(cx.listener(|this, _: &JumpToNextFailedCommand, _window, cx| { this.handle_jump_next_failed(cx); }))
             .on_action(cx.listener(|this, _: &FocusLeft, window, cx| { this.handle_navigation(NavigationDirection::Left, window, cx); }))
             .on_action(cx.listener(|this, _: &FocusRight, window, cx| { this.handle_navigation(NavigationDirection::Right, window, cx); }))
             .on_action(cx.listener(|this, _: &FocusUp, window, cx| { this.handle_navigation(NavigationDirection::Up, window, cx); }))

--- a/crates/okena-views-terminal/src/overlays/terminal_overlay_utils.rs
+++ b/crates/okena-views-terminal/src/overlays/terminal_overlay_utils.rs
@@ -6,7 +6,7 @@
 //! - Key input handling
 //! - Focus management
 
-use okena_terminal::input::{KeyEvent, KeyModifiers, key_to_bytes};
+use okena_terminal::input::{KeyEvent, KeyModifiers, KittyKeyboardFlags, key_to_bytes};
 use okena_terminal::terminal::{Terminal, TerminalSize, TerminalTransport};
 use okena_terminal::TerminalsRegistry;
 use crate::layout::terminal_pane::TerminalContent;
@@ -15,7 +15,11 @@ use gpui::*;
 use std::sync::Arc;
 
 /// Convert a GPUI key event to terminal input bytes.
-fn gpui_key_to_bytes(event: &KeyDownEvent, app_cursor_mode: bool) -> Option<Vec<u8>> {
+fn gpui_key_to_bytes(
+    event: &KeyDownEvent,
+    app_cursor_mode: bool,
+    kitty: KittyKeyboardFlags,
+) -> Option<Vec<u8>> {
     let key_event = KeyEvent {
         key: event.keystroke.key.clone(),
         key_char: event.keystroke.key_char.clone(),
@@ -26,7 +30,7 @@ fn gpui_key_to_bytes(event: &KeyDownEvent, app_cursor_mode: bool) -> Option<Vec<
             platform: event.keystroke.modifiers.platform,
         },
     };
-    key_to_bytes(&key_event, app_cursor_mode)
+    key_to_bytes(&key_event, app_cursor_mode, kitty)
 }
 
 /// Default terminal size for overlay terminals.
@@ -95,7 +99,8 @@ pub fn create_terminal_content<V: 'static>(
 /// Returns true if input was sent.
 pub fn handle_terminal_key_input(terminal: &Terminal, event: &KeyDownEvent) -> bool {
     let app_cursor_mode = terminal.is_app_cursor_mode();
-    if let Some(input) = gpui_key_to_bytes(event, app_cursor_mode) {
+    let kitty = terminal.kitty_keyboard_flags();
+    if let Some(input) = gpui_key_to_bytes(event, app_cursor_mode, kitty) {
         terminal.send_bytes(&input);
         true
     } else {

--- a/crates/okena-workspace/src/settings.rs
+++ b/crates/okena-workspace/src/settings.rs
@@ -388,6 +388,12 @@ pub struct AppSettings {
     /// (OSC 9/777 alerts and the bell). Opt-in — see [`NotificationSettings`].
     #[serde(default)]
     pub notifications: NotificationSettings,
+
+    /// Allow terminal apps to READ the system clipboard via OSC 52 (`OSC 52 ; c ; ?`).
+    /// Off by default: clipboard read lets a program exfiltrate whatever you have
+    /// copied. OSC 52 *write* is always allowed; only read is gated.
+    #[serde(default)]
+    pub allow_clipboard_read: bool,
 }
 
 impl Default for AppSettings {
@@ -439,6 +445,7 @@ impl Default for AppSettings {
             file_finder: FileFinderSettings::default(),
             header_density: HeaderDensity::default(),
             notifications: NotificationSettings::default(),
+            allow_clipboard_read: false,
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a batch of terminal escape-sequence / protocol support, grouped into two themes:

**OSC & XTWINOPS shell integration**
- **OSC 1337 `CurrentDir`** — feed iTerm2-style cwd reports into the same `reported_cwd` storage as OSC 7, so the sidebar, "new tab here", and cwd tracking work regardless of which sequence the shell speaks. Other OSC 1337 subcommands are deliberately ignored.
- **OSC 9;4 progress** — parse the ConEmu/Windows-Terminal progress protocol (also used by WezTerm, Ghostty, Kitty; emitted by npm/cargo) into per-terminal `TerminalProgress` state, surfaced as a thin 2px bar on each tab and as a progress percent in the tab label. Colored by state (normal / error / paused).
- **OSC 133 jump-to-failed** — `JumpToPrevious/NextFailedCommand` actions that walk only prompts whose command exited non-zero, bound to `cmd-shift-up` / `cmd-shift-down`. Shares the viewport scroll helper with the existing prompt-jump navigation.
- **OSC 52 clipboard read (opt-in)** — handle `OSC 52 ; c ; ?` read requests, gated behind a new `allow_clipboard_read` setting that **defaults to OFF** (clipboard read lets a program exfiltrate copied data). OSC 52 *write* is unaffected. Adds a settings-panel toggle.
- **CSI 14t** — answer the XTWINOPS "report text-area size in pixels" query with the current geometry (CSI 18t / size in cells already worked).

**Kitty keyboard protocol (level 1)**
- Enable `kitty_keyboard` in `TermConfig` so alacritty actually processes the CSI u mode push/pop/set/report sequences.
- Honor the "disambiguate escape codes" flag: ambiguous keys (Esc, Ctrl/Alt+key, modified Enter/Tab/Backspace incl. Shift+Tab) now emit CSI u; plain text / arrows / Home/End fall through to the legacy path, so there's **zero change when the flag is off**.
- Route the Esc/Tab/Shift+Tab terminal actions through the kitty encoder too.
- Higher protocol levels (report-all-keys-as-esc, associated text, event types) are tracked as a follow-up.

## Test plan
- New integration tests: `terminal/tests/kitty.rs`, plus additions to `terminal/tests/osc.rs` and `terminal/tests/prompt_jump.rs`.
- `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
