### PR TITLE
fix(worktree): allow force-closing orphaned worktrees

### DIFF
--- a/crates/okena-git/src/lib.rs
+++ b/crates/okena-git/src/lib.rs
@@ -19,6 +19,7 @@ pub use repository::{
     get_available_branches_for_worktree,
     get_repo_root,
     resolve_git_root_and_subdir,
+    resolve_worktree_root_fs,
     compute_target_paths,
     project_path_in_worktree,
     has_uncommitted_changes,

--- a/crates/okena-git/src/repository/mod.rs
+++ b/crates/okena-git/src/repository/mod.rs
@@ -32,7 +32,7 @@ pub use branch::{
 pub use ci::{get_ci_checks, get_pr_info, has_github_remote};
 pub use paths::{
     compute_target_paths, get_repo_root, normalize_path, project_path_in_worktree,
-    resolve_git_root_and_subdir,
+    resolve_git_root_and_subdir, resolve_worktree_root_fs,
 };
 pub use status::{
     count_ahead_behind, count_ahead_behind_vs, count_unpushed_commits, get_current_branch,

--- a/crates/okena-git/src/repository/paths.rs
+++ b/crates/okena-git/src/repository/paths.rs
@@ -12,6 +12,26 @@ pub fn get_repo_root(path: &Path) -> Option<PathBuf> {
     repo.workdir().map(|p| p.to_path_buf())
 }
 
+/// Resolve the worktree (or repo) root by walking up to the nearest `.git`
+/// entry, without opening the repo.
+///
+/// Unlike [`get_repo_root`], this does not go through gix, so it still works
+/// when the `.git` pointer file dangles — e.g. an orphaned worktree whose
+/// metadata entry was pruned from the main repo. For an orphan the `.git`
+/// pointer *file* still exists at the worktree root, so this returns that root.
+/// For a monorepo subdir project it walks up to the checkout root.
+///
+/// Returns None if no `.git` entry is found before reaching the filesystem root.
+pub fn resolve_worktree_root_fs(path: &Path) -> Option<PathBuf> {
+    let mut current = path;
+    loop {
+        if current.join(".git").exists() {
+            return Some(current.to_path_buf());
+        }
+        current = current.parent()?;
+    }
+}
+
 /// Normalize a path by resolving `.` and `..` components without filesystem access.
 pub fn normalize_path(path: &Path) -> PathBuf {
     let mut result = PathBuf::new();

--- a/crates/okena-git/src/repository/worktree.rs
+++ b/crates/okena-git/src/repository/worktree.rs
@@ -248,4 +248,34 @@ mod tests {
         branches.sort();
         assert_eq!(branches, vec!["feat", "main"]);
     }
+
+    /// Reproduce an orphaned worktree: the checkout directory still exists but
+    /// the main repo's metadata entry was pruned (so the `.git` pointer
+    /// dangles). `git worktree remove` fails, but the filesystem-based
+    /// resolver finds the root and `remove_worktree_fast` cleans it up.
+    #[test]
+    fn force_removes_orphaned_worktree() {
+        let (_tmp, repo) = init_temp_repo();
+        let wt_tmp = tempfile::tempdir().expect("create worktree tempdir");
+        let wt_path = wt_tmp.path().join("orphan-wt");
+        git_in(&repo, &["worktree", "add", wt_path.to_str().unwrap(), "-b", "orphan"]);
+        assert!(wt_path.exists());
+
+        // Simulate the prune that orphaned the worktree: drop the main repo's
+        // metadata entry, leaving the checkout (with its dangling `.git`) behind.
+        let meta = repo.join(".git").join("worktrees").join("orphan-wt");
+        std::fs::remove_dir_all(&meta).expect("remove worktree metadata entry");
+
+        // Normal removal fails (this is the status-128 the user hit).
+        assert!(remove_worktree(&wt_path, false).is_err());
+
+        // The fs resolver still finds the root even though gix can't open it.
+        let resolved = crate::resolve_worktree_root_fs(&wt_path)
+            .expect("resolve orphaned worktree root");
+        assert_eq!(normalize_path(&resolved), normalize_path(&wt_path));
+
+        // Force cleanup deletes the directory and prunes; returns Ok.
+        remove_worktree_fast(&wt_path, &repo).expect("force remove orphan");
+        assert!(!wt_path.exists());
+    }
 }

--- a/crates/okena-views-git/src/close_worktree_dialog.rs
+++ b/crates/okena-views-git/src/close_worktree_dialog.rs
@@ -64,6 +64,10 @@ pub struct CloseWorktreeDialog {
     pub(super) error_message: Option<String>,
     pub(super) processing: ProcessingState,
     pub(super) hooks_config: HooksConfig,
+    /// Set when the final worktree removal failed (e.g. the worktree is
+    /// orphaned and git refuses to remove it). Unlocks the destructive
+    /// force-delete button in the footer.
+    pub(super) show_force_remove: bool,
 }
 
 impl CloseWorktreeDialog {
@@ -110,6 +114,7 @@ impl CloseWorktreeDialog {
             error_message: None,
             processing: ProcessingState::Idle,
             hooks_config,
+            show_force_remove: false,
         }
     }
 

--- a/crates/okena-views-git/src/close_worktree_dialog/execute.rs
+++ b/crates/okena-views-git/src/close_worktree_dialog/execute.rs
@@ -19,6 +19,7 @@ impl CloseWorktreeDialog {
         }
 
         self.error_message = None;
+        self.show_force_remove = false;
 
         let project_id = self.project_id.clone();
         let project_name = self.project_name.clone();
@@ -548,6 +549,10 @@ impl CloseWorktreeDialog {
                         Err(e) => {
                             let _ = this.update(cx, |this, cx| {
                                 this.error_message = Some(format!("Failed to remove worktree: {}", e));
+                                // Removal failed (e.g. the worktree is orphaned —
+                                // its directory exists but git no longer tracks
+                                // it). Offer the destructive force-delete path.
+                                this.show_force_remove = true;
                                 this.processing = ProcessingState::Idle;
                                 cx.notify();
                             });
@@ -555,6 +560,53 @@ impl CloseWorktreeDialog {
                     }
                 });
             }
+        })
+        .detach();
+    }
+
+    /// Destructive fallback shown after a removal failure: delete the worktree's
+    /// on-disk directory and prune the main repo's metadata, then de-register
+    /// the project. Used for orphaned worktrees that git refuses to remove.
+    pub(super) fn force_remove(&mut self, cx: &mut Context<Self>) {
+        if self.processing != ProcessingState::Idle {
+            return;
+        }
+
+        self.error_message = None;
+
+        let project_id = self.project_id.clone();
+        let global_hooks = self.hooks_config.clone();
+        let workspace = self.workspace.clone();
+        let focus_manager = self.focus_manager.clone();
+
+        self.processing = ProcessingState::Removing;
+        cx.notify();
+
+        cx.spawn(async move |this, cx| {
+            cx.update(|cx| {
+                let result = focus_manager.update(cx, |fm, cx| {
+                    let result = workspace.update(cx, |ws, cx| {
+                        ws.force_remove_worktree_project(fm, &project_id, &global_hooks, cx)
+                    });
+                    cx.notify();
+                    result
+                });
+
+                match result {
+                    Ok(()) => {
+                        let _ = this.update(cx, |this, cx| {
+                            this.close(cx);
+                        });
+                    }
+                    Err(e) => {
+                        let _ = this.update(cx, |this, cx| {
+                            this.error_message = Some(format!("Force delete failed: {}", e));
+                            this.processing = ProcessingState::Idle;
+                            cx.notify();
+                        });
+                    }
+                }
+            });
         })
         .detach();
     }

--- a/crates/okena-views-git/src/close_worktree_dialog/view.rs
+++ b/crates/okena-views-git/src/close_worktree_dialog/view.rs
@@ -41,6 +41,7 @@ impl Render for CloseWorktreeDialog {
         let can_merge = self.can_merge();
         let confirm_label = self.confirm_label();
         let error_msg = self.error_message.clone();
+        let show_force_remove = self.show_force_remove;
 
         modal_backdrop("close-worktree-dialog-backdrop", &t)
             .track_focus(&focus_handle)
@@ -581,7 +582,28 @@ impl Render for CloseWorktreeDialog {
                                     .when(is_processing, |d| {
                                         d.opacity(0.5).cursor(CursorStyle::default())
                                     }),
-                            ),
+                            )
+                            // Destructive fallback: only after a removal failure.
+                            // Force-deletes the on-disk directory for orphaned
+                            // worktrees git refuses to remove.
+                            .when(show_force_remove, |d| {
+                                d.child(
+                                    button("force-remove-wt-btn", "Delete folder anyway", &t)
+                                        .px(px(16.0))
+                                        .py(px(8.0))
+                                        .bg(rgb(t.error))
+                                        .text_color(rgb(0xffffff))
+                                        .hover(|s| s.opacity(0.85))
+                                        .when(!is_processing, |d| {
+                                            d.on_click(cx.listener(|this, _, _, cx| {
+                                                this.force_remove(cx);
+                                            }))
+                                        })
+                                        .when(is_processing, |d| {
+                                            d.opacity(0.5).cursor(CursorStyle::default())
+                                        }),
+                                )
+                            }),
                     ),
             )
     }

--- a/crates/okena-workspace/src/actions/worktree.rs
+++ b/crates/okena-workspace/src/actions/worktree.rs
@@ -456,4 +456,44 @@ impl Workspace {
 
         Ok(())
     }
+
+    /// Force-remove a worktree project whose normal removal failed — e.g. an
+    /// orphaned worktree whose directory still exists but is no longer tracked
+    /// by git (the `.git` pointer dangles because the main repo's metadata
+    /// entry was pruned). Deletes the on-disk directory and prunes the main
+    /// repo's worktree metadata, then de-registers the project.
+    ///
+    /// This deliberately bypasses git's dirty-state safety check (git can't run
+    /// it on a worktree it no longer recognizes), so callers must only reach
+    /// this after the normal, safe removal has already been attempted.
+    pub fn force_remove_worktree_project(&mut self, focus_manager: &mut FocusManager, project_id: &str, global_hooks: &HooksConfig, cx: &mut Context<Self>) -> Result<(), String> {
+        let project = self.project(project_id)
+            .ok_or_else(|| "Project not found".to_string())?;
+        if project.worktree_info.is_none() {
+            return Err("Not a worktree project".to_string());
+        }
+        let project_path = project.path.clone();
+
+        // Resolve the worktree checkout root. `get_repo_root` goes through gix
+        // and fails for an orphan, so walk the filesystem to the `.git` pointer
+        // instead; fall back to the project path (correct for root-level
+        // worktrees, which is the common case).
+        let project_pathbuf = std::path::PathBuf::from(&project_path);
+        let worktree_root = okena_git::resolve_worktree_root_fs(&project_pathbuf)
+            .unwrap_or(project_pathbuf);
+
+        // The main repo is the worktree parent project's path.
+        let main_repo = self.worktree_parent_path(project_id)
+            .map(std::path::PathBuf::from)
+            .ok_or_else(|| "Could not resolve main repository path".to_string())?;
+
+        // Delete the directory and prune stale metadata (NotFound is treated as success).
+        okena_git::remove_worktree_fast(&worktree_root, &main_repo)
+            .map_err(|e| e.to_string())?;
+
+        // De-register the project from the workspace (also fires on_project_close).
+        self.delete_project(focus_manager, project_id, global_hooks, cx);
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Problem

A worktree shown in the sidebar could get into a state where **"Close Worktree" always failed** and there was no way to remove it from the app:

```
Failed to remove worktree: git exited with status 128:
fatal: not a git repository: …/.git/worktrees/<name>
```

## Root cause

When a worktree's metadata entry (`<main-repo>/.git/worktrees/<name>`) is pruned — e.g. `git worktree prune` runs while removing a *different* worktree (prune wipes **every** stale entry, not just the one being removed) — the checkout directory survives on disk but its `.git` pointer now dangles. Git no longer recognizes it as a worktree, so `git worktree remove` exits 128.

okena's existing auto-cleanup (`worktree_sync.rs` → `remove_stale_worktree`) only fires when the directory **no longer exists**. An orphaned-but-present directory is never cleaned up, so the entry stays stuck in the sidebar with no working removal path.

## Changes

A **two-step UX**: the normal close runs exactly as before. Only **after the final removal fails** does the dialog reveal a destructive **"Delete folder anyway"** button.

- **`okena-git`** — `resolve_worktree_root_fs`: resolves a worktree checkout root by walking up to the nearest `.git` entry, without opening the repo via gix (which fails on a dangling pointer). Handles monorepo subdir projects too.
- **`okena-workspace`** — `Workspace::force_remove_worktree_project`: deletes the on-disk directory and prunes stale metadata (reusing the existing `remove_worktree_fast`), then de-registers the project. It deliberately bypasses git's dirty-state safety because git can no longer run that check on a worktree it doesn't track — hence the second click is required to reach it.
- **`okena-views-git`** (Close Worktree dialog) — a `show_force_remove` flag set **only** on the final removal failure (not on stash/fetch/rebase/merge failures, which force-delete can't fix), an async `force_remove()`, and the destructive footer button rendered only when that flag is set.

No public behavior changes for healthy worktrees; the new button never appears unless a removal has already failed.

## How to verify it

- [x] `cargo test -p okena-git` — new `force_removes_orphaned_worktree` test reproduces the exact status-128 failure and proves the fallback resolves the root and cleans up (119 passed)
- [x] `cargo test -p okena-workspace` — no regressions (294 passed)
- [x] `cargo build -p okena-git -p okena-workspace -p okena-views-git` — all changed crates compile
- [ ] **Manual (needs a human):** on a real orphaned worktree, open Close Worktree → confirm the normal action still fails with the same error AND the new "Delete folder anyway" button now appears → click it → the entry leaves the sidebar and the directory is removed from disk.
- [ ] **Manual (regression):** close a healthy worktree the normal way → the force button must NOT appear and behavior is unchanged.

> Note: the full desktop binary build additionally requires the web client (`web/dist`, built via `yarn build` in `web/`) for the unrelated `okena-remote-server` crate; that is a pre-existing prerequisite, not part of this change.

## Changelog

Fixed: orphaned worktrees (directory present but no longer tracked by git) can now be removed from the sidebar via a "Delete folder anyway" fallback that appears after a failed close.
