### PR TITLE
Fix terminal sizing and collapsing split panes

### DIFF
--- a/crates/okena-app/src/views/panels/project_column.rs
+++ b/crates/okena-app/src/views/panels/project_column.rs
@@ -307,7 +307,7 @@ impl ProjectColumn {
             let action_dispatcher = self.action_dispatcher.clone();
             let window_id = self.window_id;
 
-            self.layout_container = Some(cx.new(move |_cx| {
+            self.layout_container = Some(cx.new(move |cx| {
                 LayoutContainer::new(
                     workspace,
                     focus_manager,
@@ -320,6 +320,7 @@ impl ProjectColumn {
                     terminals,
                     active_drag,
                     action_dispatcher,
+                    cx,
                 )
             }));
         } else if let Some(container) = &self.layout_container {
@@ -1095,10 +1096,26 @@ impl Render for ProjectColumn {
 #[cfg(test)]
 mod tests {
     use super::project_header_display_name;
+    use crate::action_dispatch::ActionDispatcher;
+    use crate::terminal::backend::TerminalBackend;
+    use crate::terminal::shell_config::ShellType;
+    use crate::terminal::terminal::TerminalTransport;
+    use crate::views::layout::layout_container::LayoutContainer;
+    use crate::views::layout::split_pane::new_active_drag;
+    use crate::workspace::focus::FocusManager;
+    use crate::workspace::request_broker::RequestBroker;
     use crate::workspace::settings::HooksConfig;
-    use crate::workspace::state::{ProjectData, WorktreeMetadata};
+    use crate::workspace::state::{
+        LayoutNode, ProjectData, WindowId, Workspace, WorkspaceData, WorktreeMetadata,
+    };
+    use anyhow::Result;
+    use gpui::AppContext as _;
     use okena_core::theme::FolderColor;
+    use std::cell::Cell;
     use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::rc::Rc;
+    use std::sync::Arc;
 
     fn project_with_name(name: &str) -> ProjectData {
         ProjectData {
@@ -1136,5 +1153,119 @@ mod tests {
         });
 
         assert_eq!(project_header_display_name(&project), "feature-login");
+    }
+
+    struct TestTransport;
+
+    impl TerminalTransport for TestTransport {
+        fn send_input(&self, _terminal_id: &str, _data: &[u8]) {}
+
+        fn resize(&self, _terminal_id: &str, _cols: u16, _rows: u16) {}
+
+        fn uses_mouse_backend(&self) -> bool {
+            false
+        }
+    }
+
+    struct TestBackend;
+
+    impl TerminalBackend for TestBackend {
+        fn transport(&self) -> Arc<dyn TerminalTransport> {
+            Arc::new(TestTransport)
+        }
+
+        fn create_terminal(&self, _cwd: &str, _shell: Option<&ShellType>) -> Result<String> {
+            unreachable!("test never creates a terminal")
+        }
+
+        fn reconnect_terminal(
+            &self,
+            _terminal_id: &str,
+            _cwd: &str,
+            _shell: Option<&ShellType>,
+        ) -> Result<String> {
+            unreachable!("test never reconnects a terminal")
+        }
+
+        fn kill(&self, _terminal_id: &str) {}
+
+        fn capture_buffer(&self, _terminal_id: &str) -> Option<PathBuf> {
+            None
+        }
+
+        fn supports_buffer_capture(&self) -> bool {
+            false
+        }
+
+        fn is_remote(&self) -> bool {
+            true
+        }
+
+        fn get_shell_pid(&self, _terminal_id: &str) -> Option<u32> {
+            None
+        }
+
+        fn get_service_pids(&self, _terminal_id: &str) -> Vec<u32> {
+            Vec::new()
+        }
+    }
+
+    #[gpui::test]
+    fn terminal_create_and_close_invalidate_cached_layout(cx: &mut gpui::TestAppContext) {
+        let mut project = project_with_name("Project");
+        project.layout = Some(LayoutNode::new_terminal());
+        let project_id = project.id.clone();
+        let mut data = WorkspaceData::empty();
+        data.project_order.push(project_id.clone());
+        data.projects.push(project);
+        let workspace = cx.new(|_| Workspace::new(data));
+        let focus_manager = cx.new(|_| FocusManager::new());
+        let request_broker = cx.new(|_| RequestBroker::new());
+        let terminals = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let container = cx.new(|cx| {
+            LayoutContainer::<ActionDispatcher>::new(
+                workspace.clone(),
+                focus_manager,
+                request_broker,
+                WindowId::Main,
+                project_id.clone(),
+                "/tmp/project".to_string(),
+                Vec::new(),
+                Arc::new(TestBackend),
+                terminals,
+                new_active_drag(),
+                None,
+                cx,
+            )
+        });
+
+        let notifications = Rc::new(Cell::new(0));
+        let observer_notifications = notifications.clone();
+        let _observer = cx.new(|cx| {
+            cx.observe(&container, move |_, _, _| {
+                observer_notifications.set(observer_notifications.get() + 1);
+            })
+            .detach();
+        });
+
+        workspace.update(cx, |workspace, cx| {
+            workspace.add_terminal(&mut FocusManager::new(), &project_id, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            notifications.get(),
+            1,
+            "creating a terminal must repaint the cached layout tree",
+        );
+
+        workspace.update(cx, |workspace, cx| {
+            workspace.close_terminal(&project_id, &[1], cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            notifications.get(),
+            2,
+            "closing a terminal must repaint the cached layout tree",
+        );
     }
 }

--- a/crates/okena-layout/src/lib.rs
+++ b/crates/okena-layout/src/lib.rs
@@ -481,6 +481,8 @@ impl LayoutNode {
     }
 
     /// Remove a child node at the given path.
+    /// For split parents, transfers the removed weight to the next sibling, or
+    /// the previous sibling when removing the last child.
     /// If the parent has only one child left after removal, collapses the parent to that child.
     /// Returns the removed node, or None if the path is invalid.
     pub fn remove_at_path(&mut self, path: &[usize]) -> Option<LayoutNode> {
@@ -501,7 +503,14 @@ impl LayoutNode {
                 }
                 let removed = children.remove(child_index);
                 if child_index < sizes.len() {
-                    sizes.remove(child_index);
+                    let removed_size = sizes.remove(child_index);
+                    if !sizes.is_empty() {
+                        // Expand the next sibling, or the previous sibling when the
+                        // removed pane was last. This makes split + close restore the
+                        // original pane's share instead of shrinking it every cycle.
+                        let recipient_index = child_index.min(sizes.len() - 1);
+                        sizes[recipient_index] += removed_size;
+                    }
                 }
                 if children.len() == 1 {
                     let remaining = children.remove(0);
@@ -552,22 +561,6 @@ impl LayoutNode {
                 }
             }
 
-        // Sizes are relative weights — the tiny-pair threshold is 10% of the total
-        // sum so the check works regardless of overall scale.
-        if let LayoutNode::Split { sizes, children, .. } = self {
-            let has_invalid = sizes.iter().any(|s| *s <= 0.0 || !s.is_finite());
-            let total: f32 = sizes.iter().sum();
-            let min_resize = total * 0.1;
-            let has_tiny_pair = sizes.windows(2).any(|w| w[0] + w[1] <= min_resize);
-            if has_invalid || has_tiny_pair {
-                log::warn!("Layout has invalid/too-small sizes {:?}, resetting to equal", sizes);
-                let equal = 100.0 / children.len() as f32;
-                for s in sizes.iter_mut() {
-                    *s = equal;
-                }
-            }
-        }
-
         let should_unwrap = match self {
             LayoutNode::Split { children, .. } | LayoutNode::Tabs { children, .. } => children.len() <= 1,
             _ => false,
@@ -612,6 +605,24 @@ impl LayoutNode {
 
                 *children = new_children;
                 *sizes = new_sizes;
+            }
+        }
+
+        // Sizes are relative weights — the tiny-pair threshold is 10% of the total
+        // sum so the check works regardless of overall scale. Validate after
+        // flattening because flattening a same-direction split can create a tiny
+        // adjacent pair even when the parent sizes were valid.
+        if let LayoutNode::Split { sizes, children, .. } = self {
+            let has_invalid = sizes.iter().any(|s| *s <= 0.0 || !s.is_finite());
+            let total: f32 = sizes.iter().sum();
+            let min_resize = total * 0.1;
+            let has_tiny_pair = sizes.windows(2).any(|w| w[0] + w[1] <= min_resize);
+            if has_invalid || has_tiny_pair {
+                log::warn!("Layout has invalid/too-small sizes {:?}, resetting to equal", sizes);
+                let equal = 100.0 / children.len() as f32;
+                for s in sizes.iter_mut() {
+                    *s = equal;
+                }
             }
         }
     }
@@ -1491,6 +1502,33 @@ mod tests {
     }
 
     #[test]
+    fn normalize_rechecks_tiny_sizes_after_flattening_same_direction_split() {
+        let mut node = LayoutNode::Split {
+            direction: SplitDirection::Horizontal,
+            sizes: vec![33.333_332, 1.041_666_6],
+            children: vec![
+                terminal("t1"),
+                LayoutNode::Split {
+                    direction: SplitDirection::Horizontal,
+                    sizes: vec![50.0, 50.0],
+                    children: vec![terminal("t2"), terminal("t3")],
+                },
+            ],
+        };
+
+        node.normalize();
+
+        let LayoutNode::Split { sizes, children, .. } = node else {
+            panic!("Expected flattened split");
+        };
+        assert_eq!(children.len(), 3);
+        let expected = 100.0 / 3.0;
+        for size in sizes {
+            assert!((size - expected).abs() < f32::EPSILON);
+        }
+    }
+
+    #[test]
     fn normalize_valid_sizes_untouched() {
         let mut node = LayoutNode::Split {
             direction: SplitDirection::Horizontal,
@@ -1566,7 +1604,7 @@ mod tests {
         match &node {
             LayoutNode::Split { children, sizes, .. } => {
                 assert_eq!(children.len(), 2);
-                assert_eq!(sizes.len(), 2);
+                assert_eq!(sizes.as_slice(), &[33.0, 67.0]);
             }
             _ => panic!("Expected split with 2 children"),
         }

--- a/crates/okena-layout/src/lib.rs
+++ b/crates/okena-layout/src/lib.rs
@@ -17,6 +17,15 @@ fn default_zoom_level() -> f32 {
     1.0
 }
 
+/// Split weights are shares of 100, one per child. Every mutation goes through
+/// [`LayoutNode::normalize`], which restores that invariant.
+pub const TOTAL_PANE_WEIGHT: f32 = 100.0;
+
+/// Smallest share a pane may hold, matching the 5% floor the resize drag clamps
+/// to — so any layout the user can build by dragging survives normalization.
+/// Splits with more than 20 children fall back to an equal share instead.
+pub const MIN_PANE_WEIGHT: f32 = 5.0;
+
 /// Recursive layout tree node
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
@@ -504,12 +513,9 @@ impl LayoutNode {
                 let removed = children.remove(child_index);
                 if child_index < sizes.len() {
                     let removed_size = sizes.remove(child_index);
-                    if !sizes.is_empty() {
-                        // Expand the next sibling, or the previous sibling when the
-                        // removed pane was last. This makes split + close restore the
-                        // original pane's share instead of shrinking it every cycle.
-                        let recipient_index = child_index.min(sizes.len() - 1);
-                        sizes[recipient_index] += removed_size;
+                    if let Some(recipient) = Self::weight_recipient(children, child_index)
+                        && let Some(slot) = sizes.get_mut(recipient) {
+                        *slot += removed_size;
                     }
                 }
                 if children.len() == 1 {
@@ -535,6 +541,124 @@ impl LayoutNode {
         }
     }
 
+    /// Append `node` as a new pane of this split, giving it an equal share of
+    /// the new total and scaling the existing weights down proportionally so
+    /// their ratios survive.
+    ///
+    /// Returns `false` when `self` is not a `Split`, leaving it untouched — the
+    /// caller decides how to wrap a bare terminal or a tab group.
+    pub fn push_split_child(&mut self, node: LayoutNode) -> bool {
+        let LayoutNode::Split { children, sizes, .. } = self else {
+            return false;
+        };
+        Self::sanitize_weights(sizes, children.len());
+
+        let share = TOTAL_PANE_WEIGHT / (children.len() + 1) as f32;
+        let keep = 1.0 - share / TOTAL_PANE_WEIGHT;
+        for size in sizes.iter_mut() {
+            *size *= keep;
+        }
+        children.push(node);
+        sizes.push(share);
+        true
+    }
+
+    /// Pick which sibling absorbs a removed pane's weight.
+    ///
+    /// Prefers the pane *before* the removed one. `split_terminal` always
+    /// inserts the new pane directly after the one it split, so crediting the
+    /// previous sibling is what makes split-then-close restore the original
+    /// layout exactly; crediting the next one instead shrank the pane you split
+    /// from on every cycle.
+    ///
+    /// Hidden panes are skipped in both directions: the renderer normalizes
+    /// over visible children only, so weight parked on a minimized or detached
+    /// pane leaves the visible budget entirely and comes back oversized when
+    /// that pane is restored.
+    ///
+    /// `children` is already post-removal, so the previous sibling sits at
+    /// `removed_index - 1` and the next one at `removed_index`.
+    fn weight_recipient(children: &[LayoutNode], removed_index: usize) -> Option<usize> {
+        if children.is_empty() {
+            return None;
+        }
+        let split_at = removed_index.min(children.len());
+
+        if let Some(previous) = children[..split_at]
+            .iter()
+            .rposition(|child| !child.is_all_hidden())
+        {
+            return Some(previous);
+        }
+        if let Some(offset) = children[split_at..]
+            .iter()
+            .position(|child| !child.is_all_hidden())
+        {
+            return Some(split_at + offset);
+        }
+        // Every sibling is hidden — keep the weight in the vec anyway so the
+        // total is preserved for whenever one of them is restored.
+        Some(split_at.min(children.len() - 1))
+    }
+
+    /// Bring a split's weights back to the model's invariant: exactly one
+    /// finite, positive weight per child, summing to 100, none below
+    /// [`MIN_PANE_WEIGHT`].
+    ///
+    /// Renormalizing to a fixed total is what makes the scale uniform — callers
+    /// that write weights on a 0..1 scale converge here instead of rendering a
+    /// pane at ~1% next to a 0..100 sibling.
+    ///
+    /// This replaces an older repair that reset *every* weight in the split to
+    /// equal as soon as it saw an adjacent pair summing under 10% of the total.
+    /// That discarded deliberate layouts wholesale, and because the resize drag
+    /// clamps each pane to 5%, two panes dragged to the minimum landed exactly
+    /// on the reject threshold — the smallest arrangement the UI let you build
+    /// was wiped by the next mutation. Rescaling keeps the user's proportions.
+    fn sanitize_weights(sizes: &mut Vec<f32>, child_count: usize) {
+        if child_count == 0 {
+            sizes.clear();
+            return;
+        }
+        let equal = TOTAL_PANE_WEIGHT / child_count as f32;
+
+        sizes.truncate(child_count);
+        while sizes.len() < child_count {
+            sizes.push(equal);
+        }
+
+        // A non-finite or non-positive weight means the vector can't be trusted
+        // — fall back to an equal split rather than trying to honour garbage.
+        if sizes.iter().any(|size| !size.is_finite() || *size <= 0.0) {
+            log::warn!("Layout has invalid split sizes {:?}, resetting to equal", sizes);
+            sizes.fill(equal);
+            return;
+        }
+
+        let total: f32 = sizes.iter().sum();
+        let scale = TOTAL_PANE_WEIGHT / total;
+        for size in sizes.iter_mut() {
+            *size *= scale;
+        }
+
+        // Raise anything under the floor, taking the difference from the panes
+        // that have room in proportion to their surplus. The total stays 100.
+        let floor = MIN_PANE_WEIGHT.min(equal);
+        let deficit: f32 = sizes.iter().map(|size| (floor - *size).max(0.0)).sum();
+        if deficit <= 0.0 {
+            return;
+        }
+        let surplus: f32 = sizes.iter().map(|size| (*size - floor).max(0.0)).sum();
+        if surplus <= deficit {
+            sizes.fill(equal);
+            return;
+        }
+        let keep = (surplus - deficit) / surplus;
+        for size in sizes.iter_mut() {
+            *size = floor + (*size - floor).max(0.0) * keep;
+        }
+    }
+
     /// Normalize the layout tree in-place:
     /// - Flatten nested splits with the same direction (merging sizes proportionally)
     /// - Unwrap splits/tabs with a single child
@@ -553,13 +677,12 @@ impl LayoutNode {
             *active_tab = (*active_tab).min(children.len().saturating_sub(1));
         }
 
-        if let LayoutNode::Split { sizes, children, .. } = self
-            && sizes.len() != children.len() {
-                sizes.truncate(children.len());
-                while sizes.len() < children.len() {
-                    sizes.push(100.0 / children.len() as f32);
-                }
-            }
+        // Reconcile lengths and scale BEFORE flattening: the flatten below
+        // indexes `sizes[i]` per child and divides the parent slot across the
+        // grandchildren, so it needs one sane weight per child to work from.
+        if let LayoutNode::Split { sizes, children, .. } = self {
+            Self::sanitize_weights(sizes, children.len());
+        }
 
         let should_unwrap = match self {
             LayoutNode::Split { children, .. } | LayoutNode::Tabs { children, .. } => children.len() <= 1,
@@ -608,22 +731,11 @@ impl LayoutNode {
             }
         }
 
-        // Sizes are relative weights — the tiny-pair threshold is 10% of the total
-        // sum so the check works regardless of overall scale. Validate after
-        // flattening because flattening a same-direction split can create a tiny
-        // adjacent pair even when the parent sizes were valid.
+        // Re-apply the invariant after flattening: splitting a parent slot
+        // across grandchildren can push a pane under the floor even when both
+        // the parent and child weights were fine on their own.
         if let LayoutNode::Split { sizes, children, .. } = self {
-            let has_invalid = sizes.iter().any(|s| *s <= 0.0 || !s.is_finite());
-            let total: f32 = sizes.iter().sum();
-            let min_resize = total * 0.1;
-            let has_tiny_pair = sizes.windows(2).any(|w| w[0] + w[1] <= min_resize);
-            if has_invalid || has_tiny_pair {
-                log::warn!("Layout has invalid/too-small sizes {:?}, resetting to equal", sizes);
-                let equal = 100.0 / children.len() as f32;
-                for s in sizes.iter_mut() {
-                    *s = equal;
-                }
-            }
+            Self::sanitize_weights(sizes, children.len());
         }
     }
 
@@ -990,7 +1102,7 @@ impl LayoutNode {
 
 #[cfg(test)]
 mod tests {
-    use super::{LayoutNode, SplitDirection};
+    use super::{LayoutNode, SplitDirection, MIN_PANE_WEIGHT, TOTAL_PANE_WEIGHT};
     use okena_core::shell::ShellType;
     use std::collections::HashSet;
 
@@ -1483,7 +1595,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_tiny_adjacent_sizes_reset_to_equal() {
+    fn normalize_raises_a_tiny_pane_to_the_floor_and_keeps_the_rest() {
         let mut node = LayoutNode::Split {
             direction: SplitDirection::Horizontal,
             sizes: vec![90.0, 1.0, 9.0],
@@ -1492,10 +1604,14 @@ mod tests {
         node.normalize();
         if let LayoutNode::Split { sizes, .. } = &node {
             assert_eq!(sizes.len(), 3);
-            let expected = 100.0 / 3.0;
-            for s in sizes {
-                assert!((*s - expected).abs() < f32::EPSILON);
-            }
+            // The pane under the floor is raised to it and the two with room
+            // give up the difference in proportion to their surplus — so the
+            // layout still reads as "one big pane, one small, one minimum".
+            // The old repair reset all three to 33.3 and threw it away.
+            assert!((sizes[1] - MIN_PANE_WEIGHT).abs() < 1e-3, "got {:?}", sizes);
+            assert!(sizes[0] > sizes[2] && sizes[2] > sizes[1], "got {:?}", sizes);
+            assert!(sizes[0] > 80.0, "the dominant pane stays dominant: {:?}", sizes);
+            assert!((sizes.iter().sum::<f32>() - TOTAL_PANE_WEIGHT).abs() < 1e-3);
         } else {
             panic!("Expected split");
         }
@@ -1522,10 +1638,12 @@ mod tests {
             panic!("Expected flattened split");
         };
         assert_eq!(children.len(), 3);
-        let expected = 100.0 / 3.0;
-        for size in sizes {
-            assert!((size - expected).abs() < f32::EPSILON);
-        }
+        // Flattening divides the nested split's slot across its grandchildren,
+        // which can drop them under the floor. They get raised to it and the
+        // big pane absorbs the cost — nobody's layout is discarded.
+        assert!((sizes[1] - MIN_PANE_WEIGHT).abs() < 1e-3, "got {:?}", sizes);
+        assert!((sizes[2] - MIN_PANE_WEIGHT).abs() < 1e-3, "got {:?}", sizes);
+        assert!((sizes.iter().sum::<f32>() - TOTAL_PANE_WEIGHT).abs() < 1e-3);
     }
 
     #[test]
@@ -1545,17 +1663,38 @@ mod tests {
     }
 
     #[test]
-    fn normalize_relative_sizes_untouched() {
+    fn normalize_rescales_relative_sizes_to_the_standard_total() {
+        let original = [26.8_f32, 9.47, 17.6];
         let mut node = LayoutNode::Split {
             direction: SplitDirection::Horizontal,
-            sizes: vec![26.8, 9.47, 17.6],
+            sizes: original.to_vec(),
             children: vec![terminal("t1"), terminal("t2"), terminal("t3")],
         };
         node.normalize();
         if let LayoutNode::Split { sizes, .. } = &node {
-            assert!((sizes[0] - 26.8).abs() < f32::EPSILON);
-            assert!((sizes[1] - 9.47).abs() < f32::EPSILON);
-            assert!((sizes[2] - 17.6).abs() < f32::EPSILON);
+            // Weights are shares of 100 whatever scale the writer used, so a
+            // vec written on one scale can never render against another.
+            assert!((sizes.iter().sum::<f32>() - TOTAL_PANE_WEIGHT).abs() < 1e-3);
+            let total: f32 = original.iter().sum();
+            for (size, source) in sizes.iter().zip(original) {
+                let expected = source / total * TOTAL_PANE_WEIGHT;
+                assert!((size - expected).abs() < 1e-3, "got {:?}", sizes);
+            }
+        } else {
+            panic!("Expected split");
+        }
+    }
+
+    #[test]
+    fn normalize_converges_weights_written_on_a_fractional_scale() {
+        let mut node = LayoutNode::Split {
+            direction: SplitDirection::Horizontal,
+            sizes: vec![0.25, 0.75],
+            children: vec![terminal("t1"), terminal("t2")],
+        };
+        node.normalize();
+        if let LayoutNode::Split { sizes, .. } = &node {
+            assert_eq!(sizes.as_slice(), &[25.0, 75.0]);
         } else {
             panic!("Expected split");
         }
@@ -1604,7 +1743,45 @@ mod tests {
         match &node {
             LayoutNode::Split { children, sizes, .. } => {
                 assert_eq!(children.len(), 2);
-                assert_eq!(sizes.as_slice(), &[33.0, 67.0]);
+                assert_eq!(
+                    sizes.as_slice(),
+                    &[66.0, 34.0],
+                    "the freed weight goes to the pane before it — the one a split would have grown from",
+                );
+            }
+            _ => panic!("Expected split with 2 children"),
+        }
+    }
+
+    #[test]
+    fn remove_at_path_credits_the_next_pane_when_removing_the_first() {
+        let mut node = LayoutNode::Split {
+            direction: SplitDirection::Horizontal,
+            sizes: vec![33.0, 33.0, 34.0],
+            children: vec![terminal("t1"), terminal("t2"), terminal("t3")],
+        };
+        node.remove_at_path(&[0]);
+        match &node {
+            LayoutNode::Split { sizes, .. } => {
+                assert_eq!(sizes.as_slice(), &[66.0, 34.0], "no previous sibling to credit");
+            }
+            _ => panic!("Expected split with 2 children"),
+        }
+    }
+
+    #[test]
+    fn remove_at_path_skips_hidden_siblings_when_crediting_weight() {
+        let mut node = LayoutNode::Split {
+            direction: SplitDirection::Horizontal,
+            sizes: vec![25.0, 25.0, 50.0],
+            children: vec![terminal("t1"), terminal_minimized("t2"), terminal("t3")],
+        };
+        // Removing t3 would positionally credit the minimized t2, parking the
+        // weight where the renderer cannot see it. Skip to the visible t1.
+        node.remove_at_path(&[2]);
+        match &node {
+            LayoutNode::Split { sizes, .. } => {
+                assert_eq!(sizes.as_slice(), &[75.0, 25.0]);
             }
             _ => panic!("Expected split with 2 children"),
         }

--- a/crates/okena-views-terminal/src/layout/layout_container.rs
+++ b/crates/okena-views-terminal/src/layout/layout_container.rs
@@ -12,7 +12,9 @@ use crate::layout::terminal_pane::TerminalPane;
 use okena_terminal::TerminalsRegistry;
 use okena_workspace::focus::FocusManager;
 use okena_workspace::request_broker::RequestBroker;
-use okena_workspace::state::{LayoutNode, SplitDirection, WindowId, Workspace};
+use okena_workspace::state::{
+    LayoutNode, ProjectLayoutMode, SplitDirection, WindowId, Workspace,
+};
 use gpui::*;
 use gpui::prelude::*;
 use std::cell::RefCell;
@@ -32,6 +34,8 @@ pub struct LayoutContainer<D: ActionDispatch> {
     pub(super) project_id: String,
     pub(super) project_path: String,
     pub(super) layout_path: Vec<usize>,
+    observed_layout: Option<LayoutNode>,
+    observed_layout_mode: ProjectLayoutMode,
     pub(super) backend: Arc<dyn TerminalBackend>,
     pub(super) terminals: TerminalsRegistry,
     terminal_pane: Option<Entity<TerminalPane<D>>>,
@@ -62,7 +66,32 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
         terminals: TerminalsRegistry,
         active_drag: ActiveDrag,
         action_dispatcher: Option<D>,
+        cx: &mut Context<Self>,
     ) -> Self {
+        let (observed_layout, observed_layout_mode) = {
+            let workspace = workspace.read(cx);
+            let layout = workspace
+                .project(&project_id)
+                .and_then(|project| project.layout.as_ref())
+                .and_then(|layout| layout.get_at_path(&layout_path))
+                .cloned();
+            (layout, workspace.project_layout_mode(window_id))
+        };
+
+        cx.observe(&workspace, |this, workspace, cx| {
+            let workspace = workspace.read(cx);
+            let next_layout = this.get_layout(workspace).cloned();
+            let next_layout_mode = workspace.project_layout_mode(this.window_id);
+            if next_layout != this.observed_layout
+                || next_layout_mode != this.observed_layout_mode
+            {
+                this.observed_layout = next_layout;
+                this.observed_layout_mode = next_layout_mode;
+                cx.notify();
+            }
+        })
+        .detach();
+
         Self {
             workspace,
             focus_manager,
@@ -71,6 +100,8 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
             project_id,
             project_path,
             layout_path,
+            observed_layout,
+            observed_layout_mode,
             backend,
             terminals,
             terminal_pane: None,
@@ -435,7 +466,7 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                 .child_containers
                 .entry(child_path.clone())
                 .or_insert_with(|| {
-                    cx.new(|_cx| {
+                    cx.new(|cx| {
                         LayoutContainer::new(
                             self.workspace.clone(),
                             self.focus_manager.clone(),
@@ -448,6 +479,7 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                             self.terminals.clone(),
                             self.active_drag.clone(),
                             self.action_dispatcher.clone(),
+                            cx,
                         )
                     })
                 })
@@ -510,7 +542,7 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                 .child_containers
                 .entry(child_path.clone())
                 .or_insert_with(|| {
-                    cx.new(|_cx| {
+                    cx.new(|cx| {
                         LayoutContainer::new(
                             self.workspace.clone(),
                             self.focus_manager.clone(),
@@ -523,6 +555,7 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                             self.terminals.clone(),
                             self.active_drag.clone(),
                             self.action_dispatcher.clone(),
+                            cx,
                         )
                     })
                 })

--- a/crates/okena-views-terminal/src/layout/layout_container.rs
+++ b/crates/okena-views-terminal/src/layout/layout_container.rs
@@ -141,6 +141,17 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
         };
 
         if needs_new_pane {
+            // Drop the outgoing pane's claim on its old terminal first. Closing
+            // a pane shifts every later sibling down one index, so containers —
+            // which are keyed by layout path — get reused for a *different*
+            // terminal and rebuild their pane here. `shared_resize_target` sizes
+            // a terminal to the MINIMUM across its registered viewers, so a
+            // viewer left behind by the replaced pane pins the survivor's PTY to
+            // the pre-close cols/rows for as long as it stays registered.
+            if let Some(pane) = self.terminal_pane.take() {
+                pane.update(cx, |pane, cx| pane.deregister_resize_viewer(cx));
+            }
+
             let workspace = self.workspace.clone();
             let focus_manager = self.focus_manager.clone();
             let request_broker = self.request_broker.clone();

--- a/crates/okena-views-terminal/src/layout/tabs/mod.rs
+++ b/crates/okena-views-terminal/src/layout/tabs/mod.rs
@@ -225,7 +225,7 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                 .child_containers
                 .entry(child_path.clone())
                 .or_insert_with(|| {
-                    cx.new(|_cx| {
+                    cx.new(|cx| {
                         LayoutContainer::new(
                             self.workspace.clone(),
                             self.focus_manager.clone(),
@@ -238,6 +238,7 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                             self.terminals.clone(),
                             self.active_drag.clone(),
                             self.action_dispatcher.clone(),
+                            cx,
                         )
                     })
                 })
@@ -302,7 +303,7 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                     let container = self.child_containers
                         .entry(child_path.clone())
                         .or_insert_with(|| {
-                            cx.new(|_cx| {
+                            cx.new(|cx| {
                                 LayoutContainer::new(
                                     self.workspace.clone(),
                                     self.focus_manager.clone(),
@@ -315,6 +316,7 @@ impl<D: ActionDispatch + Send + Sync> LayoutContainer<D> {
                                     self.terminals.clone(),
                                     self.active_drag.clone(),
                                     self.action_dispatcher.clone(),
+                                    cx,
                                 )
                             })
                         })

--- a/crates/okena-workspace/src/actions/layout/close.rs
+++ b/crates/okena-workspace/src/actions/layout/close.rs
@@ -46,6 +46,13 @@ impl Workspace {
                     {
                         *active_tab = (prev_active_tab - 1).min(children.len().saturating_sub(1));
                     }
+                    // Reconcile structure and weights now, like every other
+                    // layout mutation does. Without this a close could leave a
+                    // same-direction split nested inside its parent; nothing
+                    // flattened it until the next split or the next app launch,
+                    // so the resulting reflow surfaced long after the action
+                    // that caused it.
+                    layout.normalize();
                     self.notify_data(cx);
                     return self.cleanup_orphaned_metadata(project_id);
                 }

--- a/crates/okena-workspace/src/actions/layout/tests_gpui.rs
+++ b/crates/okena-workspace/src/actions/layout/tests_gpui.rs
@@ -52,6 +52,16 @@ fn make_workspace_data(projects: Vec<ProjectData>, order: Vec<&str>) -> Workspac
     }
 }
 
+fn terminal(id: &str) -> LayoutNode {
+    LayoutNode::Terminal {
+        terminal_id: Some(id.to_string()),
+        minimized: false,
+        detached: false,
+        shell_type: ShellType::Default,
+        zoom_level: 1.0,
+    }
+}
+
 #[gpui::test]
 fn test_split_terminal_gpui(cx: &mut gpui::TestAppContext) {
     let data = make_workspace_data(vec![make_project("p1")], vec!["p1"]);
@@ -136,6 +146,41 @@ fn test_close_terminal_gpui(cx: &mut gpui::TestAppContext) {
         let layout = ws.project("p1").unwrap().layout.as_ref().unwrap();
         // After closing child 0, sibling (t2) should replace the split
         assert!(matches!(layout, LayoutNode::Terminal { terminal_id: Some(id), .. } if id == "t2"));
+    });
+}
+
+#[gpui::test]
+fn split_close_cycle_preserves_existing_pane_sizes(cx: &mut gpui::TestAppContext) {
+    let mut project = make_project("p1");
+    project.layout = Some(LayoutNode::Split {
+        direction: SplitDirection::Horizontal,
+        sizes: vec![33.333_332, 16.666_666],
+        children: vec![terminal("t1"), terminal("t2")],
+    });
+    let data = make_workspace_data(vec![project], vec!["p1"]);
+    let workspace = cx.new(|_cx| Workspace::new(data));
+
+    for _ in 0..4 {
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            ws.split_terminal(
+                &mut FocusManager::new(),
+                "p1",
+                &[1],
+                SplitDirection::Horizontal,
+                cx,
+            );
+            ws.close_terminal("p1", &[2], cx);
+        });
+    }
+
+    workspace.read_with(cx, |ws: &Workspace, _cx| {
+        let layout = ws.project("p1").unwrap().layout.as_ref().unwrap();
+        let LayoutNode::Split { sizes, children, .. } = layout else {
+            panic!("Expected split after split/close cycles");
+        };
+        assert_eq!(children.len(), 2);
+        assert!((sizes[0] - 33.333_332).abs() < f32::EPSILON);
+        assert!((sizes[1] - 16.666_666).abs() < f32::EPSILON);
     });
 }
 

--- a/crates/okena-workspace/src/actions/layout/tests_gpui.rs
+++ b/crates/okena-workspace/src/actions/layout/tests_gpui.rs
@@ -149,12 +149,21 @@ fn test_close_terminal_gpui(cx: &mut gpui::TestAppContext) {
     });
 }
 
-#[gpui::test]
-fn split_close_cycle_preserves_existing_pane_sizes(cx: &mut gpui::TestAppContext) {
+/// Split a pane, close the pane that split created, and the layout you started
+/// from must come back — whichever pane you split. `split_terminal` inserts the
+/// new pane directly after its source, so the weight has to travel back to the
+/// pane *before* the one being closed. Crediting the next sibling instead let
+/// every cycle shave the source pane (50 -> 25 -> 12.5 -> …) until the layout
+/// bore no resemblance to what the user built.
+fn assert_split_close_cycle_is_reversible(
+    cx: &mut gpui::TestAppContext,
+    split_at: usize,
+    expected: [f32; 2],
+) {
     let mut project = make_project("p1");
     project.layout = Some(LayoutNode::Split {
         direction: SplitDirection::Horizontal,
-        sizes: vec![33.333_332, 16.666_666],
+        sizes: vec![66.666_664, 33.333_332],
         children: vec![terminal("t1"), terminal("t2")],
     });
     let data = make_workspace_data(vec![project], vec!["p1"]);
@@ -165,11 +174,12 @@ fn split_close_cycle_preserves_existing_pane_sizes(cx: &mut gpui::TestAppContext
             ws.split_terminal(
                 &mut FocusManager::new(),
                 "p1",
-                &[1],
+                &[split_at],
                 SplitDirection::Horizontal,
                 cx,
             );
-            ws.close_terminal("p1", &[2], cx);
+            // The new pane always lands directly after the one it split.
+            ws.close_terminal("p1", &[split_at + 1], cx);
         });
     }
 
@@ -179,8 +189,54 @@ fn split_close_cycle_preserves_existing_pane_sizes(cx: &mut gpui::TestAppContext
             panic!("Expected split after split/close cycles");
         };
         assert_eq!(children.len(), 2);
-        assert!((sizes[0] - 33.333_332).abs() < f32::EPSILON);
-        assert!((sizes[1] - 16.666_666).abs() < f32::EPSILON);
+        for (size, want) in sizes.iter().zip(expected) {
+            assert!(
+                (size - want).abs() < 0.01,
+                "split/close at index {split_at} drifted: {sizes:?}",
+            );
+        }
+    });
+}
+
+#[gpui::test]
+fn split_close_cycle_is_reversible_on_the_last_pane(cx: &mut gpui::TestAppContext) {
+    assert_split_close_cycle_is_reversible(cx, 1, [66.666_664, 33.333_332]);
+}
+
+#[gpui::test]
+fn split_close_cycle_is_reversible_on_a_leading_pane(cx: &mut gpui::TestAppContext) {
+    assert_split_close_cycle_is_reversible(cx, 0, [66.666_664, 33.333_332]);
+}
+
+#[gpui::test]
+fn adding_a_terminal_keeps_the_existing_panes_in_proportion(cx: &mut gpui::TestAppContext) {
+    let mut project = make_project("p1");
+    project.layout = Some(LayoutNode::Split {
+        direction: SplitDirection::Horizontal,
+        sizes: vec![70.0, 30.0],
+        children: vec![terminal("t1"), terminal("t2")],
+    });
+    let data = make_workspace_data(vec![project], vec!["p1"]);
+    let workspace = cx.new(|_cx| Workspace::new(data));
+
+    workspace.update(cx, |ws: &mut Workspace, cx| {
+        ws.add_terminal(&mut FocusManager::new(), "p1", cx);
+    });
+
+    workspace.read_with(cx, |ws: &Workspace, _cx| {
+        let layout = ws.project("p1").unwrap().layout.as_ref().unwrap();
+        let LayoutNode::Split { sizes, children, .. } = layout else {
+            panic!("Expected the new pane to join the root split");
+        };
+        // Previously this re-wrapped the whole tree in a fresh 50/50 split, so
+        // t1 and t2 were squeezed into one half — 35/15 — while the single new
+        // pane took the other 50.
+        assert_eq!(children.len(), 3);
+        assert!((sizes[2] - 100.0 / 3.0).abs() < 0.01, "got {sizes:?}");
+        assert!(
+            (sizes[0] / sizes[1] - 70.0 / 30.0).abs() < 0.01,
+            "existing panes must keep their ratio: {sizes:?}",
+        );
     });
 }
 

--- a/crates/okena-workspace/src/actions/layout/tests_simulate.rs
+++ b/crates/okena-workspace/src/actions/layout/tests_simulate.rs
@@ -152,7 +152,7 @@ fn test_close_terminal_from_3_child_split() {
 #[test]
 fn test_close_terminal_from_3_child_redistributes_removed_weight() {
     // Verify that closing a child from a 3-child split keeps sizes in sync
-    // and gives the removed weight to the next sibling.
+    // and gives the removed weight to the pane before it.
     let mut layout = LayoutNode::Split {
         direction: SplitDirection::Horizontal,
         sizes: vec![25.0, 50.0, 25.0],
@@ -165,12 +165,13 @@ fn test_close_terminal_from_3_child_redistributes_removed_weight() {
         LayoutNode::Split { children, sizes, .. } => {
             assert_eq!(children.len(), 2);
             assert_eq!(sizes.len(), 2);
-            assert_eq!(sizes, &vec![25.0, 75.0]);
+            assert_eq!(sizes, &vec![75.0, 25.0]);
         }
         _ => panic!("Expected split with 2 children"),
     }
 
-    // Close the first terminal (index 0) — should collapse to single terminal
+    // Close the first terminal (index 0) — nothing precedes it, so the weight
+    // falls through to the next pane.
     let mut layout = LayoutNode::Split {
         direction: SplitDirection::Vertical,
         sizes: vec![30.0, 40.0, 30.0],

--- a/crates/okena-workspace/src/actions/layout/tests_simulate.rs
+++ b/crates/okena-workspace/src/actions/layout/tests_simulate.rs
@@ -150,9 +150,9 @@ fn test_close_terminal_from_3_child_split() {
 }
 
 #[test]
-fn test_close_terminal_from_3_child_sizes_consistent() {
+fn test_close_terminal_from_3_child_redistributes_removed_weight() {
     // Verify that closing a child from a 3-child split keeps sizes in sync
-    // and that the remaining sizes sum correctly
+    // and gives the removed weight to the next sibling.
     let mut layout = LayoutNode::Split {
         direction: SplitDirection::Horizontal,
         sizes: vec![25.0, 50.0, 25.0],
@@ -165,8 +165,7 @@ fn test_close_terminal_from_3_child_sizes_consistent() {
         LayoutNode::Split { children, sizes, .. } => {
             assert_eq!(children.len(), 2);
             assert_eq!(sizes.len(), 2);
-            // Sizes should be [25.0, 25.0] — the middle entry was removed
-            assert_eq!(sizes, &vec![25.0, 25.0]);
+            assert_eq!(sizes, &vec![25.0, 75.0]);
         }
         _ => panic!("Expected split with 2 children"),
     }
@@ -182,7 +181,7 @@ fn test_close_terminal_from_3_child_sizes_consistent() {
         LayoutNode::Split { children, sizes, .. } => {
             assert_eq!(children.len(), 2);
             assert_eq!(sizes.len(), 2);
-            assert_eq!(sizes, &vec![40.0, 30.0]);
+            assert_eq!(sizes, &vec![70.0, 30.0]);
         }
         _ => panic!("Expected split with 2 children"),
     }

--- a/crates/okena-workspace/src/actions/project.rs
+++ b/crates/okena-workspace/src/actions/project.rs
@@ -256,16 +256,33 @@ impl Workspace {
         self.register_hook_results(hook_results, cx);
     }
 
-    /// Add a new terminal to a project by splitting the root layout
+    /// Place a new pane in an existing layout.
+    ///
+    /// When the root is already a split the pane joins it as one more child,
+    /// taking an equal share while the existing panes keep their proportions.
+    /// This used to re-wrap the *whole* layout in a fresh 50/50 split, which
+    /// halved every existing pane on every added terminal — four equal panes
+    /// became four 12.5% panes plus one at 50%.
+    ///
+    /// A bare terminal or a tab group still gets wrapped in a vertical split,
+    /// since neither can take a sibling pane directly.
+    fn add_pane_to_layout(layout: &mut LayoutNode, pane: LayoutNode) {
+        if !layout.push_split_child(pane.clone()) {
+            let existing = layout.clone();
+            *layout = LayoutNode::Split {
+                direction: crate::state::SplitDirection::Vertical,
+                sizes: vec![50.0, 50.0],
+                children: vec![existing, pane],
+            };
+        }
+        layout.normalize();
+    }
+
+    /// Add a new terminal to a project by adding a pane to the root layout
     pub fn add_terminal(&mut self, focus_manager: &mut FocusManager, project_id: &str, cx: &mut impl WorkspaceCx) {
         if let Some(project) = self.project_mut(project_id) {
-            if let Some(ref old_layout) = project.layout {
-                let old_layout = old_layout.clone();
-                project.layout = Some(LayoutNode::Split {
-                    direction: crate::state::SplitDirection::Vertical,
-                    sizes: vec![50.0, 50.0],
-                    children: vec![old_layout, LayoutNode::new_terminal()],
-                });
+            if let Some(layout) = project.layout.as_mut() {
+                Self::add_pane_to_layout(layout, LayoutNode::new_terminal());
             } else {
                 // Project has no layout - create one with a terminal
                 project.layout = Some(LayoutNode::new_terminal());
@@ -292,13 +309,8 @@ impl Workspace {
     ) {
         if let Some(project) = self.project_mut(project_id) {
             let new_node = LayoutNode::new_terminal_with_command(command, env_vars);
-            if let Some(ref old_layout) = project.layout {
-                let old_layout = old_layout.clone();
-                project.layout = Some(LayoutNode::Split {
-                    direction: crate::state::SplitDirection::Vertical,
-                    sizes: vec![50.0, 50.0],
-                    children: vec![old_layout, new_node],
-                });
+            if let Some(layout) = project.layout.as_mut() {
+                Self::add_pane_to_layout(layout, new_node);
             } else {
                 project.layout = Some(new_node);
             }


### PR DESCRIPTION
## Summary
- Fix stale terminal row/column dimensions after creating or closing a terminal.
- Prevent repeated split/close cycles from progressively collapsing every pane except one.
- Recover already-degraded tiny pane weights when the pane is split again.
- Stacked on #157 (`refactorx/full-headless`).

## Changes
- Observe `Workspace` from each `LayoutContainer` and invalidate cached recursive layouts when their subtree or `ProjectLayoutMode` changes.
- Thread GPUI context through root, split, and tab container construction so every cached container participates.
- Transfer a removed split pane's weight to its adjacent survivor, preserving geometry across split/close cycles.
- Validate split weights after flattening same-direction splits so newly exposed tiny pairs reset to usable equal sizes.
- Add regressions for cache invalidation, repeated real split/close actions, adjacent weight redistribution, and recovery from the live degraded layout shape.
- Add no dependencies or manifest changes.

## Test plan
- [x] Focused red/green regressions for cache invalidation and split geometry
- [x] `cargo test -p okena-layout -p okena-workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
