### PR TITLE
fix(git): compare header ahead/behind against the PR's base branch

### DIFF
--- a/crates/okena-app/src/views/panels/hook_panel.rs
+++ b/crates/okena-app/src/views/panels/hook_panel.rs
@@ -303,7 +303,9 @@ impl HookPanel {
         let hooks = self.get_hook_list(cx);
 
         if hooks.is_empty() {
-            return div().into_any_element();
+            // `hidden` (not an empty visible div) so it claims no flex gap in
+            // the header's button cluster.
+            return div().hidden().into_any_element();
         }
 
         // Compute aggregate status color
@@ -327,7 +329,9 @@ impl HookPanel {
         div()
             .id("hook-indicator-btn")
             .cursor_pointer()
-            .w(px(24.0))
+            // Uniform horizontal padding (not a fixed width) so header buttons
+            // are evenly spaced regardless of glyph size. See project_column.
+            .px(px(5.0))
             .h(px(24.0))
             .flex()
             .items_center()

--- a/crates/okena-app/src/views/panels/project_column.rs
+++ b/crates/okena-app/src/views/panels/project_column.rs
@@ -60,6 +60,12 @@ pub struct ProjectColumn {
     /// Advanced by the "Another tip" control; seeded per column so different
     /// empty columns don't all open on the same tip.
     tip_index: usize,
+    /// Whether the pointer is over the header. Drives revealing the hide/focus
+    /// controls. Tracked in state (not `group_hover`) because the reveal frees
+    /// layout space, and toggling `display` via hover styles crashes GPUI
+    /// (`must call prepaint before paint`) — the hover state can differ between
+    /// prepaint and paint. State + `notify` re-renders a consistent tree.
+    header_hovered: bool,
 }
 
 impl ProjectColumn {
@@ -145,6 +151,7 @@ impl ProjectColumn {
             service_panel,
             hook_panel,
             tip_index: crate::views::tips::next_start_index(),
+            header_hovered: false,
         }
     }
 
@@ -307,7 +314,8 @@ impl ProjectColumn {
             .unwrap_or_default();
 
         if minimized_terminals.is_empty() && detached_terminals.is_empty() {
-            return div().into_any_element();
+            // `hidden` (not an empty visible div) so it claims no flex gap.
+            return div().hidden().into_any_element();
         }
 
         h_flex()
@@ -517,102 +525,112 @@ impl ProjectColumn {
             ("icons/fullscreen.svg", "Focus Project")
         };
 
+        // Reveal the hide/focus controls only while the header is hovered (or
+        // always, in the focused view). Tracked via `header_hovered` state +
+        // conditional rendering rather than a `group_hover` style: the hidden
+        // controls must take no layout space, and toggling `display` on hover
+        // crashes GPUI (prepaint and paint can see different hover states).
+        let show_reveal = is_focused_view || self.header_hovered;
+
         let right_controls = h_flex()
             .gap(px(8.0))
             .child(self.render_hidden_taskbar(project, t, cx))
+            // All four action buttons share one cluster with a single, uniform
+            // gap. Absent buttons (the hover-revealed hide/fullscreen while the
+            // header isn't hovered, or an empty hook/service indicator) leave
+            // the flex layout entirely, so a gap only ever appears between
+            // buttons that are actually visible.
             .child(
-                div()
-                    .flex()
+                h_flex()
                     .gap(px(2.0))
-                    // In the overview the controls reveal on header hover; in
-                    // the focused view they stay pinned so exiting focus is
-                    // always one click away.
-                    .when(!is_focused_view, |d| {
-                        d.opacity(0.0)
-                            .group_hover("project-header", |s| s.opacity(1.0))
+                    .when(show_reveal, |d| {
+                        d.child(
+                            div()
+                                .id("hide-project-btn")
+                                .cursor_pointer()
+                                // Uniform horizontal padding (not a fixed width)
+                                // so every header button sits 5px from its
+                                // neighbours regardless of glyph size — a small
+                                // dot no longer floats in a wide box.
+                                .px(px(5.0))
+                                .h(px(24.0))
+                                .flex()
+                                .items_center()
+                                .justify_center()
+                                .rounded(px(4.0))
+                                .hover(|s| s.bg(rgb(t.bg_hover)))
+                                .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                                    cx.stop_propagation();
+                                })
+                                .on_click(move |_, _window, cx| {
+                                    cx.stop_propagation();
+                                    focus_manager_for_hide.update(cx, |fm, cx| {
+                                        workspace_for_hide.update(cx, |ws, cx| {
+                                            ws.toggle_project_overview_visibility(
+                                                fm, window_id_for_hide, &project_id_for_hide, cx,
+                                            );
+                                        });
+                                    });
+                                })
+                                .child(
+                                    svg()
+                                        .path(vis_icon)
+                                        .size(px(14.0))
+                                        .text_color(rgb(t.text_secondary)),
+                                )
+                                .tooltip(move |_window, cx| {
+                                    Tooltip::new(vis_tooltip).build(_window, cx)
+                                }),
+                        )
+                        .child(
+                            div()
+                                .id("fullscreen-project-btn")
+                                .cursor_pointer()
+                                .px(px(5.0))
+                                .h(px(24.0))
+                                .flex()
+                                .items_center()
+                                .justify_center()
+                                .rounded(px(4.0))
+                                .hover(|s| s.bg(rgb(t.bg_hover)))
+                                .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                                    cx.stop_propagation();
+                                })
+                                .on_click(move |_, _window, cx| {
+                                    cx.stop_propagation();
+                                    let pid = project_id.clone();
+                                    focus_manager.update(cx, |fm, cx| {
+                                        workspace.update(cx, |ws, cx| {
+                                            // Toggle: when already focused, clear
+                                            // focus to return to the overview.
+                                            let target = if is_focused_view { None } else { Some(pid) };
+                                            ws.set_focused_project(fm, target, cx);
+                                        });
+                                        cx.notify();
+                                    });
+                                })
+                                .child(
+                                    svg()
+                                        .path(focus_icon)
+                                        .size(px(14.0))
+                                        .text_color(rgb(t.text_secondary)),
+                                )
+                                .tooltip(move |_window, cx| {
+                                    Tooltip::new(focus_tooltip).build(_window, cx)
+                                }),
+                        )
                     })
-                    .child(
-                        div()
-                            .id("hide-project-btn")
-                            .cursor_pointer()
-                            .w(px(24.0))
-                            .h(px(24.0))
-                            .flex()
-                            .items_center()
-                            .justify_center()
-                            .rounded(px(4.0))
-                            .hover(|s| s.bg(rgb(t.bg_hover)))
-                            .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                                cx.stop_propagation();
-                            })
-                            .on_click(move |_, _window, cx| {
-                                cx.stop_propagation();
-                                focus_manager_for_hide.update(cx, |fm, cx| {
-                                    workspace_for_hide.update(cx, |ws, cx| {
-                                        ws.toggle_project_overview_visibility(
-                                            fm, window_id_for_hide, &project_id_for_hide, cx,
-                                        );
-                                    });
-                                });
-                            })
-                            .child(
-                                svg()
-                                    .path(vis_icon)
-                                    .size(px(14.0))
-                                    .text_color(rgb(t.text_secondary)),
-                            )
-                            .tooltip(move |_window, cx| {
-                                Tooltip::new(vis_tooltip).build(_window, cx)
-                            }),
-                    )
-                    .child(
-                        div()
-                            .id("fullscreen-project-btn")
-                            .cursor_pointer()
-                            .w(px(24.0))
-                            .h(px(24.0))
-                            .flex()
-                            .items_center()
-                            .justify_center()
-                            .rounded(px(4.0))
-                            .hover(|s| s.bg(rgb(t.bg_hover)))
-                            .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                                cx.stop_propagation();
-                            })
-                            .on_click(move |_, _window, cx| {
-                                cx.stop_propagation();
-                                let pid = project_id.clone();
-                                focus_manager.update(cx, |fm, cx| {
-                                    workspace.update(cx, |ws, cx| {
-                                        // Toggle: when already focused, clear
-                                        // focus to return to the overview.
-                                        let target = if is_focused_view { None } else { Some(pid) };
-                                        ws.set_focused_project(fm, target, cx);
-                                    });
-                                    cx.notify();
-                                });
-                            })
-                            .child(
-                                svg()
-                                    .path(focus_icon)
-                                    .size(px(14.0))
-                                    .text_color(rgb(t.text_secondary)),
-                            )
-                            .tooltip(move |_window, cx| {
-                                Tooltip::new(focus_tooltip).build(_window, cx)
-                            }),
-                    ),
-            )
-            .child({
-                self.hook_panel.update(cx, |hp, cx| {
-                    hp.render_hook_indicator(&t, cx)
-                })
-            })
-            .child({
-                self.service_panel.update(cx, |sp, cx| {
-                    sp.render_service_indicator(&t, cx)
-                })
-            });
+                    .child({
+                        self.hook_panel.update(cx, |hp, cx| {
+                            hp.render_hook_indicator(&t, cx)
+                        })
+                    })
+                    .child({
+                        self.service_panel.update(cx, |sp, cx| {
+                            sp.render_service_indicator(&t, cx)
+                        })
+                    }),
+            );
 
         let git_status_el = self.git_header.update(cx, |gh, cx| {
             gh.render_git_status(git_status.clone(), &t, cx)
@@ -649,6 +667,12 @@ impl ProjectColumn {
                 .bg(rgb(t.bg_header))
                 .border_b_1()
                 .border_color(rgb(t.border))
+                .on_hover(cx.listener(|this, hovered: &bool, _window, cx| {
+                    if this.header_hovered != *hovered {
+                        this.header_hovered = *hovered;
+                        cx.notify();
+                    }
+                }))
                 .on_mouse_down(MouseButton::Right, context_menu_handler)
                 // Row 1: name + right controls
                 .child(
@@ -687,6 +711,12 @@ impl ProjectColumn {
                 .bg(rgb(t.bg_header))
                 .border_b_1()
                 .border_color(rgb(t.border))
+                .on_hover(cx.listener(|this, hovered: &bool, _window, cx| {
+                    if this.header_hovered != *hovered {
+                        this.header_hovered = *hovered;
+                        cx.notify();
+                    }
+                }))
                 .on_mouse_down(MouseButton::Right, context_menu_handler)
                 .child(
                     h_flex()

--- a/crates/okena-core/src/api.rs
+++ b/crates/okena-core/src/api.rs
@@ -185,6 +185,11 @@ pub struct PrInfo {
     pub url: String,
     pub state: PrState,
     pub number: u32,
+    /// The PR's base (target) branch, e.g. `main` or `develop`. Used to measure
+    /// ahead/behind against what the PR actually diffs against rather than the
+    /// repo default. `None` when unknown (older hosts, or `gh` didn't report it).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -838,6 +843,7 @@ mod tests {
                 url: "https://github.com/o/r/pull/7".into(),
                 state: PrState::Open,
                 number: 7,
+                base: Some("main".into()),
             }),
             ci_checks: Some(CiCheckSummary {
                 status: CiStatus::Failure,

--- a/crates/okena-git/src/lib.rs
+++ b/crates/okena-git/src/lib.rs
@@ -198,10 +198,23 @@ pub fn get_git_status(path: &Path) -> Option<GitStatus> {
 /// previous cached value is returned, so a single bad poll cycle doesn't
 /// blank the +/- badge in the project header.
 pub fn refresh_git_status(path: &Path) -> Option<GitStatus> {
+    refresh_git_status_with_pr_base(path, None)
+}
+
+/// Like [`refresh_git_status`], but when `pr_base` is `Some(name)` the
+/// ahead/behind counts (and `review_base`) are measured against the branch's
+/// open-PR base instead of the repo default — so a PR onto `develop`/a stacked
+/// branch shows the right numbers and diff base. `pr_base` is the PR's base
+/// branch name (from `gh`); the watcher passes the value it already caches, so
+/// no extra network happens on this hot path.
+pub fn refresh_git_status_with_pr_base(path: &Path, pr_base: Option<&str>) -> Option<GitStatus> {
     let path_buf = path.to_path_buf();
     match repository::get_status(path) {
         repository::StatusFetch::Status(s) => {
-            let s = *s;
+            let mut s = *s;
+            if let Some(base) = pr_base {
+                repository::apply_pr_base(&mut s, path, base);
+            }
             with_cache(|cache| { cache.insert(path_buf, Some(s.clone())); });
             Some(s)
         }

--- a/crates/okena-git/src/repository/branch.rs
+++ b/crates/okena-git/src/repository/branch.rs
@@ -71,15 +71,31 @@ pub fn resolve_review_base(repo_path: &Path) -> Option<String> {
         return None;
     }
 
-    let repo = crate::gix_helpers::open(repo_path)?;
+    resolve_base_ref(repo_path, &default)
+}
 
-    // Prefer the pushed ref so the review matches what a PR would diff against.
-    if repo.find_reference(&format!("refs/remotes/origin/{}", default)).is_ok() {
-        return Some(format!("origin/{}", default));
+/// Resolve the best local ref to compare against for a target branch `name`,
+/// preferring the pushed copy so counts match what a PR would diff against:
+/// `upstream/<name>` → `origin/<name>` → local `<name>`. Returns `None` when
+/// none resolve.
+///
+/// `upstream` wins over `origin` for the fork workflow: when `origin` is the
+/// user's fork and `upstream` is the canonical repo the PR actually targets,
+/// the fork's copy lags, so comparing against it inflates "ahead" and hides
+/// "behind". Ordinary single-remote repos have no `upstream` and fall through
+/// to `origin/<name>` exactly as before.
+pub fn resolve_base_ref(repo_path: &Path, name: &str) -> Option<String> {
+    let repo = crate::gix_helpers::open(repo_path)?;
+    for remote in ["upstream", "origin"] {
+        if repo
+            .find_reference(&format!("refs/remotes/{remote}/{name}"))
+            .is_ok()
+        {
+            return Some(format!("{remote}/{name}"));
+        }
     }
-    // Fall back to the local default branch.
-    if repo.find_reference(&format!("refs/heads/{}", default)).is_ok() {
-        return Some(default);
+    if repo.find_reference(&format!("refs/heads/{name}")).is_ok() {
+        return Some(name.to_string());
     }
     None
 }
@@ -455,5 +471,37 @@ mod tests {
     fn resolve_review_base_returns_none_for_invalid_path() {
         let path = PathBuf::from("/nonexistent/path/that/does/not/exist");
         assert!(resolve_review_base(&path).is_none());
+    }
+
+    #[test]
+    fn resolve_base_ref_prefers_upstream_then_origin_then_local() {
+        let (_tmp, repo) = init_temp_repo();
+        // Local branch only.
+        assert_eq!(resolve_base_ref(&repo, "main").as_deref(), Some("main"));
+
+        // Add an origin remote-tracking ref: now preferred over local.
+        git_in(&repo, &["update-ref", "refs/remotes/origin/main", "HEAD"]);
+        assert_eq!(resolve_base_ref(&repo, "main").as_deref(), Some("origin/main"));
+
+        // Add an upstream remote-tracking ref: fork workflow — upstream wins.
+        git_in(&repo, &["update-ref", "refs/remotes/upstream/main", "HEAD"]);
+        assert_eq!(resolve_base_ref(&repo, "main").as_deref(), Some("upstream/main"));
+    }
+
+    #[test]
+    fn resolve_base_ref_is_none_when_branch_missing() {
+        let (_tmp, repo) = init_temp_repo();
+        assert_eq!(resolve_base_ref(&repo, "does-not-exist"), None);
+    }
+
+    #[test]
+    fn resolve_review_base_prefers_upstream_on_feature_branch() {
+        let (_tmp, repo) = init_temp_repo();
+        // Fork: origin (the fork) and upstream (canonical) both have main.
+        git_in(&repo, &["update-ref", "refs/remotes/origin/main", "HEAD"]);
+        git_in(&repo, &["update-ref", "refs/remotes/upstream/main", "HEAD"]);
+        create_and_checkout_branch(&repo, "feat/x", None).expect("create branch");
+        // Review base is the upstream copy the PR really targets, not the fork's.
+        assert_eq!(resolve_review_base(&repo).as_deref(), Some("upstream/main"));
     }
 }

--- a/crates/okena-git/src/repository/ci.rs
+++ b/crates/okena-git/src/repository/ci.rs
@@ -60,8 +60,8 @@ pub fn get_pr_info(path: &Path) -> Option<crate::PrInfo> {
         command("gh")
             .args([
                 "pr", "list", "--head", &branch, "--state", "all", "--limit", "1",
-                "--json", "url,state,isDraft,number",
-                "--jq", ".[0] | [.url, .state, .isDraft, .number] | @tsv",
+                "--json", "url,state,isDraft,number,baseRefName",
+                "--jq", ".[0] | [.url, .state, .isDraft, .number, .baseRefName] | @tsv",
             ])
             .current_dir(path_str),
         GH_TIMEOUT,
@@ -70,30 +70,44 @@ pub fn get_pr_info(path: &Path) -> Option<crate::PrInfo> {
 
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let line = stdout.trim();
-        let parts: Vec<&str> = line.split('\t').collect();
-        if parts.len() >= 4 && parts[0].starts_with("http") {
-            let url = parts[0].to_string();
-            let is_draft = parts[2] == "true";
-            let number = parts[3].parse::<u32>().unwrap_or(0);
-            let state = if is_draft {
-                crate::PrState::Draft
-            } else {
-                match parts[1] {
-                    "OPEN" => crate::PrState::Open,
-                    "MERGED" => crate::PrState::Merged,
-                    "CLOSED" => crate::PrState::Closed,
-                    other => {
-                        log::warn!("Unknown PR state '{}', defaulting to Open", other);
-                        crate::PrState::Open
-                    }
-                }
-            };
-            return Some(crate::PrInfo { url, state, number });
-        }
+        return parse_pr_list_tsv(stdout.trim());
     }
 
     None
+}
+
+/// Parse the single TSV line our `gh pr list --jq ... | @tsv` query emits into a
+/// [`PrInfo`]. Fields, in order: url, state, isDraft, number, baseRefName (the
+/// last may be absent on older `gh`). Returns `None` for an empty line or one
+/// that doesn't start with a URL (i.e. no PR found for the branch).
+fn parse_pr_list_tsv(line: &str) -> Option<crate::PrInfo> {
+    let parts: Vec<&str> = line.split('\t').collect();
+    if parts.len() < 4 || !parts[0].starts_with("http") {
+        return None;
+    }
+    let url = parts[0].to_string();
+    let is_draft = parts[2] == "true";
+    let number = parts[3].parse::<u32>().unwrap_or(0);
+    let state = if is_draft {
+        crate::PrState::Draft
+    } else {
+        match parts[1] {
+            "OPEN" => crate::PrState::Open,
+            "MERGED" => crate::PrState::Merged,
+            "CLOSED" => crate::PrState::Closed,
+            other => {
+                log::warn!("Unknown PR state '{}', defaulting to Open", other);
+                crate::PrState::Open
+            }
+        }
+    };
+    // baseRefName: the PR's target branch. Absent/empty -> None.
+    let base = parts
+        .get(4)
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    Some(crate::PrInfo { url, state, number, base })
 }
 
 /// Compute elapsed milliseconds between two ISO-8601 timestamps (those
@@ -453,6 +467,43 @@ pub(crate) fn parse_branch_ci(
 
 #[cfg(test)]
 mod tests {
+    // ─── PR list TSV parsing tests ─────────────────────────────────────
+
+    #[test]
+    fn parse_pr_list_tsv_captures_base_branch() {
+        let line = "https://github.com/o/r/pull/9\tOPEN\tfalse\t9\tdevelop";
+        let pr = super::parse_pr_list_tsv(line).expect("should parse");
+        assert_eq!(pr.url, "https://github.com/o/r/pull/9");
+        assert_eq!(pr.state, crate::PrState::Open);
+        assert_eq!(pr.number, 9);
+        assert_eq!(pr.base.as_deref(), Some("develop"));
+    }
+
+    #[test]
+    fn parse_pr_list_tsv_base_absent_is_none() {
+        // Older `gh` without baseRefName: only four fields.
+        let line = "https://github.com/o/r/pull/3\tMERGED\tfalse\t3";
+        let pr = super::parse_pr_list_tsv(line).expect("should parse");
+        assert_eq!(pr.state, crate::PrState::Merged);
+        assert_eq!(pr.number, 3);
+        assert_eq!(pr.base, None);
+    }
+
+    #[test]
+    fn parse_pr_list_tsv_draft_overrides_state() {
+        let line = "https://github.com/o/r/pull/5\tOPEN\ttrue\t5\tmain";
+        let pr = super::parse_pr_list_tsv(line).expect("should parse");
+        assert_eq!(pr.state, crate::PrState::Draft);
+        assert_eq!(pr.base.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn parse_pr_list_tsv_empty_or_no_pr_is_none() {
+        assert!(super::parse_pr_list_tsv("").is_none());
+        // A jq null/empty result — no leading URL.
+        assert!(super::parse_pr_list_tsv("\t\t\t").is_none());
+    }
+
     // ─── CI check parsing tests ────────────────────────────────────────
 
     #[test]

--- a/crates/okena-git/src/repository/mod.rs
+++ b/crates/okena-git/src/repository/mod.rs
@@ -26,7 +26,7 @@ pub use branch::{
     delete_local_branch, delete_remote_branch, discard_file_changes, fetch_all,
     get_available_branches_for_worktree, get_default_branch, list_branches,
     list_branches_classified, merge_branch, push_branch, rebase_onto,
-    resolve_review_base, stage_file,
+    resolve_base_ref, resolve_review_base, stage_file,
     stash_changes, stash_pop, unstage_file, BranchList,
 };
 pub use ci::{get_ci_checks, get_pr_info, has_github_remote};
@@ -35,8 +35,8 @@ pub use paths::{
     resolve_git_root_and_subdir,
 };
 pub use status::{
-    count_ahead_behind, count_ahead_behind_vs, count_unpushed_commits, get_current_branch,
-    get_head_sha, get_status, has_uncommitted_changes, StatusFetch,
+    apply_pr_base, count_ahead_behind, count_ahead_behind_vs, count_unpushed_commits,
+    get_current_branch, get_head_sha, get_status, has_uncommitted_changes, StatusFetch,
 };
 pub(crate) use status::worktree_diff;
 pub use worktree::{

--- a/crates/okena-git/src/repository/status.rs
+++ b/crates/okena-git/src/repository/status.rs
@@ -361,6 +361,31 @@ pub fn count_ahead_behind_vs(path: &Path, base_ref: &str) -> Option<(usize, usiz
     Some((ahead, behind))
 }
 
+/// Re-point a status's ahead/behind (and `review_base`) at the branch's open-PR
+/// base when it differs from the repo default. Without this, the header always
+/// measures against the default branch (e.g. `main`) even when the PR actually
+/// targets `develop` or a stacked branch — so the counts, the base label, and
+/// the click-to-review diff would all be wrong.
+///
+/// `pr_base` is the PR's base branch *name* (from `gh`, e.g. `develop`); it is
+/// resolved to a concrete ref via [`resolve_base_ref`] (preferring
+/// `upstream`/`origin`). `default_branch` is left untouched so the label chip
+/// surfaces the non-default base instead of staying hidden. No-op when the PR
+/// targets the ref we already compare against, or when nothing resolves.
+pub fn apply_pr_base(status: &mut GitStatus, path: &Path, pr_base: &str) {
+    let Some(base_ref) = super::branch::resolve_base_ref(path, pr_base) else {
+        return;
+    };
+    if status.review_base.as_deref() == Some(base_ref.as_str()) {
+        return;
+    }
+    if let Some((ahead, behind)) = count_ahead_behind_vs(path, &base_ref) {
+        status.ahead = Some(ahead);
+        status.behind = Some(behind);
+        status.review_base = Some(base_ref);
+    }
+}
+
 /// Count commits that haven't been pushed to the branch's own remote.
 /// Compares against `origin/<branch>` rather than `@{u}` because worktree
 /// branches created from `origin/main` auto-track main, which would
@@ -674,6 +699,38 @@ mod tests {
         // contributes nothing to the +/- totals.
         std::fs::write(repo.join("file.txt"), [0u8, 1, 2, 0, 5]).unwrap();
         assert_eq!(get_diff_stats(&repo), Some((0, 0)));
+    }
+
+    #[test]
+    fn apply_pr_base_repoints_ahead_behind_at_pr_target() {
+        let (_tmp, repo) = init_temp_repo();
+        let commit = |name: &str| {
+            std::fs::write(repo.join(name), "x").unwrap();
+            git_in(&repo, &["add", "."]);
+            git_in(&repo, &["-c", "commit.gpgsign=false", "commit", "-m", name]);
+        };
+        // main -> develop (+1 commit) -> feature (+2 commits), HEAD on feature.
+        git_in(&repo, &["checkout", "-b", "develop"]);
+        commit("d0.txt");
+        git_in(&repo, &["checkout", "-b", "feature"]);
+        commit("f0.txt");
+        commit("f1.txt");
+
+        let StatusFetch::Status(mut s) = get_status(&repo) else {
+            panic!("expected a fresh status");
+        };
+        // Default base is main: feature carries develop's commit plus its own two.
+        assert_eq!(s.review_base.as_deref(), Some("main"));
+        assert_eq!((s.ahead, s.behind), (Some(3), Some(0)));
+
+        // The PR actually targets develop: only the two feature commits are ahead.
+        apply_pr_base(&mut s, &repo, "develop");
+        assert_eq!(s.review_base.as_deref(), Some("develop"));
+        assert_eq!((s.ahead, s.behind), (Some(2), Some(0)));
+
+        // No-op when the PR targets the base we already compare against.
+        apply_pr_base(&mut s, &repo, "develop");
+        assert_eq!((s.ahead, s.behind), (Some(2), Some(0)));
     }
 }
 

--- a/crates/okena-views-git/src/project_header.rs
+++ b/crates/okena-views-git/src/project_header.rs
@@ -81,10 +81,15 @@ pub(crate) fn tint(color: u32, alpha: f32) -> Rgba {
 
 // ── Standalone badges ───────────────────────────────────────────────────────
 
-/// Strip a leading `origin/` so a base ref reads as a plain branch name
-/// (`origin/main` → `main`) in the comparison chip.
+/// Strip a leading remote prefix so a base ref reads as a plain branch name
+/// (`origin/main` → `main`, `upstream/main` → `main`) in the comparison chip.
+/// Stripping `upstream/` too means a fork's base (compared against the upstream
+/// copy) collapses to the same label as the default and stays hidden when it
+/// matches, instead of reading as a noisy `upstream/main`.
 pub(crate) fn base_short_name(base: &str) -> &str {
-    base.strip_prefix("origin/").unwrap_or(base)
+    base.strip_prefix("origin/")
+        .or_else(|| base.strip_prefix("upstream/"))
+        .unwrap_or(base)
 }
 
 fn plural(n: usize) -> &'static str {
@@ -176,6 +181,16 @@ pub fn render_base_compare_badge(
                 d.child(
                     div()
                         .text_color(rgb(t.text_muted))
+                        // Cap + single-line ellipsis so a long base branch name
+                        // (e.g. a stacked-PR base like `feature/really-long-name`)
+                        // truncates with a trailing "…" instead of overflowing
+                        // the header row. `whitespace_nowrap` is what makes the
+                        // dots appear: without it a name with a `/` wraps and
+                        // `overflow_hidden` just clips the second line.
+                        .max_w(px(100.0))
+                        .overflow_hidden()
+                        .whitespace_nowrap()
+                        .text_ellipsis()
                         .child(base_label.clone()),
                 )
             })

--- a/crates/okena-views-git/src/watcher.rs
+++ b/crates/okena-views-git/src/watcher.rs
@@ -148,9 +148,19 @@ impl GitStatusWatcher {
             .map(|p| p.path.clone());
         let Some(path) = path else { return };
 
+        // Reuse the cached PR base so an immediate post-action refresh measures
+        // ahead/behind against the PR's real target, matching the poll loop.
+        let pr_base = self
+            .pr_infos
+            .get(&project_id)
+            .and_then(|p| p.as_ref())
+            .and_then(|p| p.base.clone());
+
         cx.spawn(async move |this: WeakEntity<Self>, cx| {
             let new_status = smol::unblock(move || {
-                with_lane(Lane::Poll, || git::refresh_git_status(Path::new(&path)))
+                with_lane(Lane::Poll, || {
+                    git::refresh_git_status_with_pr_base(Path::new(&path), pr_base.as_deref())
+                })
             })
             .await;
 
@@ -249,13 +259,30 @@ impl GitStatusWatcher {
                 let check_prs = cycle == 1 || (cycle != 0 && cycle.is_multiple_of(PR_POLL_EVERY_N_CYCLES));
                 let check_ci = cycle == 1 || (cycle != 0 && cycle.is_multiple_of(ci_poll_interval));
 
+                // Snapshot each project's known PR base branch (from the cached
+                // PR info fetched on prior `check_prs` cycles). Passing it into
+                // the status fetch below re-points ahead/behind at what the PR
+                // actually targets (e.g. `develop`) instead of the repo default
+                // — recomputed every cycle from local refs, so no extra `gh`.
+                let pr_bases: HashMap<String, String> = this.update(cx, |this, _| {
+                    this.pr_infos
+                        .iter()
+                        .filter_map(|(id, pr)| {
+                            pr.as_ref().and_then(|p| p.base.clone()).map(|b| (id.clone(), b))
+                        })
+                        .collect()
+                }).unwrap_or_default();
+
                 // Phase 1: Fetch git status for all projects in parallel
                 let status_futures: Vec<_> = projects.iter().map(|(id, path)| {
                     let id = id.clone();
                     let path = path.clone();
+                    let pr_base = pr_bases.get(&id).cloned();
                     async move {
                         let status = smol::unblock(move || {
-                            with_lane(Lane::Poll, || git::refresh_git_status(Path::new(&path)))
+                            with_lane(Lane::Poll, || {
+                                git::refresh_git_status_with_pr_base(Path::new(&path), pr_base.as_deref())
+                            })
                         }).await;
                         (id, status)
                     }

--- a/crates/okena-views-services/src/panel.rs
+++ b/crates/okena-views-services/src/panel.rs
@@ -647,7 +647,9 @@ pub fn render_service_indicator(
     on_click: impl Fn(&mut Window, &mut App) + 'static,
 ) -> gpui::AnyElement {
     if services.is_empty() {
-        return div().into_any_element();
+        // `hidden` (not an empty visible div) so it claims no flex gap in the
+        // header's button cluster.
+        return div().hidden().into_any_element();
     }
 
     // Compute aggregate status color
@@ -681,7 +683,10 @@ pub fn render_service_indicator(
     div()
         .id("service-indicator-btn")
         .cursor_pointer()
-        .w(px(24.0))
+        // Uniform horizontal padding (not a fixed width) so the small status
+        // dot gets the same 5px breathing room as the icon buttons instead of
+        // floating in a wide 24px box. See project_column's header cluster.
+        .px(px(5.0))
         .h(px(24.0))
         .flex()
         .items_center()

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -41,6 +41,8 @@ export interface PrInfo {
   url: string;
   state: PrState;
   number: number;
+  /** The PR's base (target) branch, e.g. "main" or "develop". Omitted when unknown. */
+  base?: string | null;
 }
 
 export type CiStatus = "Success" | "Failure" | "Pending";


### PR DESCRIPTION
## Summary
Two fixes to the project header, one per commit.

**1. Ahead/behind measured against the PR's real base branch.** The header's "commits ahead/behind" chip always compared against the repo default (`origin/HEAD` → `main`), so a PR onto `develop` or a stacked branch showed wrong numbers, a wrong base label, and diffed against the wrong base on click-to-review. okena knew a PR existed but never fetched its base branch.

**2. Header action buttons: even spacing + safe hover-collapse.** The hide/fullscreen/hook/service cluster had inconsistent gaps, a status dot floating in extra whitespace, and hover-hidden controls that still reserved layout space.

## Changes

### PR base awareness (`5b898ba4`)
- Fetch `baseRefName` in `get_pr_info` and add `PrInfo.base` (okena-core → wire + web). Parsing extracted into a pure, unit-tested `parse_pr_list_tsv`.
- `apply_pr_base` re-points ahead/behind + `review_base` at the PR's real base, folded into the status fetch (`refresh_git_status_with_pr_base`) so it runs in the 5s poll's `unblock` step — no extra `gh` on the hot path, cache stays correct, click-to-review diffs the right base.
- New `resolve_base_ref` prefers `upstream/<name>` → `origin/<name>` → local, fixing the fork workflow (origin is the fork, upstream the real base). `resolve_review_base` refactored onto it (single-remote repos unchanged).
- `base_short_name` also strips `upstream/`; long base labels truncate with a single-line ellipsis (`whitespace_nowrap` so the `…` renders).

### Header button cluster (`97a00eb7`)
- Even spacing: uniform 5px horizontal padding per button instead of fixed 24px boxes, so the small status dot no longer floats in extra whitespace. Empty hook/service indicators and the hidden taskbar now leave the flex layout (`display:none`) so they claim no gap.
- Reveal hide/fullscreen on header hover via a `header_hovered` flag + conditional render, so they take no layout space when hidden. Replaces a `group_hover` display toggle that crashed GPUI (`must call prepaint before paint`) — hover state can differ between prepaint and paint, so an element skipped at prepaint got painted.

## Test plan
- [ ] `cargo test -p okena-git` / `-p okena-core` — PR-base recompute, `resolve_base_ref` precedence, fork review-base, TSV parsing, wire round-trip
- [ ] PR onto a non-`main` branch → chip shows `develop +N −M` with correct counts; click → review diff is against the PR base
- [ ] PR onto a long-named branch → base label truncates with `…`
- [ ] Repo with no PR / PR onto `main` → unchanged
- [ ] Header: four buttons evenly spaced, status dot no longer floats; hide/fullscreen appear on hover and take no space at rest; no crash on hover

## Known residual (accepted)
Right after switching branches, ahead/behind can lag up to ~60s until the next PR poll refreshes the cached base — the same staleness the PR badge already has; self-heals, never crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)