### PR TITLE
fix(terminal): don't zoom font on Ctrl during inertial scroll momentum

### DIFF
--- a/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
@@ -45,6 +45,14 @@ pub struct TerminalContent {
     window_id: Option<WindowId>,
     workspace: Entity<Workspace>,
     scroll_accumulator: f32,
+    /// True while we're in the inertial "momentum" tail after a trackpad scroll
+    /// gesture was released. On macOS the OS keeps emitting scroll-wheel events
+    /// as a flick coasts, but GPUI drops the momentum phase and reports them as
+    /// plain `TouchPhase::Moved` — so we reconstruct the gesture boundary here:
+    /// set on `Ended`, cleared on the next `Started`. Used to reject Control-zoom
+    /// during momentum so a fast scroll that coasts into an accidental Control
+    /// press can't resize the font (see the `on_scroll_wheel` handler).
+    in_scroll_inertia: bool,
     mouse_down_cell: Option<(usize, i32)>,
     forwarded_button: Option<(u8, u8)>,
     /// Runs while a drag-selection is active, scrolling the viewport when the
@@ -82,6 +90,7 @@ impl TerminalContent {
             window_id,
             workspace,
             scroll_accumulator: 0.0,
+            in_scroll_inertia: false,
             mouse_down_cell: None,
             forwarded_button: None,
             autoscroll_task: None,
@@ -625,11 +634,32 @@ impl Render for TerminalContent {
                 }),
             )
             .on_scroll_wheel(cx.listener(|this, event: &ScrollWheelEvent, _window, cx| {
+                // Track the trackpad gesture boundary so we can tell an active,
+                // finger-on-the-pad scroll from its inertial momentum tail. GPUI
+                // collapses the macOS momentum phase into `TouchPhase::Moved`, so
+                // this flag is our only signal (see `in_scroll_inertia`).
+                match event.touch_phase {
+                    TouchPhase::Started => this.in_scroll_inertia = false,
+                    TouchPhase::Ended => this.in_scroll_inertia = true,
+                    TouchPhase::Moved => {}
+                }
+
                 if event.modifiers.shift {
                     return;
                 }
                 let delta = event.delta.pixel_delta(px(17.0));
-                if event.modifiers.control {
+
+                // Only zoom on genuinely user-driven Control+scroll. Reject the
+                // inertial-momentum tail of a trackpad flick — a precise (pixel)
+                // delta arriving while coasting after the fingers lifted — so a
+                // fast scroll that coasts into an accidental Control press can't
+                // resize the font; that momentum falls through to scroll the
+                // terminal instead. A real mouse wheel reports `Lines` (never
+                // momentum), so wheel-driven Control+scroll always zooms.
+                let is_inertial_momentum =
+                    this.in_scroll_inertia && matches!(event.delta, ScrollDelta::Pixels(_));
+
+                if event.modifiers.control && !is_inertial_momentum {
                     let current_zoom = this.workspace.read(cx).get_terminal_zoom(&this.project_id, &this.layout_path);
                     let zoom_delta = if f32::from(delta.y) > 0.0 { 0.1 } else { -0.1 };
                     let new_zoom = (current_zoom + zoom_delta).clamp(0.5, 3.0);


### PR DESCRIPTION
## Problem

On macOS, a fast trackpad flick keeps emitting scroll-wheel events as it coasts (inertial momentum). If you press **Ctrl** during that coast, the terminal font size changed — because the Ctrl+scroll zoom handler keyed purely on the live `event.modifiers.control`.

Root cause: GPUI's macOS layer maps only `NSEvent.phase` to `touch_phase` and **discards `momentumPhase`** (`gpui_macos/events.rs`), so momentum events arrive as ordinary `TouchPhase::Moved` — indistinguishable from an active drag by that field alone.

## Fix

Reconstruct the gesture boundary GPUI drops. New `in_scroll_inertia` flag: set on `Ended`, cleared on `Started`. Ctrl+scroll zooms only when **not** in the inertia tail; momentum during Ctrl falls through to normal scrolling (terminal keeps scrolling — no font change).

- **`Pixels`-delta gate** → a real mouse wheel is `ScrollDelta::Lines`, never momentum, so wheel Ctrl+zoom always works.
- **Ended-sets / Started-clears** (not an "active gesture" flag) → chosen because **Wayland** delivers touchpad scroll as `Pixels` + hardcoded `Moved` and **never sends `Started`** (`gpui_linux/.../wayland/client.rs`). An active-gesture heuristic would flag every Wayland touchpad scroll as momentum and kill Ctrl+zoom on Linux. Ended-based tracking keeps it working there.
- **Windows** precision touchpad sends real `Started`/`Ended`; wheel is `Lines` — both correct. **X11** wheel is `Lines` — correct.

## Testing

- `cargo build` (full workspace) — green.
- Behavioral verification needs a hand on the trackpad (momentum can't be meaningfully simulated): flick-scroll fast, then press Ctrl mid-coast → font no longer resizes; content keeps scrolling. Deliberate Ctrl+scroll (fingers down) still zooms.

## Known same-shape bug, not touched here

File viewer / image zoom (`okena-files/src/file_viewer/render.rs`) has the identical issue with Cmd/Ctrl+scroll — it only filters the sub-pixel momentum *tail* (`dy.abs() < 0.5`), so a fast flick's large-delta momentum still zooms. Left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKa57pTfChofkR6BbDo3VY