### PR TITLE
fix(window): restore macOS titlebar drag by bumping gpui past #58947 revert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -269,7 +269,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -552,8 +552,7 @@ dependencies = [
 [[package]]
 name = "async-process"
 version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+source = "git+https://github.com/zed-industries/async-process.git?rev=0b6d6713570af61806e1e5cb40e0f757cb93fd9d#0b6d6713570af61806e1e5cb40e0f757cb93fd9d"
 dependencies = [
  "async-channel 2.5.0",
  "async-io",
@@ -640,8 +639,7 @@ dependencies = [
 [[package]]
 name = "async-task"
 version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+source = "git+https://github.com/smol-rs/async-task.git?rev=b4486cd71e4e94fbda54ce6302444de14f4d190e#b4486cd71e4e94fbda54ce6302444de14f4d190e"
 
 [[package]]
 name = "async-trait"
@@ -874,7 +872,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -894,7 +892,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1389,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1847,7 +1845,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1920,7 +1918,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2162,7 +2160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3707,7 +3705,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.62.2",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -3733,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -3890,7 +3888,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -3941,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -3971,7 +3969,9 @@ dependencies = [
  "media",
  "metal",
  "objc",
+ "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "parking_lot",
  "pathfinder_geometry",
  "raw-window-handle",
@@ -3986,7 +3986,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3997,7 +3997,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -4010,7 +4010,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "schemars",
  "serde",
@@ -4020,7 +4020,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "anyhow",
  "log",
@@ -4029,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -4053,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4082,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -4355,7 +4355,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4465,7 +4465,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4829,7 +4829,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5313,7 +5313,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "anyhow",
  "bindgen 0.71.1",
@@ -5429,7 +5429,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5624,7 +5624,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6936,7 +6936,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "collections",
  "serde",
@@ -7790,7 +7790,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "derive_refineable",
 ]
@@ -8059,7 +8059,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8193,7 +8193,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "async-task",
  "backtrace",
@@ -8576,7 +8576,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 5.0.1",
 ]
 
 [[package]]
@@ -8727,7 +8727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8885,7 +8885,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "heapless 0.9.2",
  "log",
@@ -9162,7 +9162,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9821,7 +9821,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10124,7 +10124,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "anyhow",
  "async-fs",
@@ -10163,7 +10163,7 @@ dependencies = [
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "perf",
  "quote",
@@ -10784,7 +10784,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -12068,7 +12068,7 @@ checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -12085,7 +12085,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -12096,7 +12096,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#8432a26a9d1707163a0f0438693ad13003fc33d0"
+source = "git+https://github.com/zed-industries/zed#fca2ccd403e8d13c8f4b968cda2f2c322f420f5a"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,3 +126,13 @@ core-text = ">=21.0, <21.1"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winresource = "0.1"
+
+# Mirror zed's async-process patch: zed's `util` crate (pulled in transitively
+# by gpui) calls `smol::process::Child::adopt_raw_pid`, which only exists in
+# zed's async-process fork. `[patch]` entries from the gpui git dep don't
+# propagate, so we must declare them here. Revs match zed at our pinned gpui
+# commit (fca2ccd4). Required to build gpui >= the macOS titlebar-drag revert
+# (#59214); do not pin gpui back before it or window dragging breaks on macOS.
+[patch.crates-io]
+async-process = { git = "https://github.com/zed-industries/async-process.git", rev = "0b6d6713570af61806e1e5cb40e0f757cb93fd9d" }
+async-task = { git = "https://github.com/smol-rs/async-task.git", rev = "b4486cd71e4e94fbda54ce6302444de14f4d190e" }


### PR DESCRIPTION
## Problem

On macOS the main window cannot be moved by dragging the title bar (clicking + dragging the titlebar does nothing). Minimize/maximize and the Window menu still work.

## Root cause

Not our title-bar code — it's the pinned **gpui** revision.

okena was locked to gpui `8432a26` (2026-06-11), which sits inside the 3-day window where Zed's [#58947](https://github.com/zed-industries/zed/pull/58947) ("Fix title bar clicks being delayed on macOS") was live before being reverted in [#59214](https://github.com/zed-industries/zed/pull/59214) (2026-06-12).

That patch implements the undocumented `_opaqueRectForWindowMoveWhenInTitlebar` SPI on gpui's macOS Metal view. For full-size-content windows — which we are, via `appears_transparent: true` → `NSFullSizeContentViewWindowMask` — it returns the **entire view bounds** as opaque app content. AppKit then treats no part of the window as a draggable titlebar, so `window.start_window_move()` becomes a no-op. Zed hit the exact same bug ("broke dragging the settings UI window") and reverted it the next business day.

## Fix

- Bump gpui `8432a26` → `fca2ccd4` (one day forward, past the revert). Moving the lock forward is always safe for this bug since the bad patch only ever existed in that 3-day window.
- The newer `util` crate (transitive via gpui) now calls `smol::process::Child::adopt_raw_pid`, which only exists in Zed's `async-process` fork. `[patch]` entries from a git dependency don't propagate, so mirror Zed's `async-process` / `async-task` patches in the workspace manifest (revs matched to the pinned gpui commit).

No Rust source changed — only `Cargo.toml` (+`[patch.crates-io]`) and `Cargo.lock`.

## Verification

- `cargo check --workspace` — all okena crates incl. `okena-app` compile against the new gpui.
- Debug-built and ran on macOS (Darwin 25.5 / Tahoe): **titlebar drag-to-move works**, double-click-to-zoom still works.

## Note for builders

Building gpui needs the Metal compiler. On a machine where `xcode-select -p` points at CommandLineTools, the shader build fails; select full Xcode (`sudo xcode-select -s /Applications/Xcode.app`) and, on Xcode 26, install the Metal Toolchain component (`xcodebuild -downloadComponent MetalToolchain`).
