### PR TITLE
perf: reduce idle GUI and daemon CPU

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,10 @@ rust-embed = "8.5"
 default = ["jemalloc", "mimalloc"]
 mimalloc = ["dep:mimalloc"]
 
+# Compile the terminal latency probe into both desktop and headless modes.
+# Runtime collection still requires OKENA_TERMINAL_LATENCY_PROBE=1.
+terminal-latency-probe = ["okena-core/terminal-latency-probe"]
+
 # jemalloc: default on Unix. Shares a small fixed set of arenas across all
 # threads (narenas:N in src/main.rs) instead of mimalloc's per-thread heaps, so
 # okena's ~90 threads don't each pin their own segments — cut anon-heap RSS

--- a/crates/okena-app/src/app/mod.rs
+++ b/crates/okena-app/src/app/mod.rs
@@ -630,21 +630,29 @@ impl Okena {
         terminal_ids: &[String],
         cx: &mut Context<Self>,
     ) {
-        if !self
+        let input_response_ids: Vec<_> = {
+            let registry = self.terminals.lock();
+            terminal_ids
+                .iter()
+                .filter(|terminal_id| {
+                    registry
+                        .get(*terminal_id)
+                        .is_some_and(|terminal| terminal.take_input_repaint_request())
+                })
+                .cloned()
+                .collect()
+        };
+
+        let decision = self
             .terminal_activity_repaints
-            .queue(terminal_ids.iter().cloned())
-        {
+            .queue_activity(terminal_ids.iter().cloned(), input_response_ids);
+        if !decision.immediate.is_empty() {
+            let immediate_ids: Vec<_> = decision.immediate.into_iter().collect();
+            self.present_terminal_activity_repaints(&immediate_ids, cx);
+        }
+        if !decision.start_timer {
             return;
         }
-
-        // Leading edge: normal typed echo is presented immediately after the
-        // first output arrives. Only sustained activity enters the 20 ms cadence.
-        let immediate_ids: Vec<_> = self
-            .terminal_activity_repaints
-            .take_immediate()
-            .into_iter()
-            .collect();
-        self.present_terminal_activity_repaints(&immediate_ids, cx);
 
         cx.spawn(async move |this: WeakEntity<Self>, cx| {
             loop {

--- a/crates/okena-app/src/app/mod.rs
+++ b/crates/okena-app/src/app/mod.rs
@@ -19,10 +19,10 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 /// Repaint-only terminal activity is limited to one app-wide presentation frame.
-/// A ~30 FPS terminal scene keeps interactive output fluid without allowing
+/// A ~50 FPS terminal scene keeps interactive output responsive without allowing
 /// independent TUI animations to drive the same OS window at aggregate rates.
 /// Parsing, notifications, and OSC clipboard replies are intentionally not delayed.
-const TERMINAL_ACTIVITY_REPAINT_INTERVAL: Duration = Duration::from_millis(33);
+const TERMINAL_ACTIVITY_REPAINT_INTERVAL: Duration = Duration::from_millis(20);
 
 #[derive(Default)]
 struct WindowLayoutSaveTracker {
@@ -198,8 +198,8 @@ pub struct Okena {
     /// (`open_extra_window` calls `set_remote_manager` on the new view).
     remote_manager: Entity<RemoteConnectionManager>,
     /// Exact terminal panes dirtied during the current app-wide frame window.
-    /// Keeps parsing/notification handling immediate while all OS windows share
-    /// one repaint cadence under multi-stream terminal activity.
+    /// The idle-to-active edge is presented immediately; sustained activity is
+    /// coalesced while parsing and notification handling remain immediate.
     terminal_activity_repaints: ActivityRepaintBatch<String>,
     /// Sender handed to desktop-notification threads. When a user clicks an
     /// XDG notification, the thread sends a `NotificationJump` here and the
@@ -373,9 +373,9 @@ impl Okena {
         cx.subscribe(&remote_manager, |this, _rm, event, cx| match event {
             RemoteManagerEvent::TerminalActivity(terminal_ids) => {
                 if !terminal_ids.is_empty() {
-                    // Parsing already happened in the manager pump. Keep
-                    // notification/clipboard semantics immediate, but collect
-                    // exact pane ids behind one app-wide display-frame repaint.
+                    // Parsing already happened in the manager pump. Present the
+                    // first output immediately, then coalesce sustained output,
+                    // while notification and clipboard semantics stay immediate.
                     this.queue_terminal_activity_repaints(terminal_ids, cx);
                     this.process_terminal_notifications(terminal_ids, cx);
                     this.process_clipboard_writes(terminal_ids, cx);
@@ -637,33 +637,59 @@ impl Okena {
             return;
         }
 
+        // Leading edge: normal typed echo is presented immediately after the
+        // first output arrives. Only sustained activity enters the 20 ms cadence.
+        let immediate_ids: Vec<_> = self
+            .terminal_activity_repaints
+            .take_immediate()
+            .into_iter()
+            .collect();
+        self.present_terminal_activity_repaints(&immediate_ids, cx);
+
         cx.spawn(async move |this: WeakEntity<Self>, cx| {
-            cx.background_executor()
-                .timer(TERMINAL_ACTIVITY_REPAINT_INTERVAL)
-                .await;
-            let _ = this.update(cx, |this, cx| {
-                let terminal_ids: Vec<_> =
-                    this.terminal_activity_repaints.take().into_iter().collect();
-
-                // Pane and sidebar notifications happen in this single app
-                // update so GPUI can present one frame for all windows rather
-                // than racing independent per-view timers.
-                {
-                    let mut registry = content_pane_registry().lock();
-                    request_registered_content_pane_repaints(&mut registry, &terminal_ids, cx);
+            loop {
+                cx.background_executor()
+                    .timer(TERMINAL_ACTIVITY_REPAINT_INTERVAL)
+                    .await;
+                let keep_scheduled = this
+                    .update(cx, |this, cx| {
+                        let Some(terminal_ids) = this.terminal_activity_repaints.take_scheduled()
+                        else {
+                            return false;
+                        };
+                        let terminal_ids: Vec<_> = terminal_ids.into_iter().collect();
+                        this.present_terminal_activity_repaints(&terminal_ids, cx);
+                        true
+                    })
+                    .unwrap_or(false);
+                if !keep_scheduled {
+                    break;
                 }
-
-                let mut window_views = Vec::with_capacity(1 + this.extra_windows.len());
-                window_views.push(this.main_window.clone());
-                window_views.extend(this.extra_windows.values().cloned());
-                for window_view in window_views {
-                    window_view.update(cx, |window_view, cx| {
-                        window_view.request_sidebar_activity_repaint(cx);
-                    });
-                }
-            });
+            }
         })
         .detach();
+    }
+
+    fn present_terminal_activity_repaints(
+        &mut self,
+        terminal_ids: &[String],
+        cx: &mut Context<Self>,
+    ) {
+        // Pane and sidebar notifications happen in one app update so GPUI can
+        // present one frame for all windows rather than racing per-view timers.
+        {
+            let mut registry = content_pane_registry().lock();
+            request_registered_content_pane_repaints(&mut registry, terminal_ids, cx);
+        }
+
+        let mut window_views = Vec::with_capacity(1 + self.extra_windows.len());
+        window_views.push(self.main_window.clone());
+        window_views.extend(self.extra_windows.values().cloned());
+        for window_view in window_views {
+            window_view.update(cx, |window_view, cx| {
+                window_view.request_sidebar_activity_repaint(cx);
+            });
+        }
     }
 
     /// Mark the app as quitting before the platform loop stops. Called from

--- a/crates/okena-app/src/app/mod.rs
+++ b/crates/okena-app/src/app/mod.rs
@@ -8,14 +8,21 @@ pub use detached_overlays::open_detached_overlay;
 
 use crate::remote_client::manager::{RemoteConnectionManager, RemoteManagerEvent};
 use crate::views::window::{
-    TerminalsRegistry, WindowView, content_pane_registry, notify_registered_panes,
+    TerminalsRegistry, WindowView, content_pane_registry, request_registered_content_pane_repaints,
 };
 use crate::workspace::state::{GlobalWorkspace, WindowId, Workspace, WorkspaceData};
 use gpui::*;
+use okena_ui::activity_repaint::ActivityRepaintBatch;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
+
+/// Repaint-only terminal activity is limited to one app-wide presentation frame.
+/// A ~30 FPS terminal scene keeps interactive output fluid without allowing
+/// independent TUI animations to drive the same OS window at aggregate rates.
+/// Parsing, notifications, and OSC clipboard replies are intentionally not delayed.
+const TERMINAL_ACTIVITY_REPAINT_INTERVAL: Duration = Duration::from_millis(33);
 
 #[derive(Default)]
 struct WindowLayoutSaveTracker {
@@ -190,6 +197,10 @@ pub struct Okena {
     /// be wired with the same singleton main was wired with at startup
     /// (`open_extra_window` calls `set_remote_manager` on the new view).
     remote_manager: Entity<RemoteConnectionManager>,
+    /// Exact terminal panes dirtied during the current app-wide frame window.
+    /// Keeps parsing/notification handling immediate while all OS windows share
+    /// one repaint cadence under multi-stream terminal activity.
+    terminal_activity_repaints: ActivityRepaintBatch<String>,
     /// Sender handed to desktop-notification threads. When a user clicks an
     /// XDG notification, the thread sends a `NotificationJump` here and the
     /// click loop focuses the originating pane. See `app/notifications.rs`.
@@ -312,6 +323,7 @@ impl Okena {
             terminals,
             opened_detached_windows: HashSet::new(),
             remote_manager: remote_manager.clone(),
+            terminal_activity_repaints: ActivityRepaintBatch::default(),
             notification_jump_tx,
             spawned_daemon,
             preserve_daemon_on_quit: false,
@@ -361,14 +373,12 @@ impl Okena {
         cx.subscribe(&remote_manager, |this, _rm, event, cx| match event {
             RemoteManagerEvent::TerminalActivity(terminal_ids) => {
                 if !terminal_ids.is_empty() {
-                    // One app-wide fan-out refreshes panes in every main, extra,
-                    // and detached window. Keeping this out of WindowView avoids
-                    // duplicate notifications and does not depend on a specific
-                    // OS window entity remaining alive.
-                    let mut registry = content_pane_registry().lock();
-                    notify_registered_panes(&mut registry, terminal_ids, cx);
-                    drop(registry);
+                    // Parsing already happened in the manager pump. Keep
+                    // notification/clipboard semantics immediate, but collect
+                    // exact pane ids behind one app-wide display-frame repaint.
+                    this.queue_terminal_activity_repaints(terminal_ids, cx);
                     this.process_terminal_notifications(terminal_ids, cx);
+                    this.process_clipboard_writes(terminal_ids, cx);
                     // Answer (or, when disabled, drop) OSC 52 clipboard *read*
                     // requests for remote terminals. The clipboard physically
                     // lives on this client machine, so the reply must be
@@ -615,6 +625,47 @@ impl Okena {
 }
 
 impl Okena {
+    fn queue_terminal_activity_repaints(
+        &mut self,
+        terminal_ids: &[String],
+        cx: &mut Context<Self>,
+    ) {
+        if !self
+            .terminal_activity_repaints
+            .queue(terminal_ids.iter().cloned())
+        {
+            return;
+        }
+
+        cx.spawn(async move |this: WeakEntity<Self>, cx| {
+            cx.background_executor()
+                .timer(TERMINAL_ACTIVITY_REPAINT_INTERVAL)
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                let terminal_ids: Vec<_> =
+                    this.terminal_activity_repaints.take().into_iter().collect();
+
+                // Pane and sidebar notifications happen in this single app
+                // update so GPUI can present one frame for all windows rather
+                // than racing independent per-view timers.
+                {
+                    let mut registry = content_pane_registry().lock();
+                    request_registered_content_pane_repaints(&mut registry, &terminal_ids, cx);
+                }
+
+                let mut window_views = Vec::with_capacity(1 + this.extra_windows.len());
+                window_views.push(this.main_window.clone());
+                window_views.extend(this.extra_windows.values().cloned());
+                for window_view in window_views {
+                    window_view.update(cx, |window_view, cx| {
+                        window_view.request_sidebar_activity_repaint(cx);
+                    });
+                }
+            });
+        })
+        .detach();
+    }
+
     /// Mark the app as quitting before the platform loop stops. Called from
     /// the main window's close handler (main.rs) ahead of `cx.quit()` so
     /// deferred extra-window forgets and daemon recovery bail immediately —

--- a/crates/okena-app/src/app/mod.rs
+++ b/crates/okena-app/src/app/mod.rs
@@ -373,6 +373,9 @@ impl Okena {
         cx.subscribe(&remote_manager, |this, _rm, event, cx| match event {
             RemoteManagerEvent::TerminalActivity(terminal_ids) => {
                 if !terminal_ids.is_empty() {
+                    for terminal_id in terminal_ids {
+                        okena_core::latency_probe::client_activity_received(terminal_id);
+                    }
                     // Parsing already happened in the manager pump. Present the
                     // first output immediately, then coalesce sustained output,
                     // while notification and clipboard semantics stay immediate.
@@ -683,6 +686,10 @@ impl Okena {
         terminal_ids: &[String],
         cx: &mut Context<Self>,
     ) {
+        for terminal_id in terminal_ids {
+            okena_core::latency_probe::client_repaint_dispatched(terminal_id);
+        }
+
         // Pane and sidebar notifications happen in one app update so GPUI can
         // present one frame for all windows rather than racing per-view timers.
         {

--- a/crates/okena-app/src/app/notifications.rs
+++ b/crates/okena-app/src/app/notifications.rs
@@ -201,6 +201,33 @@ impl Okena {
         }
     }
 
+    /// Apply OSC 52 clipboard *writes* queued by terminals that produced output.
+    ///
+    /// This side effect is intentionally drained from the immediate activity
+    /// handler rather than relying on `TerminalContent::render`: background-only
+    /// panes may remain inactive indefinitely, while clipboard semantics must not.
+    /// The render path keeps a fallback drain for non-remote terminal producers.
+    pub(super) fn process_clipboard_writes(
+        &mut self,
+        dirty_terminal_ids: &[String],
+        cx: &mut Context<Self>,
+    ) {
+        let writes = {
+            let reg = self.terminals.lock();
+            let mut writes = Vec::new();
+            for terminal_id in dirty_terminal_ids {
+                if let Some(terminal) = reg.get(terminal_id) {
+                    writes.extend(terminal.take_pending_clipboard_writes());
+                }
+            }
+            writes
+        };
+
+        for text in writes {
+            cx.write_to_clipboard(ClipboardItem::new_string(text));
+        }
+    }
+
     /// Answer (or silently deny) OSC 52 clipboard *read* requests
     /// (`OSC 52 ; c ; ?`) queued by terminals that produced output this batch.
     /// Runs here, in the PTY event loop, because this is where the opt-in

--- a/crates/okena-app/src/views/window/mod.rs
+++ b/crates/okena-app/src/views/window/mod.rs
@@ -4,7 +4,7 @@ mod render;
 mod sidebar;
 mod terminal_actions;
 
-use crate::remote_client::manager::{RemoteConnectionManager, RemoteManagerEvent};
+use crate::remote_client::manager::RemoteConnectionManager;
 use crate::services::manager::ServiceManager;
 use crate::settings::settings;
 use crate::views::chrome::title_bar::TitleBar;
@@ -19,6 +19,7 @@ use crate::workspace::focus::FocusManager;
 use crate::workspace::request_broker::RequestBroker;
 use crate::workspace::state::{WindowBounds as PersistedWindowBounds, WindowId, Workspace};
 use gpui::*;
+use okena_ui::activity_repaint::ActivityRepaintGate;
 use parking_lot::Mutex;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -49,9 +50,13 @@ pub fn content_pane_registry() -> &'static ContentPaneRegistry {
 /// whether any UI update was actually triggered). Generic over the target
 /// type so the same helper services the multi-window terminal fan-out and is
 /// testable without standing up a `TerminalContent`.
-pub fn notify_pane_weaks<T: 'static>(weaks: &mut Vec<WeakEntity<T>>, cx: &mut App) -> bool {
+fn update_pane_weaks<T: 'static>(
+    weaks: &mut Vec<WeakEntity<T>>,
+    cx: &mut App,
+    mut update: impl FnMut(&mut T, &mut Context<T>),
+) -> bool {
     let mut any_alive = false;
-    weaks.retain(|w| match w.update(cx, |_, cx| cx.notify()) {
+    weaks.retain(|weak| match weak.update(cx, |pane, cx| update(pane, cx)) {
         Ok(_) => {
             any_alive = true;
             true
@@ -61,6 +66,10 @@ pub fn notify_pane_weaks<T: 'static>(weaks: &mut Vec<WeakEntity<T>>, cx: &mut Ap
     any_alive
 }
 
+pub fn notify_pane_weaks<T: 'static>(weaks: &mut Vec<WeakEntity<T>>, cx: &mut App) -> bool {
+    update_pane_weaks(weaks, cx, |_, cx| cx.notify())
+}
+
 /// Notify panes for terminals whose remote content actually advanced. Empty
 /// registrations are removed so repeated activity cannot grow stale weak lists.
 pub fn notify_registered_panes<T: 'static>(
@@ -68,11 +77,36 @@ pub fn notify_registered_panes<T: 'static>(
     terminal_ids: &[String],
     cx: &mut App,
 ) -> usize {
+    update_registered_panes(registry, terminal_ids, cx, notify_pane_weaks)
+}
+
+/// Request activity repaints from the concrete terminal-content panes. Each
+/// pane independently gates the request against its own OS window activation,
+/// so the same terminal can stay live in an active extra window without
+/// repainting copies rendered by inactive windows.
+pub fn request_registered_content_pane_repaints(
+    registry: &mut HashMap<String, Vec<WeakEntity<super::layout::terminal_pane::TerminalContent>>>,
+    terminal_ids: &[String],
+    cx: &mut App,
+) -> usize {
+    update_registered_panes(registry, terminal_ids, cx, |weaks, cx| {
+        update_pane_weaks(weaks, cx, |pane, cx| {
+            pane.request_activity_repaint(cx);
+        })
+    })
+}
+
+fn update_registered_panes<T: 'static>(
+    registry: &mut HashMap<String, Vec<WeakEntity<T>>>,
+    terminal_ids: &[String],
+    cx: &mut App,
+    mut update: impl FnMut(&mut Vec<WeakEntity<T>>, &mut App) -> bool,
+) -> usize {
     let mut notified = 0;
     let mut empty = Vec::new();
     for terminal_id in terminal_ids {
         if let Some(weaks) = registry.get_mut(terminal_id) {
-            if notify_pane_weaks(weaks, cx) {
+            if update(weaks, cx) {
                 notified += 1;
             }
             if weaks.is_empty() {
@@ -133,6 +167,8 @@ pub struct WindowView {
     request_broker: Entity<RequestBroker>,
     terminals: TerminalsRegistry,
     sidebar: Entity<Sidebar>,
+    /// Coalesces terminal-activity sidebar updates while this OS window is inactive.
+    sidebar_activity_repaint: ActivityRepaintGate,
     /// Sidebar state controller
     sidebar_ctrl: SidebarController,
     /// Stored project column entities (created once, not during render)
@@ -337,6 +373,7 @@ impl WindowView {
             request_broker,
             terminals,
             sidebar,
+            sidebar_activity_repaint: ActivityRepaintGate::new(window.is_window_active()),
             sidebar_ctrl,
             project_columns: HashMap::new(),
             title_bar,
@@ -379,6 +416,22 @@ impl WindowView {
         // path coalesce. Conversion mirrors the inverse path in
         // `src/app/extras.rs::open_extra_window` (gpui `Bounds<Pixels>` ->
         // `PersistedWindowBounds` via four `f32::from(...)` calls).
+        cx.observe_window_activation(window, |this, window, cx| {
+            let active = window.is_window_active();
+            let changed = active != this.sidebar_activity_repaint.is_active();
+            let flush_pending = this.sidebar_activity_repaint.set_active(active);
+            if flush_pending {
+                this.sidebar.update(cx, |_, cx| cx.notify());
+                this.sidebar_activity_repaint.repainted();
+            }
+            if changed {
+                // Refresh active/inactive chrome and ensure the current terminal
+                // scene is presented once when the user returns to this window.
+                cx.notify();
+            }
+        })
+        .detach();
+
         cx.observe_window_bounds(window, |this, window, cx| {
             let bounds = window.window_bounds().get_bounds();
             let persisted = PersistedWindowBounds {
@@ -584,33 +637,22 @@ impl WindowView {
                 status_bar_for_observe.update(cx, |_, cx| cx.notify());
             })
             .detach();
-
-            // Repaint the sidebar on remote terminal activity (bell / idle).
-            // The sidebar reads these flags straight from the TerminalsRegistry,
-            // which GPUI's dependency tracking can't see, so incoming server
-            // output would otherwise only surface on local input (issue #128).
-            // This rides a dedicated event rather than cx.notify() so the
-            // high-frequency output cadence doesn't trigger the project-sync
-            // observer above.
-            let sidebar_for_activity = self.sidebar.clone();
-            cx.subscribe(&manager, move |_this, _rm, event, cx| match event {
-                // The app-wide manager subscription performs targeted terminal
-                // pane fan-out once; each WindowView only owns its sidebar repaint.
-                RemoteManagerEvent::TerminalActivity(_) => {
-                    sidebar_for_activity.update(cx, |_, cx| cx.notify());
-                }
-                // Local-daemon self-heal is driven by `Okena`, not the sidebar.
-                RemoteManagerEvent::LocalConnectionFailed
-                | RemoteManagerEvent::SettingsChanged(_)
-                | RemoteManagerEvent::TerminalFocusRequested { .. } => {}
-            })
-            .detach();
         }
 
         self.remote_manager = Some(manager);
 
         // Rebuild dispatch callback with remote manager
         self.rebuild_sidebar_dispatch(cx);
+    }
+
+    /// Request the sidebar half of the app-wide terminal activity frame.
+    /// Parsing and notifications already ran; this only presents current bell /
+    /// idle state, or retains one pending presentation while the window is inactive.
+    pub(crate) fn request_sidebar_activity_repaint(&mut self, cx: &mut Context<Self>) {
+        if self.sidebar_activity_repaint.request() {
+            self.sidebar.update(cx, |_, cx| cx.notify());
+            self.sidebar_activity_repaint.repainted();
+        }
     }
 
     /// Set the service manager entity (called by Okena after creation).

--- a/crates/okena-app/src/views/window/mod.rs
+++ b/crates/okena-app/src/views/window/mod.rs
@@ -19,7 +19,6 @@ use crate::workspace::focus::FocusManager;
 use crate::workspace::request_broker::RequestBroker;
 use crate::workspace::state::{WindowBounds as PersistedWindowBounds, WindowId, Workspace};
 use gpui::*;
-use okena_ui::activity_repaint::ActivityRepaintGate;
 use parking_lot::Mutex;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -80,10 +79,9 @@ pub fn notify_registered_panes<T: 'static>(
     update_registered_panes(registry, terminal_ids, cx, notify_pane_weaks)
 }
 
-/// Request activity repaints from the concrete terminal-content panes. Each
-/// pane independently gates the request against its own OS window activation,
-/// so the same terminal can stay live in an active extra window without
-/// repainting copies rendered by inactive windows.
+/// Request activity repaints from concrete terminal-content panes. Calls are
+/// already limited by the app-wide presentation cadence, so every visible copy
+/// remains live without each stream driving an independent clock.
 pub fn request_registered_content_pane_repaints(
     registry: &mut HashMap<String, Vec<WeakEntity<super::layout::terminal_pane::TerminalContent>>>,
     terminal_ids: &[String],
@@ -167,8 +165,6 @@ pub struct WindowView {
     request_broker: Entity<RequestBroker>,
     terminals: TerminalsRegistry,
     sidebar: Entity<Sidebar>,
-    /// Coalesces terminal-activity sidebar updates while this OS window is inactive.
-    sidebar_activity_repaint: ActivityRepaintGate,
     /// Sidebar state controller
     sidebar_ctrl: SidebarController,
     /// Stored project column entities (created once, not during render)
@@ -373,7 +369,6 @@ impl WindowView {
             request_broker,
             terminals,
             sidebar,
-            sidebar_activity_repaint: ActivityRepaintGate::new(window.is_window_active()),
             sidebar_ctrl,
             project_columns: HashMap::new(),
             title_bar,
@@ -416,19 +411,10 @@ impl WindowView {
         // path coalesce. Conversion mirrors the inverse path in
         // `src/app/extras.rs::open_extra_window` (gpui `Bounds<Pixels>` ->
         // `PersistedWindowBounds` via four `f32::from(...)` calls).
-        cx.observe_window_activation(window, |this, window, cx| {
-            let active = window.is_window_active();
-            let changed = active != this.sidebar_activity_repaint.is_active();
-            let flush_pending = this.sidebar_activity_repaint.set_active(active);
-            if flush_pending {
-                this.sidebar.update(cx, |_, cx| cx.notify());
-                this.sidebar_activity_repaint.repainted();
-            }
-            if changed {
-                // Refresh active/inactive chrome and ensure the current terminal
-                // scene is presented once when the user returns to this window.
-                cx.notify();
-            }
+        cx.observe_window_activation(window, |_this, _window, cx| {
+            // Refresh key-window chrome while activity-driven presentation stays
+            // live in every visible window.
+            cx.notify();
         })
         .detach();
 
@@ -647,12 +633,9 @@ impl WindowView {
 
     /// Request the sidebar half of the app-wide terminal activity frame.
     /// Parsing and notifications already ran; this only presents current bell /
-    /// idle state, or retains one pending presentation while the window is inactive.
+    /// idle state at the shared capped cadence.
     pub(crate) fn request_sidebar_activity_repaint(&mut self, cx: &mut Context<Self>) {
-        if self.sidebar_activity_repaint.request() {
-            self.sidebar.update(cx, |_, cx| cx.notify());
-            self.sidebar_activity_repaint.repainted();
-        }
+        self.sidebar.update(cx, |_, cx| cx.notify());
     }
 
     /// Set the service manager entity (called by Okena after creation).

--- a/crates/okena-core/Cargo.toml
+++ b/crates/okena-core/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT"
 default = []
 # Exposes `process::testing` (command bus mock) to downstream crates' tests.
 test-support = []
+# Compiles opt-in terminal input latency instrumentation.
+terminal-latency-probe = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/okena-core/src/latency_probe.rs
+++ b/crates/okena-core/src/latency_probe.rs
@@ -1,0 +1,541 @@
+//! Opt-in terminal input latency instrumentation.
+//!
+//! Build with `terminal-latency-probe`, then set
+//! `OKENA_TERMINAL_LATENCY_PROBE=1` before starting Okena. The desktop and its
+//! daemon then record matching per-terminal samples. The controlled test must
+//! keep one input in flight and avoid unrelated terminal output.
+
+#[cfg(feature = "terminal-latency-probe")]
+mod imp {
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::{Mutex, OnceLock};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const MAX_PENDING_PER_TERMINAL: usize = 512;
+
+    #[derive(Debug, Clone)]
+    struct ClientProbe {
+        sample: u64,
+        viewer: u64,
+        input_len: usize,
+        input_hash: u64,
+        input_us: u64,
+        output_receive_us: Option<u64>,
+        parsed_us: Option<u64>,
+        activity_emit_us: Option<u64>,
+        activity_receive_us: Option<u64>,
+        throttle_fire_us: Option<u64>,
+        notify_us: Option<u64>,
+        paint_us: Option<u64>,
+    }
+
+    #[derive(Debug, Clone)]
+    struct DaemonProbe {
+        sample: u64,
+        input_len: usize,
+        input_hash: u64,
+        ws_receive_us: u64,
+        bridge_us: Option<u64>,
+        pty_queue_us: Option<u64>,
+        pty_write_start_us: Option<u64>,
+        pty_write_end_us: Option<u64>,
+        pty_output_us: Option<u64>,
+        stream_us: Option<u64>,
+    }
+
+    #[derive(Default)]
+    struct ProbeBook {
+        next_client_sample: HashMap<String, u64>,
+        next_daemon_sample: HashMap<String, u64>,
+        client: HashMap<String, VecDeque<ClientProbe>>,
+        daemon: HashMap<String, VecDeque<DaemonProbe>>,
+    }
+
+    impl ProbeBook {
+        fn start_client(
+            &mut self,
+            terminal_id: &str,
+            viewer: u64,
+            data: &[u8],
+            now_us: u64,
+        ) -> u64 {
+            let sample = next_sample(&mut self.next_client_sample, terminal_id);
+            let pending = self.client.entry(terminal_id.to_string()).or_default();
+            trim_pending(pending);
+            pending.push_back(ClientProbe {
+                sample,
+                viewer,
+                input_len: data.len(),
+                input_hash: input_hash(data),
+                input_us: now_us,
+                output_receive_us: None,
+                parsed_us: None,
+                activity_emit_us: None,
+                activity_receive_us: None,
+                throttle_fire_us: None,
+                notify_us: None,
+                paint_us: None,
+            });
+            sample
+        }
+
+        fn start_daemon(&mut self, terminal_id: &str, data: &[u8], now_us: u64) -> u64 {
+            let sample = next_sample(&mut self.next_daemon_sample, terminal_id);
+            let pending = self.daemon.entry(terminal_id.to_string()).or_default();
+            trim_pending(pending);
+            pending.push_back(DaemonProbe {
+                sample,
+                input_len: data.len(),
+                input_hash: input_hash(data),
+                ws_receive_us: now_us,
+                bridge_us: None,
+                pty_queue_us: None,
+                pty_write_start_us: None,
+                pty_write_end_us: None,
+                pty_output_us: None,
+                stream_us: None,
+            });
+            sample
+        }
+
+        fn mark_client(
+            &mut self,
+            terminal_id: &str,
+            now_us: u64,
+            update: impl Fn(&mut ClientProbe, u64),
+        ) {
+            if let Some(pending) = self.client.get_mut(terminal_id) {
+                for probe in pending {
+                    update(probe, now_us);
+                }
+            }
+        }
+
+        fn mark_daemon(
+            &mut self,
+            terminal_id: &str,
+            now_us: u64,
+            update: impl Fn(&mut DaemonProbe, u64),
+        ) {
+            if let Some(pending) = self.daemon.get_mut(terminal_id) {
+                for probe in pending {
+                    update(probe, now_us);
+                }
+            }
+        }
+
+        fn client_painted(&mut self, terminal_id: &str, viewer: u64, now_us: u64) -> Vec<u64> {
+            let Some(pending) = self.client.get_mut(terminal_id) else {
+                return Vec::new();
+            };
+            let mut painted = Vec::new();
+            for probe in pending {
+                if probe.viewer == viewer && probe.parsed_us.is_some() && probe.paint_us.is_none() {
+                    probe.paint_us = Some(now_us);
+                    painted.push(probe.sample);
+                }
+            }
+            painted
+        }
+
+        fn client_framed(
+            &mut self,
+            terminal_id: &str,
+            viewer: u64,
+            samples: &[u64],
+        ) -> Vec<ClientProbe> {
+            let Some(mut pending) = self.client.remove(terminal_id) else {
+                return Vec::new();
+            };
+            let mut completed = Vec::new();
+            pending.retain(|probe| {
+                if probe.viewer == viewer && samples.contains(&probe.sample) {
+                    completed.push(probe.clone());
+                    false
+                } else {
+                    true
+                }
+            });
+            if !pending.is_empty() {
+                self.client.insert(terminal_id.to_string(), pending);
+            }
+            completed
+        }
+
+        fn daemon_streamed(&mut self, terminal_id: &str) -> Vec<DaemonProbe> {
+            let Some(mut pending) = self.daemon.remove(terminal_id) else {
+                return Vec::new();
+            };
+            let mut completed = Vec::new();
+            pending.retain(|probe| {
+                if probe.pty_write_end_us.is_some()
+                    && probe.pty_output_us.is_some()
+                    && probe.stream_us.is_some()
+                {
+                    completed.push(probe.clone());
+                    false
+                } else {
+                    true
+                }
+            });
+            if !pending.is_empty() {
+                self.daemon.insert(terminal_id.to_string(), pending);
+            }
+            completed
+        }
+    }
+
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    static PROBES: OnceLock<Mutex<ProbeBook>> = OnceLock::new();
+
+    pub fn enabled() -> bool {
+        *ENABLED.get_or_init(|| {
+            std::env::var("OKENA_TERMINAL_LATENCY_PROBE")
+                .ok()
+                .is_some_and(|value| !matches!(value.as_str(), "" | "0" | "false" | "off"))
+        })
+    }
+
+    pub fn client_start(terminal_id: &str, viewer: u64, data: &[u8]) {
+        with_book(|book| {
+            let sample = book.start_client(terminal_id, viewer, data, now_us());
+            log::info!(
+                target: "okena::terminal_latency",
+                "terminal_latency_client_start terminal={terminal_id} sample={sample} viewer={viewer}"
+            );
+        });
+    }
+
+    pub fn client_output_received(terminal_id: &str) {
+        mark_client(terminal_id, |probe, now| {
+            probe.output_receive_us.get_or_insert(now);
+        });
+    }
+
+    pub fn client_output_parsed(terminal_id: &str) {
+        mark_client(terminal_id, |probe, now| {
+            if probe.output_receive_us.is_some() {
+                probe.parsed_us.get_or_insert(now);
+            }
+        });
+    }
+
+    pub fn client_activity_emitted(terminal_id: &str) {
+        mark_client(terminal_id, |probe, now| {
+            if probe.parsed_us.is_some() {
+                probe.activity_emit_us.get_or_insert(now);
+            }
+        });
+    }
+
+    pub fn client_activity_received(terminal_id: &str) {
+        mark_client(terminal_id, |probe, now| {
+            if probe.activity_emit_us.is_some() {
+                probe.activity_receive_us.get_or_insert(now);
+            }
+        });
+    }
+
+    pub fn client_repaint_dispatched(terminal_id: &str) {
+        mark_client(terminal_id, |probe, now| {
+            if probe.activity_receive_us.is_some() {
+                probe.throttle_fire_us.get_or_insert(now);
+            }
+        });
+    }
+
+    pub fn client_notify_requested(terminal_id: &str, viewer: u64) {
+        mark_client(terminal_id, |probe, now| {
+            if probe.viewer == viewer && probe.throttle_fire_us.is_some() {
+                probe.notify_us.get_or_insert(now);
+            }
+        });
+    }
+
+    pub fn client_painted(terminal_id: &str, viewer: u64) -> Vec<u64> {
+        if !enabled() {
+            return Vec::new();
+        }
+        lock_book()
+            .map(|mut book| book.client_painted(terminal_id, viewer, now_us()))
+            .unwrap_or_default()
+    }
+
+    pub fn client_frame_completed(terminal_id: &str, viewer: u64, samples: &[u64]) {
+        if !enabled() {
+            return;
+        }
+        let frame_us = now_us();
+        let completed = lock_book()
+            .map(|mut book| book.client_framed(terminal_id, viewer, samples))
+            .unwrap_or_default();
+        for probe in completed {
+            log::info!(
+                target: "okena::terminal_latency",
+                "terminal_latency_client terminal={terminal_id} sample={} viewer={} input_len={} input_hash={} input_us={} output_receive_us={} parsed_us={} activity_emit_us={} activity_receive_us={} throttle_fire_us={} notify_us={} paint_us={} frame_us={frame_us}",
+                probe.sample,
+                probe.viewer,
+                probe.input_len,
+                probe.input_hash,
+                probe.input_us,
+                value(probe.output_receive_us),
+                value(probe.parsed_us),
+                value(probe.activity_emit_us),
+                value(probe.activity_receive_us),
+                value(probe.throttle_fire_us),
+                value(probe.notify_us),
+                value(probe.paint_us),
+            );
+        }
+    }
+
+    pub fn daemon_input_received(terminal_id: &str, data: &[u8]) {
+        with_book(|book| {
+            book.start_daemon(terminal_id, data, now_us());
+        });
+    }
+
+    pub fn daemon_bridge_received(terminal_id: &str) {
+        mark_daemon(terminal_id, |probe, now| {
+            probe.bridge_us.get_or_insert(now);
+        });
+    }
+
+    pub fn daemon_pty_queued(terminal_id: &str) {
+        mark_daemon(terminal_id, |probe, now| {
+            if probe.bridge_us.is_some() {
+                probe.pty_queue_us.get_or_insert(now);
+            }
+        });
+    }
+
+    pub fn daemon_pty_write_started(terminal_id: &str) {
+        mark_daemon(terminal_id, |probe, now| {
+            if probe.pty_queue_us.is_some() {
+                probe.pty_write_start_us.get_or_insert(now);
+            }
+        });
+    }
+
+    pub fn daemon_pty_write_completed(terminal_id: &str) {
+        mark_daemon(terminal_id, |probe, now| {
+            if probe.pty_write_start_us.is_some() {
+                probe.pty_write_end_us.get_or_insert(now);
+            }
+        });
+        log_completed_daemon(terminal_id);
+    }
+
+    pub fn daemon_pty_output_received(terminal_id: &str) {
+        mark_daemon(terminal_id, |probe, now| {
+            if probe.pty_write_start_us.is_some() {
+                probe.pty_output_us.get_or_insert(now);
+            }
+        });
+    }
+
+    pub fn daemon_stream_queued(terminal_id: &str) {
+        mark_daemon(terminal_id, |probe, now| {
+            if probe.pty_output_us.is_some() {
+                probe.stream_us.get_or_insert(now);
+            }
+        });
+        log_completed_daemon(terminal_id);
+    }
+
+    fn log_completed_daemon(terminal_id: &str) {
+        if !enabled() {
+            return;
+        }
+        let completed = lock_book()
+            .map(|mut book| book.daemon_streamed(terminal_id))
+            .unwrap_or_default();
+        for probe in completed {
+            log::info!(
+                target: "okena::terminal_latency",
+                "terminal_latency_daemon terminal={terminal_id} sample={} input_len={} input_hash={} ws_receive_us={} bridge_us={} pty_queue_us={} pty_write_start_us={} pty_write_end_us={} pty_output_us={} stream_us={}",
+                probe.sample,
+                probe.input_len,
+                probe.input_hash,
+                probe.ws_receive_us,
+                value(probe.bridge_us),
+                value(probe.pty_queue_us),
+                value(probe.pty_write_start_us),
+                value(probe.pty_write_end_us),
+                value(probe.pty_output_us),
+                value(probe.stream_us),
+            );
+        }
+    }
+
+    fn mark_client(terminal_id: &str, update: impl Fn(&mut ClientProbe, u64)) {
+        with_book(|book| book.mark_client(terminal_id, now_us(), update));
+    }
+
+    fn mark_daemon(terminal_id: &str, update: impl Fn(&mut DaemonProbe, u64)) {
+        with_book(|book| book.mark_daemon(terminal_id, now_us(), update));
+    }
+
+    fn with_book(update: impl FnOnce(&mut ProbeBook)) {
+        if !enabled() {
+            return;
+        }
+        if let Some(mut book) = lock_book() {
+            update(&mut book);
+        }
+    }
+
+    fn lock_book() -> Option<std::sync::MutexGuard<'static, ProbeBook>> {
+        PROBES
+            .get_or_init(|| Mutex::new(ProbeBook::default()))
+            .lock()
+            .ok()
+    }
+
+    fn now_us() -> u64 {
+        let micros = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros();
+        u64::try_from(micros).unwrap_or(u64::MAX)
+    }
+
+    fn next_sample(counters: &mut HashMap<String, u64>, terminal_id: &str) -> u64 {
+        let next = counters.entry(terminal_id.to_string()).or_insert(1);
+        let sample = *next;
+        *next = next.saturating_add(1);
+        sample
+    }
+
+    fn trim_pending<T>(pending: &mut VecDeque<T>) {
+        if pending.len() >= MAX_PENDING_PER_TERMINAL {
+            pending.pop_front();
+        }
+    }
+
+    fn input_hash(data: &[u8]) -> u64 {
+        data.iter().fold(0xcbf29ce484222325, |hash, byte| {
+            (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+        })
+    }
+
+    fn value(timestamp: Option<u64>) -> u64 {
+        timestamp.unwrap_or(0)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::ProbeBook;
+
+        #[test]
+        fn client_probe_completes_only_in_originating_viewer() {
+            let mut book = ProbeBook::default();
+            let sample = book.start_client("remote:local:t1", 7, b"x", 100);
+            book.mark_client("remote:local:t1", 120, |probe, now| {
+                probe.output_receive_us = Some(now);
+            });
+            book.mark_client("remote:local:t1", 125, |probe, now| {
+                probe.parsed_us = Some(now);
+            });
+
+            assert!(book.client_painted("remote:local:t1", 8, 160).is_empty());
+            assert_eq!(book.client_painted("remote:local:t1", 7, 160), vec![sample]);
+            assert!(
+                book.client_framed("remote:local:t1", 8, &[sample])
+                    .is_empty()
+            );
+            let completed = book.client_framed("remote:local:t1", 7, &[sample]);
+            assert_eq!(completed.len(), 1);
+            assert_eq!(completed[0].input_us, 100);
+            assert_eq!(completed[0].paint_us, Some(160));
+        }
+
+        #[test]
+        fn daemon_probe_waits_for_pty_output_before_stream_completion() {
+            let mut book = ProbeBook::default();
+            let sample = book.start_daemon("t1", b"x", 200);
+
+            assert!(book.daemon_streamed("t1").is_empty());
+            book.mark_daemon("t1", 230, |probe, now| {
+                probe.pty_output_us = Some(now);
+                probe.pty_write_end_us = Some(now - 1);
+                probe.stream_us = Some(now + 1);
+            });
+            let completed = book.daemon_streamed("t1");
+            assert_eq!(completed.len(), 1);
+            assert_eq!(completed[0].sample, sample);
+            assert_eq!(completed[0].pty_output_us, Some(230));
+        }
+
+        #[test]
+        fn input_hash_and_sample_order_match_for_repeated_bytes() {
+            let mut book = ProbeBook::default();
+            let first = book.start_client("t1", 1, b"a", 1);
+            let second = book.start_client("t1", 1, b"a", 2);
+            let pending = book.client.get("t1").expect("client probes");
+
+            assert_eq!((first, second), (1, 2));
+            assert_eq!(pending[0].input_hash, pending[1].input_hash);
+        }
+    }
+}
+
+#[cfg(not(feature = "terminal-latency-probe"))]
+mod imp {
+    #[inline(always)]
+    pub fn enabled() -> bool {
+        false
+    }
+
+    #[inline(always)]
+    pub fn client_start(_terminal_id: &str, _viewer: u64, _data: &[u8]) {}
+
+    #[inline(always)]
+    pub fn client_output_received(_terminal_id: &str) {}
+
+    #[inline(always)]
+    pub fn client_output_parsed(_terminal_id: &str) {}
+
+    #[inline(always)]
+    pub fn client_activity_emitted(_terminal_id: &str) {}
+
+    #[inline(always)]
+    pub fn client_activity_received(_terminal_id: &str) {}
+
+    #[inline(always)]
+    pub fn client_repaint_dispatched(_terminal_id: &str) {}
+
+    #[inline(always)]
+    pub fn client_notify_requested(_terminal_id: &str, _viewer: u64) {}
+
+    #[inline(always)]
+    pub fn client_painted(_terminal_id: &str, _viewer: u64) -> Vec<u64> {
+        Vec::new()
+    }
+
+    #[inline(always)]
+    pub fn client_frame_completed(_terminal_id: &str, _viewer: u64, _samples: &[u64]) {}
+
+    #[inline(always)]
+    pub fn daemon_input_received(_terminal_id: &str, _data: &[u8]) {}
+
+    #[inline(always)]
+    pub fn daemon_bridge_received(_terminal_id: &str) {}
+
+    #[inline(always)]
+    pub fn daemon_pty_queued(_terminal_id: &str) {}
+
+    #[inline(always)]
+    pub fn daemon_pty_write_started(_terminal_id: &str) {}
+
+    #[inline(always)]
+    pub fn daemon_pty_write_completed(_terminal_id: &str) {}
+
+    #[inline(always)]
+    pub fn daemon_pty_output_received(_terminal_id: &str) {}
+
+    #[inline(always)]
+    pub fn daemon_stream_queued(_terminal_id: &str) {}
+}
+
+pub use imp::*;

--- a/crates/okena-core/src/lib.rs
+++ b/crates/okena-core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod api;
 pub mod git_poll;
 pub mod keys;
+pub mod latency_probe;
 pub mod process;
 pub mod profiles;
 pub mod selection;

--- a/crates/okena-daemon-core/src/command_loop.rs
+++ b/crates/okena-daemon-core/src/command_loop.rs
@@ -2481,6 +2481,9 @@ pub async fn daemon_command_loop(
                 action,
                 connection_id,
             } => {
+                if let ActionRequest::SendBytes { terminal_id, .. } = &action {
+                    okena_core::latency_probe::daemon_bridge_received(terminal_id);
+                }
                 claim_input_resize_owner(&action, &connection_id);
                 RemoteCommand::Action(action)
             }

--- a/crates/okena-daemon-core/src/daemon.rs
+++ b/crates/okena-daemon-core/src/daemon.rs
@@ -524,11 +524,12 @@ impl DaemonCore {
                 reactor.workspace.clone(),
                 git_status_tx.clone(),
                 reactor.state_version.clone(),
-                remote_subscribed_terminals,
+                remote_subscribed_terminals.clone(),
                 git_poll_trigger_rx,
             ));
             tokio::task::spawn_local(crate::git_poll::run_git_head_poll(
                 reactor.workspace.clone(),
+                remote_subscribed_terminals,
                 git_poll_trigger_tx.clone(),
             ));
             // Forward the daemon's HookMonitor toasts to clients. The daemon has

--- a/crates/okena-daemon-core/src/git_poll.rs
+++ b/crates/okena-daemon-core/src/git_poll.rs
@@ -1,34 +1,11 @@
-//! GPUI-free git-status poller: the headless analogue of
-//! `okena-views-git`'s `GitStatusWatcher` (its `watcher.rs`), minus the GUI.
-//! A separate cheap HEAD-only loop wakes the full poll within 250ms of commits
-//! and checkouts without walking the index or worktree.
+//! GPUI-free git-status polling for the headless daemon.
 //!
-//! The GUI's watcher polls git status every ~5s for the set of *visible*
-//! non-remote projects, caches per-project [`GitStatus`], and pushes a slimmed
-//! [`ApiGitStatus`] map into a `tokio::sync::watch` channel (`remote_tx`) that
-//! the remote server broadcasts to clients. The daemon reproduces exactly that
-//! `watch`-channel output path with `okena-git` directly (NOT `okena-views-git`,
-//! which is a GUI crate).
-//!
-//! ## What is faithfully ported vs. dropped
-//!
-//! * **Ported:** the 5s cadence, the visible-non-remote project selection (via
-//!   [`Workspace::all_visible_project_ids`], which is the union across the main
-//!   and all extra windows — the same set the GUI uses), running
-//!   [`okena_git::refresh_git_status`] on a blocking pool under [`Lane::Poll`],
-//!   building the `HashMap<String, ApiGitStatus>`, and `send_replace`-ing it.
-//!   Also ported: the `gh` PR/CI fan-out and its adaptive cadence
-//!   ([`okena_git::repository::get_pr_info`] / [`get_ci_checks`], gated by
-//!   [`has_github_remote`]), with the across-cycle `pr_infos`/`ci_checks` caches
-//!   and the two-phase publish — basic gix status is published first so the
-//!   branch/diff badge never waits on a (possibly hanging) `gh` call, then the
-//!   richer PR/CI data is merged in and published as a follow-up.
-//! * **Dropped (GUI/remote-server concerns not present in daemon-core):** the
-//!   `cx.notify()` local-UI push, the branch-only warmup, and the
-//!   remotely-subscribed-terminals augmentation of the poll set (that set lives
-//!   in the remote server, which wires the daemon — it can extend the poll set
-//!   there later). The primary output is the `git_status_tx` watch, exactly as
-//!   in the GUI.
+//! Projects visible in any window, or owning a terminal subscribed by a remote
+//! client, stay on the responsive tier: HEAD every 250ms and full status every
+//! 5s. Hidden, unsubscribed repositories use bounded fallback cadences (2s HEAD,
+//! 30s full status). Explicit actions and detected HEAD changes still trigger an
+//! immediate targeted refresh. Cached statuses for projects not selected in a
+//! cycle remain published, so tiering changes freshness rather than visibility.
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -43,10 +20,14 @@ use okena_workspace::state::Workspace;
 use parking_lot::Mutex;
 use tokio::sync::{mpsc, watch};
 
-/// How often to poll git status. Mirrors the GUI watcher's `GIT_POLL_INTERVAL`.
+/// Responsive full-status cadence for visible or remotely subscribed projects.
 const GIT_POLL_INTERVAL: Duration = Duration::from_secs(5);
-/// Cheap HEAD-only cadence used to wake the full status poll after commits and checkouts.
+/// Hidden projects receive a full fallback scan every 6 responsive cycles (30s).
+const HIDDEN_GIT_POLL_EVERY_N_CYCLES: u64 = 6;
+/// Responsive HEAD cadence for visible or remotely subscribed projects.
 const HEAD_POLL_INTERVAL: Duration = Duration::from_millis(250);
+/// Hidden projects receive a cheap HEAD fallback scan every 8 ticks (2s).
+const HIDDEN_HEAD_POLL_EVERY_N_TICKS: u64 = 8;
 /// How many git poll cycles between PR URL checks (~60s). Mirrors the GUI
 /// watcher's `PR_POLL_EVERY_N_CYCLES`.
 const PR_POLL_EVERY_N_CYCLES: u64 = 12;
@@ -101,6 +82,15 @@ impl TriggerAccumulator {
         }
     }
 
+    fn local_status_ids(&self) -> HashSet<String> {
+        self.head_change_ids
+            .iter()
+            .chain(&self.force_gh_ids)
+            .chain(&self.candidate_gh_ids)
+            .cloned()
+            .collect()
+    }
+
     fn clear(&mut self) {
         self.head_change_ids.clear();
         self.force_gh_ids.clear();
@@ -116,13 +106,76 @@ struct GithubPollResult {
     ci_checks: HashMap<String, Option<git::CiCheckSummary>>,
 }
 
+fn relevant_project_ids(
+    workspace: &Workspace,
+    remote_subscribed_terminals: &RwLock<HashMap<u64, HashSet<String>>>,
+) -> HashSet<String> {
+    let mut relevant = workspace.all_visible_project_ids();
+    if let Ok(subscribed) = remote_subscribed_terminals.read() {
+        for terminal_ids in subscribed.values() {
+            for terminal_id in terminal_ids {
+                if let Some(project) = workspace.find_project_for_terminal(terminal_id)
+                    && !project.is_remote
+                {
+                    relevant.insert(project.id.clone());
+                }
+            }
+        }
+    }
+    relevant
+}
+
+fn select_status_poll_ids(
+    active_ids: &HashSet<String>,
+    relevant_ids: &HashSet<String>,
+    forced_ids: &HashSet<String>,
+    newly_relevant_ids: &HashSet<String>,
+    cadence_due: bool,
+    poll_hidden: bool,
+) -> HashSet<String> {
+    if poll_hidden {
+        return active_ids.clone();
+    }
+
+    let mut selected = HashSet::new();
+    if cadence_due {
+        selected.extend(relevant_ids.iter().cloned());
+    }
+    selected.extend(forced_ids.iter().cloned());
+    selected.extend(newly_relevant_ids.iter().cloned());
+    selected.retain(|id| active_ids.contains(id));
+    selected
+}
+
+fn merge_status_results(
+    previous: &HashMap<String, GitStatus>,
+    active_ids: &HashSet<String>,
+    attempted: HashMap<String, Option<GitStatus>>,
+) -> HashMap<String, GitStatus> {
+    let mut merged = previous.clone();
+    merged.retain(|id, _| active_ids.contains(id));
+    for (id, status) in attempted {
+        match status {
+            Some(status) if active_ids.contains(&id) => {
+                merged.insert(id, status);
+            }
+            _ => {
+                merged.remove(&id);
+            }
+        }
+    }
+    merged
+}
+
 /// Poll only each repository's symbolic HEAD and commit id, waking the full
 /// status loop when either changes. This never reads the index or worktree.
 pub async fn run_git_head_poll(
     workspace: Arc<Mutex<Workspace>>,
+    remote_subscribed_terminals: Arc<RwLock<HashMap<u64, HashSet<String>>>>,
     trigger_tx: mpsc::UnboundedSender<GitPollTrigger>,
 ) {
     let mut previous = HashMap::<String, HeadSnapshot>::new();
+    let mut tick = 0u64;
     let mut interval = tokio::time::interval(HEAD_POLL_INTERVAL);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -132,15 +185,24 @@ pub async fn run_git_head_poll(
             return;
         }
 
-        let projects: Vec<(String, String)> = {
-            let ws = workspace.lock();
-            ws.projects()
+        let (projects, relevant_ids): (Vec<(String, String)>, HashSet<String>) = {
+            let workspace = workspace.lock();
+            let relevant = relevant_project_ids(&workspace, &remote_subscribed_terminals);
+            let projects = workspace
+                .projects()
                 .iter()
                 .filter(|project| !project.is_remote)
                 .map(|project| (project.id.clone(), project.path.clone()))
-                .collect()
+                .collect();
+            (projects, relevant)
         };
         let active_ids: HashSet<String> = projects.iter().map(|(id, _)| id.clone()).collect();
+        let poll_hidden = tick.is_multiple_of(HIDDEN_HEAD_POLL_EVERY_N_TICKS);
+        tick = tick.wrapping_add(1);
+        let projects: Vec<_> = projects
+            .into_iter()
+            .filter(|(id, _)| poll_hidden || relevant_ids.contains(id))
+            .collect();
         let snapshots = tokio::task::spawn_blocking(move || {
             projects
                 .into_iter()
@@ -156,6 +218,8 @@ pub async fn run_git_head_poll(
             continue;
         };
 
+        // `active_ids` deliberately includes unsampled hidden projects so their
+        // prior snapshots survive fast-tier ticks and later changes are detected.
         for id in update_head_snapshots(&mut previous, &active_ids, snapshots) {
             if trigger_tx.send(GitPollTrigger::head_change(id)).is_err() {
                 return;
@@ -164,10 +228,10 @@ pub async fn run_git_head_poll(
     }
 }
 
-fn update_head_snapshots(
-    previous: &mut HashMap<String, HeadSnapshot>,
+fn update_head_snapshots<T: PartialEq>(
+    previous: &mut HashMap<String, T>,
     active_ids: &HashSet<String>,
-    snapshots: HashMap<String, HeadSnapshot>,
+    snapshots: HashMap<String, T>,
 ) -> Vec<String> {
     previous.retain(|id, _| active_ids.contains(id));
     snapshots
@@ -304,18 +368,12 @@ fn apply_github_result(
 /// Run the daemon git-status poll loop until the `watch` channel is closed (all
 /// receivers dropped → the server is gone).
 ///
-/// Each cycle:
-/// 1. Lock the workspace, snapshot the `(id, path)` of the projects to poll
-///    (visible, non-remote — see module docs), then DROP the lock.
-/// 2. Run [`git::refresh_git_status`] for each on a blocking pool
-///    ([`tokio::task::spawn_blocking`], under [`Lane::Poll`]) so the gix dir-walk
-///    and diff never stall the reactor thread. Merge in any cached PR/CI so the
-///    badges don't blank mid-cycle, then build + `send_replace` the slimmed
-///    `HashMap<String, ApiGitStatus>` on change — BEFORE the slow `gh` calls.
-/// 3. On the PR/CI cadence (skip cycle 0; first check at cycle 1), fan out the
-///    `gh` PR/CI lookups — also on the blocking pool, gated by `has_github_remote`
-///    — merge the results into the across-cycle caches, then re-publish the
-///    statuses with the richer PR/CI data as a follow-up update.
+/// Each cycle snapshots all local projects and their current relevance, selects
+/// only due or explicitly triggered repositories, and runs their gix work on the
+/// blocking pool. Results merge into the prior cache so skipped hidden projects
+/// remain published. The independent wall-clock interval keeps 5s/30s deadlines
+/// stable even when targeted triggers wake the loop between cadence ticks.
+/// PR/CI lookups retain their existing visible-project adaptive cadence.
 ///
 /// Bumps `state_version` on a real change so a snapshot/broadcast observer can
 /// react; the *primary* output is the `git_status_tx` watch.
@@ -344,9 +402,16 @@ pub async fn run_git_poll(
     let mut cycle: u64 = 0;
     let mut trigger_acc = TriggerAccumulator::default();
     let mut known_gh_ids: HashSet<String> = HashSet::new();
+    let mut known_relevant_ids: HashSet<String> = HashSet::new();
     let mut trigger_rx_closed = false;
     let mut head_generations: HashMap<String, u64> = HashMap::new();
     let (github_result_tx, mut github_result_rx) = mpsc::unbounded_channel();
+    // Consume `interval`'s immediate first tick. Subsequent ticks stay anchored
+    // to wall time, so targeted wakes cannot postpone periodic refreshes.
+    let mut cadence = tokio::time::interval(GIT_POLL_INTERVAL);
+    cadence.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    cadence.tick().await;
+    let mut cadence_due = true;
 
     loop {
         drain_git_poll_triggers(&mut trigger_rx, &mut trigger_acc, &mut trigger_rx_closed);
@@ -364,39 +429,47 @@ pub async fn run_git_poll(
             any_pending_ci = has_pending_ci(&ci_checks);
         }
 
-        // ── 1. Snapshot the projects to poll under the workspace lock ────────
-        // git status (gix, cheap, local-only) is polled for EVERY non-remote
-        // project: the daemon's own window visibility is synthetic and must not
-        // gate it, or a project a CLIENT views (but the daemon's window hides)
-        // would show no branch/diff/PR badge. The expensive `gh` PR/CI fan-out
-        // (network) is instead gated to `gh_ids` — projects visible in some
-        // window PLUS any with a remotely-subscribed terminal (i.e. what a
-        // client is actually looking at). Mirrors the GUI watcher's split.
-        let (projects, mut gh_ids): (Vec<(String, String)>, HashSet<String>) = {
-            let ws = workspace.lock();
-            let projects = ws
+        // ── 1. Snapshot relevance and choose this cycle's local work ─────────
+        let (projects, relevant_ids): (Vec<(String, String)>, HashSet<String>) = {
+            let workspace = workspace.lock();
+            let relevant = relevant_project_ids(&workspace, &remote_subscribed_terminals);
+            let projects = workspace
                 .projects()
                 .iter()
-                .filter(|p| !p.is_remote)
-                .map(|p| (p.id.clone(), p.path.clone()))
+                .filter(|project| !project.is_remote)
+                .map(|project| (project.id.clone(), project.path.clone()))
                 .collect();
-
-            let mut gh_ids = ws.all_visible_project_ids();
-            if let Ok(subscribed) = remote_subscribed_terminals.read() {
-                for terminal_ids in subscribed.values() {
-                    for tid in terminal_ids {
-                        if let Some(p) = ws.find_project_for_terminal(tid)
-                            && !p.is_remote
-                        {
-                            gh_ids.insert(p.id.clone());
-                        }
-                    }
-                }
-            }
-            gh_ids.extend(trigger_acc.force_gh_ids.iter().cloned());
-            gh_ids.extend(trigger_acc.candidate_gh_ids.iter().cloned());
-            (projects, gh_ids)
+            (projects, relevant)
         };
+        let active_ids: HashSet<String> = projects.iter().map(|(id, _)| id.clone()).collect();
+        pr_infos.retain(|id, _| active_ids.contains(id));
+        ci_checks.retain(|id, _| active_ids.contains(id));
+        head_generations.retain(|id, _| active_ids.contains(id));
+        known_gh_ids.retain(|id| active_ids.contains(id));
+        known_relevant_ids.retain(|id| active_ids.contains(id));
+
+        let newly_relevant_ids: HashSet<String> = relevant_ids
+            .difference(&known_relevant_ids)
+            .cloned()
+            .collect();
+        known_relevant_ids = relevant_ids.clone();
+        let forced_local_ids = trigger_acc.local_status_ids();
+        let poll_hidden =
+            cycle == 0 || (cadence_due && cycle.is_multiple_of(HIDDEN_GIT_POLL_EVERY_N_CYCLES));
+        let status_poll_ids = select_status_poll_ids(
+            &active_ids,
+            &relevant_ids,
+            &forced_local_ids,
+            &newly_relevant_ids,
+            cadence_due,
+            poll_hidden,
+        );
+
+        // `gh` stays limited to relevant/explicit projects independently of the
+        // slower hidden local-status fallback.
+        let mut gh_ids = relevant_ids;
+        gh_ids.extend(trigger_acc.force_gh_ids.iter().cloned());
+        gh_ids.extend(trigger_acc.candidate_gh_ids.iter().cloned());
         if cycle != 0 || !known_gh_ids.is_empty() {
             trigger_acc.force_gh_ids.extend(missing_github_stats_ids(
                 gh_ids.difference(&known_gh_ids),
@@ -412,9 +485,12 @@ pub async fn run_git_poll(
         gh_ids.extend(trigger_acc.force_gh_ids.iter().cloned());
         known_gh_ids = gh_ids.clone();
 
-        // ── 2. Refresh each project's git status on the blocking pool ────────
-        let mut new_statuses: HashMap<String, GitStatus> = HashMap::new();
-        for (id, path) in &projects {
+        // ── 2. Refresh selected statuses and merge into the published cache ──
+        let mut attempted: HashMap<String, Option<GitStatus>> = HashMap::new();
+        for (id, path) in projects
+            .iter()
+            .filter(|(id, _)| status_poll_ids.contains(id))
+        {
             let id = id.clone();
             let path = path.clone();
             let status = tokio::task::spawn_blocking(move || {
@@ -427,16 +503,26 @@ pub async fn run_git_poll(
                     // badge doesn't blank between `gh` cadence cycles.
                     status.pr_info = pr_infos.get(&id).cloned().flatten();
                     status.ci_checks = ci_checks.get(&id).cloned().flatten();
-                    new_statuses.insert(id, status);
+                    attempted.insert(id, Some(status));
                 }
-                // No status (not a repo / transient miss with no cache): omit it,
-                // matching the GUI's `filter_map` over `Some` statuses.
-                Ok(None) => {}
-                Err(e) => {
-                    log::error!("git status poll task panicked for {id}: {e}");
+                Ok(None) => {
+                    attempted.insert(id, None);
+                }
+                Err(error) => {
+                    // Preserve the last published value on a panicked blocking
+                    // task; the next cadence or targeted trigger retries it.
+                    log::error!("git status poll task panicked for {id}: {error}");
                 }
             }
         }
+        let missing_status_ids: HashSet<String> = attempted
+            .iter()
+            .filter_map(|(id, status)| status.is_none().then_some(id.clone()))
+            .collect();
+        if clear_github_cache_for_ids(&missing_status_ids, &mut pr_infos, &mut ci_checks) {
+            any_pending_ci = has_pending_ci(&ci_checks);
+        }
+        let mut new_statuses = merge_status_results(&last, &active_ids, attempted);
 
         let branch_changes = branch_changed_ids(&last, &new_statuses);
         if !branch_changes.is_empty() {
@@ -462,8 +548,10 @@ pub async fn run_git_poll(
         } else {
             CI_SETTLED_POLL_EVERY_N_CYCLES
         };
-        let pr_cadence = cycle == 1 || (cycle != 0 && cycle.is_multiple_of(PR_POLL_EVERY_N_CYCLES));
-        let ci_cadence = cycle == 1 || (cycle != 0 && cycle.is_multiple_of(ci_poll_interval));
+        let pr_cadence = cadence_due
+            && (cycle == 1 || (cycle != 0 && cycle.is_multiple_of(PR_POLL_EVERY_N_CYCLES)));
+        let ci_cadence =
+            cadence_due && (cycle == 1 || (cycle != 0 && cycle.is_multiple_of(ci_poll_interval)));
         let force_gh = !trigger_acc.force_gh_ids.is_empty();
         let check_prs = force_gh || pr_cadence;
         let check_ci = force_gh || ci_cadence;
@@ -513,12 +601,17 @@ pub async fn run_git_poll(
         }
 
         trigger_acc.clear();
-        cycle += 1;
-        let deadline = tokio::time::sleep(GIT_POLL_INTERVAL);
-        tokio::pin!(deadline);
+        if cadence_due {
+            cycle = cycle.wrapping_add(1);
+        }
+        cadence_due = false;
         loop {
             tokio::select! {
                 biased;
+                _ = cadence.tick() => {
+                    cadence_due = true;
+                    break;
+                }
                 trigger = trigger_rx.recv(), if !trigger_rx_closed => {
                     match trigger {
                         Some(trigger) => {
@@ -539,7 +632,6 @@ pub async fn run_git_poll(
                         &state_version,
                     );
                 }
-                _ = &mut deadline => break,
             }
         }
     }
@@ -789,6 +881,116 @@ mod tests {
         assert!(acc.head_change_ids.contains("committed"));
         assert!(!acc.force_gh_ids.contains("committed"));
         assert!(!acc.force_gh_ids.contains("visible"));
+        assert_eq!(
+            acc.local_status_ids(),
+            HashSet::from([
+                "committed".to_string(),
+                "visible".to_string(),
+                "switched".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn status_poll_selection_respects_tiers_and_targeted_wakes() {
+        let active = HashSet::from(["visible".to_string(), "hidden".to_string()]);
+        let relevant = HashSet::from(["visible".to_string()]);
+        let hidden = HashSet::from(["hidden".to_string()]);
+        let empty = HashSet::new();
+
+        assert_eq!(
+            select_status_poll_ids(&active, &relevant, &empty, &empty, true, true),
+            active,
+            "startup and hidden fallback cycles scan every active project"
+        );
+        assert_eq!(
+            select_status_poll_ids(&active, &relevant, &empty, &empty, true, false),
+            relevant,
+            "ordinary cadence scans only relevant projects"
+        );
+        assert_eq!(
+            select_status_poll_ids(&active, &relevant, &hidden, &empty, false, false),
+            hidden,
+            "targeted hidden refreshes do not wait for fallback cadence"
+        );
+        assert_eq!(
+            select_status_poll_ids(&active, &empty, &empty, &hidden, false, false),
+            hidden,
+            "promotion to the relevant tier refreshes immediately"
+        );
+    }
+
+    #[test]
+    fn merging_targeted_statuses_retains_unpolled_and_prunes_deleted() {
+        let previous = HashMap::from([
+            (
+                "visible".to_string(),
+                GitStatus {
+                    branch: Some("main".to_string()),
+                    ..GitStatus::default()
+                },
+            ),
+            (
+                "hidden".to_string(),
+                GitStatus {
+                    branch: Some("main".to_string()),
+                    ..GitStatus::default()
+                },
+            ),
+            ("deleted".to_string(), GitStatus::default()),
+        ]);
+        let active = HashSet::from([
+            "visible".to_string(),
+            "hidden".to_string(),
+            "not-a-repo".to_string(),
+        ]);
+        let attempted = HashMap::from([
+            (
+                "hidden".to_string(),
+                Some(GitStatus {
+                    branch: Some("feature".to_string()),
+                    ..GitStatus::default()
+                }),
+            ),
+            ("not-a-repo".to_string(), None),
+        ]);
+
+        let merged = merge_status_results(&previous, &active, attempted);
+        assert_eq!(
+            merged
+                .get("visible")
+                .and_then(|status| status.branch.as_deref()),
+            Some("main"),
+            "unpolled active status stays published"
+        );
+        assert_eq!(
+            merged
+                .get("hidden")
+                .and_then(|status| status.branch.as_deref()),
+            Some("feature")
+        );
+        assert!(!merged.contains_key("deleted"));
+        assert!(!merged.contains_key("not-a-repo"));
+    }
+
+    #[test]
+    fn unsampled_head_snapshots_survive_fast_tier_ticks() {
+        let mut previous = HashMap::from([
+            ("hidden".to_string(), "old".to_string()),
+            ("deleted".to_string(), "old".to_string()),
+        ]);
+        let active = HashSet::from(["hidden".to_string()]);
+
+        assert!(update_head_snapshots(&mut previous, &active, HashMap::new()).is_empty());
+        assert_eq!(previous.get("hidden").map(String::as_str), Some("old"));
+        assert!(!previous.contains_key("deleted"));
+
+        let changed = update_head_snapshots(
+            &mut previous,
+            &active,
+            HashMap::from([("hidden".to_string(), "new".to_string())]),
+        );
+        assert_eq!(changed, vec!["hidden".to_string()]);
     }
 
     #[test]

--- a/crates/okena-daemon/Cargo.toml
+++ b/crates/okena-daemon/Cargo.toml
@@ -8,6 +8,11 @@ license = "MIT"
 name = "okena-daemon"
 path = "src/main.rs"
 
+[features]
+default = []
+# Runtime collection still requires OKENA_TERMINAL_LATENCY_PROBE=1.
+terminal-latency-probe = ["okena-core/terminal-latency-probe"]
+
 [dependencies]
 okena-daemon-core = { path = "../okena-daemon-core" }
 # gpui-free: provides the profile resolution used to honor OKENA_PROFILE so the

--- a/crates/okena-remote-client/src/connection.rs
+++ b/crates/okena-remote-client/src/connection.rs
@@ -78,6 +78,7 @@ impl ConnectionHandler for DesktopConnectionHandler {
     fn on_terminal_output(&self, prefixed_id: &str, data: &[u8]) {
         let terminal = self.terminals.lock().get(prefixed_id).cloned();
         if let Some(terminal) = terminal {
+            okena_core::latency_probe::client_output_received(prefixed_id);
             terminal.enqueue_output(data);
             // Ring the doorbell so the GPUI-side activity pump wakes and
             // repaints bell/idle indicators. Capacity 1: a full channel means a

--- a/crates/okena-remote-client/src/manager.rs
+++ b/crates/okena-remote-client/src/manager.rs
@@ -300,6 +300,7 @@ impl RemoteConnectionManager {
                         // Parse on the GPUI thread so bell/idle flags are
                         // current even for terminals with no mounted pane.
                         terminal.process_pending_output();
+                        okena_core::latency_probe::client_output_parsed(id);
                         let generation = terminal.content_generation();
                         if last_generations.get(id) != Some(&generation) {
                             advanced.push(id.clone());
@@ -310,6 +311,9 @@ impl RemoteConnectionManager {
                     last_generations = next_generations;
 
                     if changed {
+                        for terminal_id in &advanced {
+                            okena_core::latency_probe::client_activity_emitted(terminal_id);
+                        }
                         // Emit (not notify): repaint the sidebar's bell/idle
                         // indicators without dragging in the heavy project-sync
                         // observer that fires on `cx.notify()`, and let `Okena`

--- a/crates/okena-remote-server/src/routes/stream.rs
+++ b/crates/okena-remote-server/src/routes/stream.rs
@@ -269,6 +269,10 @@ async fn handle_ws(
                                 }).await;
                             }
                             Ok(WsInbound::SendBytes { terminal_id, data }) => {
+                                okena_core::latency_probe::daemon_input_received(
+                                    &terminal_id,
+                                    &data,
+                                );
                                 let _ = state.bridge_tx.send(BridgeMessage {
                                     command: RemoteCommand::ActionFromConnection {
                                         action: ActionRequest::SendBytes { terminal_id, data },
@@ -344,6 +348,10 @@ async fn handle_ws(
                         // Binary input frame from client — fire-and-forget
                         if let Some((FRAME_TYPE_INPUT, stream_id, payload)) = parse_binary_frame(&data)
                             && let Some(terminal_id) = reverse_stream_map.get(&stream_id) {
+                                okena_core::latency_probe::daemon_input_received(
+                                    terminal_id,
+                                    payload,
+                                );
                                 let _ = state.bridge_tx.send(BridgeMessage {
                                     command: RemoteCommand::ActionFromConnection {
                                         action: ActionRequest::SendBytes {
@@ -374,6 +382,7 @@ async fn handle_ws(
                                 if output_is_newer(&output_watermarks, terminal_id, *sequence)
                                     && let Some(&stream_id) = subscribed_ids.get(terminal_id)
                                 {
+                                    okena_core::latency_probe::daemon_stream_queued(terminal_id);
                                     batch.entry(stream_id).or_default().extend_from_slice(data);
                                 }
                             }
@@ -406,6 +415,7 @@ async fn handle_ws(
                                         if output_is_newer(&output_watermarks, terminal_id, *sequence)
                                             && let Some(&sid) = subscribed_ids.get(terminal_id)
                                         {
+                                            okena_core::latency_probe::daemon_stream_queued(terminal_id);
                                             batch.entry(sid).or_default().extend_from_slice(data);
                                         }
                                     }

--- a/crates/okena-terminal/src/pty_manager.rs
+++ b/crates/okena-terminal/src/pty_manager.rs
@@ -1259,6 +1259,7 @@ impl PtyManager {
                         n,
                         String::from_utf8_lossy(&data[..n.min(100)])
                     );
+                    okena_core::latency_probe::daemon_pty_output_received(&terminal_id);
                     // Broadcast to external consumers immediately (bypasses UI event loop)
                     let sequence = {
                         let instances = instances.lock();
@@ -1318,6 +1319,7 @@ impl PtyManager {
             }
 
             // Write the batched data
+            okena_core::latency_probe::daemon_pty_write_started(&terminal_id);
             if let Err(e) = writer.lock().write_all(&batch) {
                 log::error!("Failed to write to PTY {}: {}", terminal_id, e);
                 shutdown.mark_broken();
@@ -1328,6 +1330,7 @@ impl PtyManager {
                 });
                 break;
             }
+            okena_core::latency_probe::daemon_pty_write_completed(&terminal_id);
         }
     }
 
@@ -1338,6 +1341,7 @@ impl PtyManager {
         if let Some(handle) = self.terminals.lock().get(terminal_id)
             && let Some(input_tx) = handle.input_tx.as_ref()
         {
+            okena_core::latency_probe::daemon_pty_queued(terminal_id);
             let _ = input_tx.send(data.to_vec());
         }
     }

--- a/crates/okena-terminal/src/terminal/io.rs
+++ b/crates/okena-terminal/src/terminal/io.rs
@@ -1,10 +1,12 @@
 use alacritty_terminal::grid::Dimensions;
 use alacritty_terminal::term::TermMode;
 use std::sync::atomic::Ordering;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
-use super::Terminal;
 use super::prompt_marks::advance_with_prompt_marks;
+use super::{InputRepaintRequest, Terminal};
+
+const INPUT_REPAINT_REQUEST_TTL: Duration = Duration::from_secs(5);
 
 impl Terminal {
     /// Process output from PTY
@@ -14,6 +16,8 @@ impl Terminal {
 
     /// Process PTY output and atomically associate it with its broadcast order.
     pub fn process_output_with_sequence(&self, data: &[u8], sequence: u64) {
+        let output_epoch =
+            (!data.is_empty()).then(|| self.output_epoch.fetch_add(1, Ordering::AcqRel) + 1);
         let mut _slow = okena_core::timing::SlowGuard::with_detail(
             "Terminal::process_output",
             format!("{} bytes", data.len()),
@@ -64,6 +68,10 @@ impl Terminal {
             self.processed_output_sequence
                 .store(sequence, Ordering::Release);
         }
+        if let Some(output_epoch) = output_epoch {
+            self.processed_output_epoch
+                .fetch_max(output_epoch, Ordering::Release);
+        }
         *self.last_output_time.lock() = Instant::now();
     }
 
@@ -73,7 +81,14 @@ impl Terminal {
     /// `term.lock()`. The pending data is drained and parsed on the GPUI
     /// thread just before rendering (see `with_content`).
     pub fn enqueue_output(&self, data: &[u8]) {
-        self.pending_output.lock().extend_from_slice(data);
+        let mut pending = self.pending_output.lock();
+        pending.extend_from_slice(data);
+        if !data.is_empty() {
+            let output_epoch = self.output_epoch.fetch_add(1, Ordering::AcqRel) + 1;
+            self.pending_output_epoch
+                .store(output_epoch, Ordering::Release);
+        }
+        drop(pending);
         self.dirty.store(true, Ordering::Relaxed);
         *self.last_output_time.lock() = Instant::now();
     }
@@ -97,12 +112,13 @@ impl Terminal {
     ///
     /// Called automatically by `with_content` before rendering.
     pub(super) fn drain_pending_output(&self) {
-        let data = {
+        let (data, output_epoch) = {
             let mut pending = self.pending_output.lock();
             if pending.is_empty() {
                 return;
             }
-            std::mem::take(&mut *pending)
+            let output_epoch = self.pending_output_epoch.load(Ordering::Acquire);
+            (std::mem::take(&mut *pending), output_epoch)
         };
         let _slow = okena_core::timing::SlowGuard::with_detail(
             "Terminal::drain_pending_output",
@@ -133,6 +149,8 @@ impl Terminal {
             term.grid().topmost_line().0,
         );
         self.content_generation.fetch_add(1, Ordering::Relaxed);
+        self.processed_output_epoch
+            .fetch_max(output_epoch, Ordering::Release);
     }
 
     /// Check if terminal has pending changes (and clear the flag).
@@ -146,10 +164,51 @@ impl Terminal {
         self.content_generation.load(Ordering::Relaxed)
     }
 
+    fn mark_user_input(&self, has_payload: bool) {
+        self.had_user_input.store(true, Ordering::Relaxed);
+        if !has_payload {
+            return;
+        }
+
+        // Synchronize with remote enqueue so output already buffered before the
+        // input cannot consume this request. The next enqueue receives this epoch.
+        let after_output_epoch = {
+            let _pending = self.pending_output.lock();
+            self.output_epoch.load(Ordering::Acquire).saturating_add(1)
+        };
+        *self.input_repaint_request.lock() = Some(InputRepaintRequest {
+            after_output_epoch,
+            expires_at: Instant::now() + INPUT_REPAINT_REQUEST_TTL,
+        });
+    }
+
+    /// Consume the one-shot request once parsed output crosses the output epoch
+    /// captured immediately before user input reached the transport.
+    pub fn take_input_repaint_request(&self) -> bool {
+        self.take_input_repaint_request_at(Instant::now())
+    }
+
+    pub(crate) fn take_input_repaint_request_at(&self, now: Instant) -> bool {
+        let processed_output_epoch = self.processed_output_epoch.load(Ordering::Acquire);
+        let mut request = self.input_repaint_request.lock();
+        let Some(current) = *request else {
+            return false;
+        };
+        if now >= current.expires_at {
+            *request = None;
+            return false;
+        }
+        if processed_output_epoch < current.after_output_epoch {
+            return false;
+        }
+        *request = None;
+        true
+    }
+
     /// Send input to the PTY
     /// Automatically scrolls to bottom if scrolled into history
     pub fn send_input(&self, input: &str) {
-        self.had_user_input.store(true, Ordering::Relaxed);
+        self.mark_user_input(!input.is_empty());
         self.scroll_to_bottom();
         self.transport
             .send_input(&self.terminal_id, input.as_bytes());
@@ -159,7 +218,7 @@ impl Terminal {
     /// terminal application has enabled bracketed paste mode (DECSET 2004).
     /// This prevents shells from executing each line of a multi-line paste individually.
     pub fn send_paste(&self, text: &str) {
-        self.had_user_input.store(true, Ordering::Relaxed);
+        self.mark_user_input(!text.is_empty());
         self.scroll_to_bottom();
 
         let bracketed = self.term.lock().mode().contains(TermMode::BRACKETED_PASTE);
@@ -184,7 +243,7 @@ impl Terminal {
     /// as literal text — annoying but recoverable, vs. multi-line content
     /// executing each line as a separate command.
     pub fn send_paste_force_bracketed(&self, text: &str) {
-        self.had_user_input.store(true, Ordering::Relaxed);
+        self.mark_user_input(!text.is_empty());
         self.scroll_to_bottom();
         self.write_bracketed_paste(text);
     }
@@ -209,7 +268,7 @@ impl Terminal {
     /// Send raw bytes to the PTY
     /// Automatically scrolls to bottom if scrolled into history
     pub fn send_bytes(&self, data: &[u8]) {
-        self.had_user_input.store(true, Ordering::Relaxed);
+        self.mark_user_input(!data.is_empty());
         self.scroll_to_bottom();
         self.transport.send_input(&self.terminal_id, data);
     }

--- a/crates/okena-terminal/src/terminal/io.rs
+++ b/crates/okena-terminal/src/terminal/io.rs
@@ -208,8 +208,20 @@ impl Terminal {
     /// Send input to the PTY
     /// Automatically scrolls to bottom if scrolled into history
     pub fn send_input(&self, input: &str) {
+        self.send_input_inner(input, None);
+    }
+
+    /// Send text input and associate latency samples with its originating viewer.
+    pub fn send_input_from_viewer(&self, input: &str, viewer: u64) {
+        self.send_input_inner(input, Some(viewer));
+    }
+
+    fn send_input_inner(&self, input: &str, viewer: Option<u64>) {
         self.mark_user_input(!input.is_empty());
         self.scroll_to_bottom();
+        if let Some(viewer) = viewer {
+            okena_core::latency_probe::client_start(&self.terminal_id, viewer, input.as_bytes());
+        }
         self.transport
             .send_input(&self.terminal_id, input.as_bytes());
     }
@@ -268,8 +280,20 @@ impl Terminal {
     /// Send raw bytes to the PTY
     /// Automatically scrolls to bottom if scrolled into history
     pub fn send_bytes(&self, data: &[u8]) {
+        self.send_bytes_inner(data, None);
+    }
+
+    /// Send raw input and associate latency samples with its originating viewer.
+    pub fn send_bytes_from_viewer(&self, data: &[u8], viewer: u64) {
+        self.send_bytes_inner(data, Some(viewer));
+    }
+
+    fn send_bytes_inner(&self, data: &[u8], viewer: Option<u64>) {
         self.mark_user_input(!data.is_empty());
         self.scroll_to_bottom();
+        if let Some(viewer) = viewer {
+            okena_core::latency_probe::client_start(&self.terminal_id, viewer, data);
+        }
         self.transport.send_input(&self.terminal_id, data);
     }
 

--- a/crates/okena-terminal/src/terminal/meta.rs
+++ b/crates/okena-terminal/src/terminal/meta.rs
@@ -13,8 +13,8 @@ impl Terminal {
         *self.has_bell.lock()
     }
 
-    /// Take any pending OSC 52 clipboard writes. Called by the GPUI thread
-    /// on each render; returns the texts to write to the system clipboard.
+    /// Take any pending OSC 52 clipboard writes. Called by the GPUI activity
+    /// handler (with render as a fallback); returns texts for the system clipboard.
     pub fn take_pending_clipboard_writes(&self) -> Vec<String> {
         std::mem::take(&mut *self.pending_clipboard.lock())
     }

--- a/crates/okena-terminal/src/terminal/mod.rs
+++ b/crates/okena-terminal/src/terminal/mod.rs
@@ -55,6 +55,12 @@ use osc_sidecar::OscSidecar;
 use prompt_marks::{PromptSidecar, PromptTracker};
 use types::FocusReportState;
 
+#[derive(Debug, Clone, Copy)]
+pub(super) struct InputRepaintRequest {
+    after_output_epoch: u64,
+    expires_at: Instant,
+}
+
 /// A terminal instance wrapping alacritty_terminal
 /// Terminal emulator state.
 ///
@@ -71,7 +77,7 @@ use types::FocusReportState;
 ///
 /// 2. **Tokio reader task** (remote connections only) — calls `enqueue_output`
 ///    to buffer incoming data without holding `term.lock()`. Only touches
-///    `pending_output`, `dirty`, and `last_output_time`.
+///    `pending_output`, output epochs, `dirty`, and `last_output_time`.
 ///
 /// 3. **Resize debounce timer** — a short-lived `std::thread::spawn` that
 ///    flushes a trailing-edge resize after the debounce window. Only touches
@@ -94,8 +100,8 @@ use types::FocusReportState;
 ///   threads contend.
 ///
 /// - **`AtomicBool` / `AtomicU64`** — lock-free signaling between the GPUI
-///   thread and the tokio reader task (for `dirty`), or between the GPUI
-///   thread's output path and its render path (for `content_generation`,
+///   thread and the tokio reader task (for `dirty` and output epochs), or between
+///   the GPUI thread's output path and its render path (for `content_generation`,
 ///   `waiting_for_input`, `had_user_input`) to avoid mutex overhead on every
 ///   frame.
 pub struct Terminal {
@@ -275,6 +281,22 @@ pub struct Terminal {
     /// freeze the UI.
     pub(super) pending_output: Mutex<Vec<u8>>,
 
+    /// Monotonic arrival epoch for local and remotely enqueued output. Input
+    /// captures the next epoch as its causal repaint boundary.
+    pub(super) output_epoch: AtomicU64,
+
+    /// Last remote-output epoch represented by `pending_output`. Updated while
+    /// holding `pending_output` so a drain captures bytes and epoch atomically.
+    pub(super) pending_output_epoch: AtomicU64,
+
+    /// Highest output epoch incorporated into the terminal model.
+    pub(super) processed_output_epoch: AtomicU64,
+
+    /// Output-after-input promotion request. The epoch prevents pre-input
+    /// backlog from consuming it; expiry prevents an unanswered input from
+    /// promoting unrelated output indefinitely.
+    pub(super) input_repaint_request: Mutex<Option<InputRepaintRequest>>,
+
     /// Content-changed flag. Set by `process_output` (GPUI) and
     /// `enqueue_output` (tokio). Cleared by `take_dirty` (GPUI render).
     /// `AtomicBool` for lock-free cross-thread signaling.
@@ -402,6 +424,10 @@ impl Terminal {
             pending_clipboard_reads,
             palette,
             pending_output: Mutex::new(Vec::new()),
+            output_epoch: AtomicU64::new(0),
+            pending_output_epoch: AtomicU64::new(0),
+            processed_output_epoch: AtomicU64::new(0),
+            input_repaint_request: Mutex::new(None),
             dirty: AtomicBool::new(false),
             content_generation: AtomicU64::new(0),
             processed_output_sequence: AtomicU64::new(0),

--- a/crates/okena-terminal/src/terminal/mod.rs
+++ b/crates/okena-terminal/src/terminal/mod.rs
@@ -162,8 +162,8 @@ pub struct Terminal {
     pub(super) has_notification: AtomicBool,
 
     /// Pending OSC 52 clipboard writes requested by the running app. `Arc`
-    /// shared with `ZedEventListener`: pushed during `process_output`,
-    /// drained by the GPUI render path via `drain_clipboard_writes`.
+    /// shared with `ZedEventListener`: pushed during `process_output`, then
+    /// drained by the GPUI activity handler (or render fallback).
     /// GPUI thread only.
     pub(super) pending_clipboard: Arc<Mutex<Vec<String>>>,
 

--- a/crates/okena-terminal/src/terminal/tests/input_repaint.rs
+++ b/crates/okena-terminal/src/terminal/tests/input_repaint.rs
@@ -1,0 +1,108 @@
+use super::super::Terminal;
+use super::super::types::TerminalSize;
+use super::NullTransport;
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn terminal() -> Terminal {
+    Terminal::new(
+        "input-repaint-test".to_string(),
+        TerminalSize::default(),
+        Arc::new(NullTransport),
+        "/tmp".to_string(),
+    )
+}
+
+#[test]
+fn user_input_promotes_the_next_processed_output_once() {
+    let terminal = terminal();
+
+    terminal.send_input("a");
+    assert!(
+        !terminal.take_input_repaint_request(),
+        "input alone does not promote an old terminal frame"
+    );
+
+    terminal.process_output(b"a");
+    assert!(terminal.take_input_repaint_request());
+    assert!(
+        !terminal.take_input_repaint_request(),
+        "the request is one-shot until more input arrives"
+    );
+}
+
+#[test]
+fn pre_input_backlog_cannot_consume_the_request() {
+    let terminal = terminal();
+
+    terminal.enqueue_output(b"before input");
+    terminal.send_input("a");
+    terminal.process_pending_output();
+    assert!(!terminal.take_input_repaint_request());
+
+    terminal.enqueue_output(b"after input");
+    terminal.process_pending_output();
+    assert!(terminal.take_input_repaint_request());
+}
+
+#[test]
+fn concurrent_enqueue_and_input_never_lose_the_priority_request() {
+    for _ in 0..16 {
+        let terminal = Arc::new(terminal());
+        let start = Arc::new(Barrier::new(3));
+
+        let enqueue = {
+            let terminal = terminal.clone();
+            let start = start.clone();
+            thread::spawn(move || {
+                start.wait();
+                terminal.enqueue_output(b"racing output");
+            })
+        };
+        let input = {
+            let terminal = terminal.clone();
+            let start = start.clone();
+            thread::spawn(move || {
+                start.wait();
+                terminal.send_input("a");
+            })
+        };
+
+        start.wait();
+        assert!(enqueue.join().is_ok(), "enqueue thread panicked");
+        assert!(input.join().is_ok(), "input thread panicked");
+        terminal.process_pending_output();
+
+        if !terminal.take_input_repaint_request() {
+            // The racing output was ordered before the input. The first output
+            // ordered after it must still consume the request.
+            terminal.enqueue_output(b"after input");
+            terminal.process_pending_output();
+            assert!(terminal.take_input_repaint_request());
+        }
+    }
+}
+
+#[test]
+fn unanswered_and_empty_input_do_not_leave_stale_priority() {
+    let terminal = terminal();
+
+    terminal.send_input("");
+    terminal.process_output(b"unrelated");
+    assert!(!terminal.take_input_repaint_request());
+
+    terminal.send_bytes(b"x");
+    assert!(!terminal.take_input_repaint_request_at(Instant::now() + Duration::from_secs(10)));
+    terminal.process_output(b"much later");
+    assert!(!terminal.take_input_repaint_request());
+}
+
+#[test]
+fn terminal_output_alone_does_not_request_input_priority() {
+    let terminal = terminal();
+
+    terminal.process_output(b"background output");
+
+    assert!(!terminal.take_input_repaint_request());
+}

--- a/crates/okena-terminal/src/terminal/tests/mod.rs
+++ b/crates/okena-terminal/src/terminal/tests/mod.rs
@@ -1,5 +1,6 @@
 mod focus_report;
 mod helpers;
+mod input_repaint;
 mod kitty;
 mod osc;
 mod prompt_jump;

--- a/crates/okena-ui/src/activity_repaint.rs
+++ b/crates/okena-ui/src/activity_repaint.rs
@@ -1,14 +1,22 @@
 use std::collections::HashSet;
 use std::hash::Hash;
 
+/// Immediate presentation work produced by one activity event.
+#[derive(Debug)]
+pub struct ActivityRepaintDecision<T> {
+    /// Keys to present synchronously for either the leading edge or input priority.
+    pub immediate: HashSet<T>,
+    /// Whether this event transitioned from idle and must start the sole timer loop.
+    pub start_timer: bool,
+}
+
 /// Collects exact repaint keys behind a leading-edge presentation batch.
 ///
-/// [`queue`](Self::queue) returns `true` when activity transitions from idle.
-/// The caller drains those keys with [`take_immediate`](Self::take_immediate),
-/// presents them immediately, and starts its frame timer. Activity during that
-/// interval is deduplicated for [`take_scheduled`](Self::take_scheduled). The
-/// timer keeps running while frames contain activity and rearms the leading edge
-/// after one empty frame.
+/// [`queue_activity`](Self::queue_activity) presents the idle-to-active edge
+/// immediately and tells the caller to start one frame timer. While that timer
+/// is active, ordinary activity is deduplicated for
+/// [`take_scheduled`](Self::take_scheduled), but selected input-response keys can
+/// be promoted to immediate presentation without starting another timer.
 #[derive(Debug)]
 pub struct ActivityRepaintBatch<T> {
     pending: HashSet<T>,
@@ -25,19 +33,30 @@ impl<T> Default for ActivityRepaintBatch<T> {
 }
 
 impl<T: Eq + Hash> ActivityRepaintBatch<T> {
-    pub fn queue(&mut self, keys: impl IntoIterator<Item = T>) -> bool {
+    pub fn queue_activity(
+        &mut self,
+        keys: impl IntoIterator<Item = T>,
+        promoted: impl IntoIterator<Item = T>,
+    ) -> ActivityRepaintDecision<T> {
         self.pending.extend(keys);
-        if self.scheduled || self.pending.is_empty() {
-            return false;
+        if !self.scheduled && !self.pending.is_empty() {
+            self.scheduled = true;
+            return ActivityRepaintDecision {
+                immediate: std::mem::take(&mut self.pending),
+                start_timer: true,
+            };
         }
-        self.scheduled = true;
-        true
-    }
 
-    /// Drain the leading-edge keys without ending the scheduled frame window.
-    pub fn take_immediate(&mut self) -> HashSet<T> {
-        debug_assert!(self.scheduled);
-        std::mem::take(&mut self.pending)
+        let mut immediate = HashSet::new();
+        for key in promoted {
+            if self.pending.remove(&key) {
+                immediate.insert(key);
+            }
+        }
+        ActivityRepaintDecision {
+            immediate,
+            start_timer: false,
+        }
     }
 
     /// Drain one scheduled frame, or end the frame window when activity is idle.
@@ -57,23 +76,42 @@ mod tests {
     use std::collections::HashSet;
 
     #[test]
-    fn first_activity_is_immediate_then_frames_are_deduplicated() {
+    fn leading_edge_is_immediate_and_starts_one_timer() {
         let mut batch = ActivityRepaintBatch::default();
 
-        assert!(batch.queue(["a", "b"]));
-        assert_eq!(batch.take_immediate(), HashSet::from(["a", "b"]));
+        let decision = batch.queue_activity(["a", "b"], []);
 
-        assert!(!batch.queue(["b", "c"]));
-        assert!(!batch.queue(["c"]));
-        assert_eq!(batch.take_scheduled(), Some(HashSet::from(["b", "c"])));
-
-        assert_eq!(batch.take_scheduled(), None, "an empty frame ends batching");
-        assert!(batch.queue(["a"]), "activity after idle is immediate again");
+        assert!(decision.start_timer);
+        assert_eq!(decision.immediate, HashSet::from(["a", "b"]));
     }
 
     #[test]
-    fn empty_repaint_batch_does_not_schedule() {
+    fn input_response_is_promoted_while_unrelated_activity_stays_batched() {
+        let mut batch = ActivityRepaintBatch::default();
+        let leading = batch.queue_activity(["initial"], []);
+        assert!(leading.start_timer);
+
+        let busy = batch.queue_activity(["input", "background"], ["input"]);
+
+        assert!(!busy.start_timer, "promotion must not start a second timer");
+        assert_eq!(busy.immediate, HashSet::from(["input"]));
+        assert_eq!(
+            batch.take_scheduled(),
+            Some(HashSet::from(["background"])),
+            "promoted ids must not repaint again on the scheduled frame"
+        );
+        assert_eq!(batch.take_scheduled(), None, "an empty frame rearms idle");
+
+        let next = batch.queue_activity(["next"], []);
+        assert!(next.start_timer);
+        assert_eq!(next.immediate, HashSet::from(["next"]));
+    }
+
+    #[test]
+    fn empty_activity_does_not_schedule() {
         let mut batch = ActivityRepaintBatch::<&str>::default();
-        assert!(!batch.queue([]));
+        let decision = batch.queue_activity([], []);
+        assert!(!decision.start_timer);
+        assert!(decision.immediate.is_empty());
     }
 }

--- a/crates/okena-ui/src/activity_repaint.rs
+++ b/crates/okena-ui/src/activity_repaint.rs
@@ -1,11 +1,14 @@
 use std::collections::HashSet;
 use std::hash::Hash;
 
-/// Collects exact repaint keys behind one scheduled frame callback.
+/// Collects exact repaint keys behind a leading-edge presentation batch.
 ///
-/// [`queue`](Self::queue) returns `true` only for the first key(s) in a batch,
-/// telling the caller to schedule one timer. Further activity is deduplicated
-/// until [`take`](Self::take) drains the keys and rearms the batch.
+/// [`queue`](Self::queue) returns `true` when activity transitions from idle.
+/// The caller drains those keys with [`take_immediate`](Self::take_immediate),
+/// presents them immediately, and starts its frame timer. Activity during that
+/// interval is deduplicated for [`take_scheduled`](Self::take_scheduled). The
+/// timer keeps running while frames contain activity and rearms the leading edge
+/// after one empty frame.
 #[derive(Debug)]
 pub struct ActivityRepaintBatch<T> {
     pending: HashSet<T>,
@@ -31,9 +34,20 @@ impl<T: Eq + Hash> ActivityRepaintBatch<T> {
         true
     }
 
-    pub fn take(&mut self) -> HashSet<T> {
-        self.scheduled = false;
+    /// Drain the leading-edge keys without ending the scheduled frame window.
+    pub fn take_immediate(&mut self) -> HashSet<T> {
+        debug_assert!(self.scheduled);
         std::mem::take(&mut self.pending)
+    }
+
+    /// Drain one scheduled frame, or end the frame window when activity is idle.
+    pub fn take_scheduled(&mut self) -> Option<HashSet<T>> {
+        if self.pending.is_empty() {
+            self.scheduled = false;
+            None
+        } else {
+            Some(std::mem::take(&mut self.pending))
+        }
     }
 }
 
@@ -43,13 +57,18 @@ mod tests {
     use std::collections::HashSet;
 
     #[test]
-    fn repaint_batch_deduplicates_keys_behind_one_schedule() {
+    fn first_activity_is_immediate_then_frames_are_deduplicated() {
         let mut batch = ActivityRepaintBatch::default();
 
         assert!(batch.queue(["a", "b"]));
+        assert_eq!(batch.take_immediate(), HashSet::from(["a", "b"]));
+
         assert!(!batch.queue(["b", "c"]));
-        assert_eq!(batch.take(), HashSet::from(["a", "b", "c"]));
-        assert!(batch.queue(["a"]), "taking the batch rearms scheduling");
+        assert!(!batch.queue(["c"]));
+        assert_eq!(batch.take_scheduled(), Some(HashSet::from(["b", "c"])));
+
+        assert_eq!(batch.take_scheduled(), None, "an empty frame ends batching");
+        assert!(batch.queue(["a"]), "activity after idle is immediate again");
     }
 
     #[test]

--- a/crates/okena-ui/src/activity_repaint.rs
+++ b/crates/okena-ui/src/activity_repaint.rs
@@ -1,0 +1,139 @@
+use std::collections::HashSet;
+use std::hash::Hash;
+
+/// Collects exact repaint keys behind one scheduled frame callback.
+///
+/// [`queue`](Self::queue) returns `true` only for the first key(s) in a batch,
+/// telling the caller to schedule one timer. Further activity is deduplicated
+/// until [`take`](Self::take) drains the keys and rearms the batch.
+#[derive(Debug)]
+pub struct ActivityRepaintBatch<T> {
+    pending: HashSet<T>,
+    scheduled: bool,
+}
+
+impl<T> Default for ActivityRepaintBatch<T> {
+    fn default() -> Self {
+        Self {
+            pending: HashSet::new(),
+            scheduled: false,
+        }
+    }
+}
+
+impl<T: Eq + Hash> ActivityRepaintBatch<T> {
+    pub fn queue(&mut self, keys: impl IntoIterator<Item = T>) -> bool {
+        self.pending.extend(keys);
+        if self.scheduled || self.pending.is_empty() {
+            return false;
+        }
+        self.scheduled = true;
+        true
+    }
+
+    pub fn take(&mut self) -> HashSet<T> {
+        self.scheduled = false;
+        std::mem::take(&mut self.pending)
+    }
+}
+
+/// Coalesces activity-driven repaint requests while a window is inactive.
+///
+/// Call [`request`](Self::request) when model activity may have changed what a
+/// view displays. A `true` return means the caller should notify the view now;
+/// `false` means either the window is inactive or a repaint is already pending.
+/// Call [`repainted`](Self::repainted) from the view's render path, and call
+/// [`set_active`](Self::set_active) when its OS window activation changes.
+#[derive(Debug, Clone, Copy)]
+pub struct ActivityRepaintGate {
+    active: bool,
+    repaint_pending: bool,
+}
+
+impl ActivityRepaintGate {
+    pub fn new(active: bool) -> Self {
+        Self {
+            active,
+            repaint_pending: false,
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    /// Records activity and reports whether a repaint should be scheduled now.
+    pub fn request(&mut self) -> bool {
+        if self.repaint_pending {
+            return false;
+        }
+        self.repaint_pending = true;
+        self.active
+    }
+
+    /// Updates activation and reports whether pending activity should be flushed.
+    pub fn set_active(&mut self, active: bool) -> bool {
+        self.active = active;
+        active && self.repaint_pending
+    }
+
+    /// Marks the pending model state as represented by the rendered view.
+    pub fn repainted(&mut self) {
+        self.repaint_pending = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ActivityRepaintBatch, ActivityRepaintGate};
+    use std::collections::HashSet;
+
+    #[test]
+    fn repaint_batch_deduplicates_keys_behind_one_schedule() {
+        let mut batch = ActivityRepaintBatch::default();
+
+        assert!(batch.queue(["a", "b"]));
+        assert!(!batch.queue(["b", "c"]));
+        assert_eq!(batch.take(), HashSet::from(["a", "b", "c"]));
+        assert!(batch.queue(["a"]), "taking the batch rearms scheduling");
+    }
+
+    #[test]
+    fn empty_repaint_batch_does_not_schedule() {
+        let mut batch = ActivityRepaintBatch::<&str>::default();
+        assert!(!batch.queue([]));
+    }
+
+    #[test]
+    fn active_requests_coalesce_until_rendered() {
+        let mut gate = ActivityRepaintGate::new(true);
+
+        assert!(gate.request());
+        assert!(!gate.request());
+
+        gate.repainted();
+        assert!(gate.request());
+    }
+
+    #[test]
+    fn inactive_requests_flush_once_on_activation() {
+        let mut gate = ActivityRepaintGate::new(false);
+
+        assert!(!gate.request());
+        assert!(!gate.request());
+        assert!(gate.set_active(true));
+
+        gate.repainted();
+        assert!(!gate.set_active(false));
+        assert!(!gate.set_active(true));
+    }
+
+    #[test]
+    fn deactivation_preserves_an_already_pending_repaint() {
+        let mut gate = ActivityRepaintGate::new(true);
+
+        assert!(gate.request());
+        assert!(!gate.set_active(false));
+        assert!(gate.set_active(true));
+    }
+}

--- a/crates/okena-ui/src/activity_repaint.rs
+++ b/crates/okena-ui/src/activity_repaint.rs
@@ -37,55 +37,9 @@ impl<T: Eq + Hash> ActivityRepaintBatch<T> {
     }
 }
 
-/// Coalesces activity-driven repaint requests while a window is inactive.
-///
-/// Call [`request`](Self::request) when model activity may have changed what a
-/// view displays. A `true` return means the caller should notify the view now;
-/// `false` means either the window is inactive or a repaint is already pending.
-/// Call [`repainted`](Self::repainted) from the view's render path, and call
-/// [`set_active`](Self::set_active) when its OS window activation changes.
-#[derive(Debug, Clone, Copy)]
-pub struct ActivityRepaintGate {
-    active: bool,
-    repaint_pending: bool,
-}
-
-impl ActivityRepaintGate {
-    pub fn new(active: bool) -> Self {
-        Self {
-            active,
-            repaint_pending: false,
-        }
-    }
-
-    pub fn is_active(&self) -> bool {
-        self.active
-    }
-
-    /// Records activity and reports whether a repaint should be scheduled now.
-    pub fn request(&mut self) -> bool {
-        if self.repaint_pending {
-            return false;
-        }
-        self.repaint_pending = true;
-        self.active
-    }
-
-    /// Updates activation and reports whether pending activity should be flushed.
-    pub fn set_active(&mut self, active: bool) -> bool {
-        self.active = active;
-        active && self.repaint_pending
-    }
-
-    /// Marks the pending model state as represented by the rendered view.
-    pub fn repainted(&mut self) {
-        self.repaint_pending = false;
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{ActivityRepaintBatch, ActivityRepaintGate};
+    use super::ActivityRepaintBatch;
     use std::collections::HashSet;
 
     #[test]
@@ -102,38 +56,5 @@ mod tests {
     fn empty_repaint_batch_does_not_schedule() {
         let mut batch = ActivityRepaintBatch::<&str>::default();
         assert!(!batch.queue([]));
-    }
-
-    #[test]
-    fn active_requests_coalesce_until_rendered() {
-        let mut gate = ActivityRepaintGate::new(true);
-
-        assert!(gate.request());
-        assert!(!gate.request());
-
-        gate.repainted();
-        assert!(gate.request());
-    }
-
-    #[test]
-    fn inactive_requests_flush_once_on_activation() {
-        let mut gate = ActivityRepaintGate::new(false);
-
-        assert!(!gate.request());
-        assert!(!gate.request());
-        assert!(gate.set_active(true));
-
-        gate.repainted();
-        assert!(!gate.set_active(false));
-        assert!(!gate.set_active(true));
-    }
-
-    #[test]
-    fn deactivation_preserves_an_already_pending_repaint() {
-        let mut gate = ActivityRepaintGate::new(true);
-
-        assert!(gate.request());
-        assert!(!gate.set_active(false));
-        assert!(gate.set_active(true));
     }
 }

--- a/crates/okena-ui/src/lib.rs
+++ b/crates/okena-ui/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! Reusable UI components, design tokens, and theme helpers for the Okena terminal.
 
+pub mod activity_repaint;
 pub mod badge;
 pub mod button;
 pub mod chip;

--- a/crates/okena-views-terminal/src/elements/terminal_element.rs
+++ b/crates/okena-views-terminal/src/elements/terminal_element.rs
@@ -390,6 +390,7 @@ impl Element for TerminalElement {
         // Register input handler
         let input_handler = TerminalInputHandler {
             terminal: self.terminal.clone(),
+            viewer_id: self.resize_viewer_id,
         };
         window.handle_input(&self.focus_handle, input_handler, cx);
 
@@ -818,6 +819,22 @@ impl Element for TerminalElement {
                 a: 0.2,
             });
             window.paint_quad(fill(bounds, fog));
+        }
+
+        let painted_samples = okena_core::latency_probe::client_painted(
+            &self.terminal.terminal_id,
+            self.resize_viewer_id,
+        );
+        if !painted_samples.is_empty() {
+            let terminal_id = self.terminal.terminal_id.clone();
+            let viewer_id = self.resize_viewer_id;
+            window.on_next_frame(move |_window, _cx| {
+                okena_core::latency_probe::client_frame_completed(
+                    &terminal_id,
+                    viewer_id,
+                    &painted_samples,
+                );
+            });
         }
     }
 }

--- a/crates/okena-views-terminal/src/elements/terminal_input.rs
+++ b/crates/okena-views-terminal/src/elements/terminal_input.rs
@@ -14,6 +14,7 @@ const MACOS_FUNCTION_KEY_RANGE: std::ops::RangeInclusive<char> = '\u{F700}'..='\
 /// Input handler for terminal text input
 pub(crate) struct TerminalInputHandler {
     pub terminal: Arc<Terminal>,
+    pub viewer_id: u64,
 }
 
 impl TerminalInputHandler {
@@ -37,19 +38,20 @@ impl TerminalInputHandler {
 
         // Fast path: no control characters, send entire string at once
         if !filtered.chars().any(|c| matches!(c, '\n' | '\r' | '\u{8}')) {
-            self.terminal.send_input(&filtered);
+            self.terminal
+                .send_input_from_viewer(&filtered, self.viewer_id);
             return;
         }
 
         // Slow path: handle control characters individually
         for c in filtered.chars() {
             match c {
-                '\u{8}' => self.terminal.send_bytes(&[DEL]),
-                '\n' | '\r' => self.terminal.send_bytes(b"\r"),
+                '\u{8}' => self.terminal.send_bytes_from_viewer(&[DEL], self.viewer_id),
+                '\n' | '\r' => self.terminal.send_bytes_from_viewer(b"\r", self.viewer_id),
                 _ => {
                     let mut buf = [0u8; 4];
                     let s = c.encode_utf8(&mut buf);
-                    self.terminal.send_input(s);
+                    self.terminal.send_input_from_viewer(s, self.viewer_id);
                 }
             }
         }

--- a/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
@@ -107,6 +107,12 @@ impl TerminalContent {
     /// the app-wide activity frame, so visible non-key windows stay live without
     /// each terminal stream driving an independent repaint clock.
     pub fn request_activity_repaint(&mut self, cx: &mut Context<Self>) {
+        if let Some(terminal) = &self.terminal {
+            okena_core::latency_probe::client_notify_requested(
+                &terminal.terminal_id,
+                self.resize_viewer_id,
+            );
+        }
         cx.notify();
     }
 

--- a/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
@@ -9,7 +9,6 @@ use crate::terminal_view_settings;
 use gpui::*;
 use okena_files::theme::theme;
 use okena_terminal::terminal::Terminal;
-use okena_ui::activity_repaint::ActivityRepaintGate;
 use okena_ui::color_utils::tint_color;
 use okena_workspace::request_broker::RequestBroker;
 use okena_workspace::state::{WindowId, Workspace};
@@ -33,7 +32,6 @@ pub struct TerminalContent {
     terminal: Option<Arc<Terminal>>,
     resize_viewer_id: u64,
     focus_handle: FocusHandle,
-    activity_repaint: ActivityRepaintGate,
     window_activation_subscription: Option<Subscription>,
     url_detector: UrlDetector,
     scrollbar: Entity<Scrollbar>,
@@ -82,7 +80,6 @@ impl TerminalContent {
             terminal: None,
             resize_viewer_id: next_resize_viewer_id(),
             focus_handle,
-            activity_repaint: ActivityRepaintGate::new(true),
             window_activation_subscription: None,
             url_detector: UrlDetector::new(),
             scrollbar,
@@ -106,13 +103,11 @@ impl TerminalContent {
         }
     }
 
-    /// Schedule a content repaint only when this pane's OS window is active.
-    /// Activity that arrives in the background is represented by one pending
-    /// repaint, flushed when GPUI reports that window active again.
+    /// Present the latest parsed terminal state. Calls are already coalesced by
+    /// the app-wide activity frame, so visible non-key windows stay live without
+    /// each terminal stream driving an independent repaint clock.
     pub fn request_activity_repaint(&mut self, cx: &mut Context<Self>) {
-        if self.activity_repaint.request() {
-            cx.notify();
-        }
+        cx.notify();
     }
 
     fn bind_window_activation(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -120,25 +115,19 @@ impl TerminalContent {
             return;
         }
 
-        self.activity_repaint.set_active(window.is_window_active());
         let subscription = cx.observe_window_activation(window, |this, window, cx| {
-            let active = window.is_window_active();
-            let changed = active != this.activity_repaint.is_active();
-            let flush_pending = this.activity_repaint.set_active(active);
-
             // A GPUI focus handle remains focused when its OS window deactivates.
-            // Keep the terminal's notification-suppression reporter aligned with
-            // actual foreground visibility even while activity paints are gated.
+            // Keep the notification-suppression reporter aligned with the exact
+            // key window.
             if let Some(ref terminal) = this.terminal {
                 terminal.update_focus_reporter(
                     this.resize_viewer_id,
-                    active && this.focus_handle.is_focused(window),
+                    window.is_window_active() && this.focus_handle.is_focused(window),
                 );
             }
 
-            if changed || flush_pending {
-                cx.notify();
-            }
+            // Activation changes update focused styling immediately.
+            cx.notify();
         });
         self.window_activation_subscription = Some(subscription);
     }
@@ -640,7 +629,6 @@ impl TerminalContent {
 impl Render for TerminalContent {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         self.bind_window_activation(window, cx);
-        self.activity_repaint.repainted();
 
         let t = theme(cx);
         let is_focused = window.is_window_active() && self.focus_handle.is_focused(window);

--- a/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
@@ -9,6 +9,7 @@ use crate::terminal_view_settings;
 use gpui::*;
 use okena_files::theme::theme;
 use okena_terminal::terminal::Terminal;
+use okena_ui::activity_repaint::ActivityRepaintGate;
 use okena_ui::color_utils::tint_color;
 use okena_workspace::request_broker::RequestBroker;
 use okena_workspace::state::{WindowId, Workspace};
@@ -32,6 +33,8 @@ pub struct TerminalContent {
     terminal: Option<Arc<Terminal>>,
     resize_viewer_id: u64,
     focus_handle: FocusHandle,
+    activity_repaint: ActivityRepaintGate,
+    window_activation_subscription: Option<Subscription>,
     url_detector: UrlDetector,
     scrollbar: Entity<Scrollbar>,
     is_selecting: bool,
@@ -79,6 +82,8 @@ impl TerminalContent {
             terminal: None,
             resize_viewer_id: next_resize_viewer_id(),
             focus_handle,
+            activity_repaint: ActivityRepaintGate::new(true),
+            window_activation_subscription: None,
             url_detector: UrlDetector::new(),
             scrollbar,
             is_selecting: false,
@@ -99,6 +104,43 @@ impl TerminalContent {
             forwarded_button: None,
             autoscroll_task: None,
         }
+    }
+
+    /// Schedule a content repaint only when this pane's OS window is active.
+    /// Activity that arrives in the background is represented by one pending
+    /// repaint, flushed when GPUI reports that window active again.
+    pub fn request_activity_repaint(&mut self, cx: &mut Context<Self>) {
+        if self.activity_repaint.request() {
+            cx.notify();
+        }
+    }
+
+    fn bind_window_activation(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.window_activation_subscription.is_some() {
+            return;
+        }
+
+        self.activity_repaint.set_active(window.is_window_active());
+        let subscription = cx.observe_window_activation(window, |this, window, cx| {
+            let active = window.is_window_active();
+            let changed = active != this.activity_repaint.is_active();
+            let flush_pending = this.activity_repaint.set_active(active);
+
+            // A GPUI focus handle remains focused when its OS window deactivates.
+            // Keep the terminal's notification-suppression reporter aligned with
+            // actual foreground visibility even while activity paints are gated.
+            if let Some(ref terminal) = this.terminal {
+                terminal.update_focus_reporter(
+                    this.resize_viewer_id,
+                    active && this.focus_handle.is_focused(window),
+                );
+            }
+
+            if changed || flush_pending {
+                cx.notify();
+            }
+        });
+        self.window_activation_subscription = Some(subscription);
     }
 
     fn mouse_modifier_bits(m: &Modifiers) -> u8 {
@@ -597,8 +639,11 @@ impl TerminalContent {
 
 impl Render for TerminalContent {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.bind_window_activation(window, cx);
+        self.activity_repaint.repainted();
+
         let t = theme(cx);
-        let is_focused = self.focus_handle.is_focused(window);
+        let is_focused = window.is_window_active() && self.focus_handle.is_focused(window);
 
         if let Some(ref terminal) = self.terminal {
             terminal.update_focus_reporter(self.resize_viewer_id, is_focused);

--- a/crates/okena-views-terminal/src/layout/terminal_pane/render.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/render.rs
@@ -62,7 +62,7 @@ impl<D: ActionDispatch + Send + Sync> Render for TerminalPane<D> {
             window.focus(&self.focus_handle, cx);
         }
 
-        let is_focused = focus_handle.is_focused(window);
+        let is_focused = window.is_window_active() && focus_handle.is_focused(window);
 
         let has_bell = self.terminal.as_ref().is_some_and(|t| t.has_bell());
         if is_focused

--- a/scripts/terminal-latency-report.py
+++ b/scripts/terminal-latency-report.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Merge Okena desktop and daemon terminal-latency probe logs."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import re
+import statistics
+import sys
+from pathlib import Path
+
+FIELD_RE = re.compile(r"([a-z_]+)=([^\s]+)")
+
+STAGES = [
+    ("client_to_daemon_ms", "Client send → daemon WebSocket receive"),
+    ("daemon_bridge_ms", "Daemon WebSocket → command loop"),
+    ("daemon_to_pty_queue_ms", "Command loop → PTY writer queue"),
+    ("pty_writer_queue_ms", "PTY writer queue wait"),
+    ("pty_write_ms", "PTY write"),
+    ("pty_echo_ms", "dtach/PTY/application echo"),
+    ("daemon_fanout_ms", "PTY read → daemon stream queue"),
+    ("return_transport_ms", "Daemon stream queue → client receive"),
+    ("client_parse_ms", "Client receive → terminal parse"),
+    ("activity_emit_ms", "Parse → TerminalActivity emit"),
+    ("activity_delivery_ms", "TerminalActivity emit → Okena"),
+    ("throttle_ms", "Okena activity → repaint dispatch"),
+    ("notify_fanout_ms", "Repaint dispatch → pane notify"),
+    ("notify_to_paint_ms", "Pane notify → paint"),
+    ("input_to_paint_ms", "Client send → terminal paint"),
+    ("paint_to_frame_ms", "Paint → next GPUI frame callback"),
+    ("total_ms", "Client send → next GPUI frame callback"),
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("client_log", type=Path)
+    parser.add_argument("daemon_log", type=Path)
+    parser.add_argument("--terminal", help="only include one normalized terminal id")
+    parser.add_argument("--last", type=int, help="only include the last N matched samples")
+    parser.add_argument("--csv", action="store_true", help="print matched samples as CSV")
+    return parser.parse_args()
+
+
+def parse_records(path: Path, marker: str) -> list[dict[str, str]]:
+    records = []
+    for line in path.read_text(errors="replace").splitlines():
+        if marker not in line:
+            continue
+        fields = dict(FIELD_RE.findall(line))
+        if fields:
+            records.append(fields)
+    return records
+
+
+def normalized_terminal(terminal_id: str) -> str:
+    if terminal_id.startswith("remote:"):
+        parts = terminal_id.split(":", 2)
+        if len(parts) == 3:
+            return parts[2]
+    return terminal_id
+
+
+def record_signature(record: dict[str, str]) -> tuple[str, str, str]:
+    return (
+        normalized_terminal(record["terminal"]),
+        record["input_len"],
+        record["input_hash"],
+    )
+
+
+def timestamp(record: dict[str, str], name: str) -> int | None:
+    value = int(record.get(name, "0"))
+    return value if value > 0 else None
+
+
+def elapsed_ms(start: int | None, end: int | None) -> float | None:
+    if start is None or end is None or end < start:
+        return None
+    return (end - start) / 1_000
+
+
+def merge_samples(
+    clients: list[dict[str, str]], daemons: list[dict[str, str]]
+) -> list[dict[str, object]]:
+    daemon_by_signature: dict[tuple[str, str, str], list[dict[str, str]]] = {}
+    for daemon in daemons:
+        daemon_by_signature.setdefault(record_signature(daemon), []).append(daemon)
+
+    rows = []
+    for client in clients:
+        signature = record_signature(client)
+        input_us = timestamp(client, "input_us")
+        candidates = daemon_by_signature.get(signature, [])
+        daemon = min(
+            (
+                candidate
+                for candidate in candidates
+                if input_us is not None
+                and timestamp(candidate, "ws_receive_us") is not None
+                and timestamp(candidate, "ws_receive_us") >= input_us
+            ),
+            key=lambda candidate: timestamp(candidate, "ws_receive_us") - input_us,
+            default=None,
+        )
+        if daemon is None:
+            continue
+        candidates.remove(daemon)
+
+        output_receive_us = timestamp(client, "output_receive_us")
+        parsed_us = timestamp(client, "parsed_us")
+        activity_emit_us = timestamp(client, "activity_emit_us")
+        activity_receive_us = timestamp(client, "activity_receive_us")
+        throttle_fire_us = timestamp(client, "throttle_fire_us")
+        notify_us = timestamp(client, "notify_us")
+        paint_us = timestamp(client, "paint_us")
+        frame_us = timestamp(client, "frame_us")
+
+        ws_receive_us = timestamp(daemon, "ws_receive_us")
+        bridge_us = timestamp(daemon, "bridge_us")
+        pty_queue_us = timestamp(daemon, "pty_queue_us")
+        pty_write_start_us = timestamp(daemon, "pty_write_start_us")
+        pty_write_end_us = timestamp(daemon, "pty_write_end_us")
+        pty_output_us = timestamp(daemon, "pty_output_us")
+        stream_us = timestamp(daemon, "stream_us")
+
+        rows.append(
+            {
+                "terminal": signature[0],
+                "sample": int(client["sample"]),
+                "daemon_sample": int(daemon["sample"]),
+                "client_to_daemon_ms": elapsed_ms(input_us, ws_receive_us),
+                "daemon_bridge_ms": elapsed_ms(ws_receive_us, bridge_us),
+                "daemon_to_pty_queue_ms": elapsed_ms(bridge_us, pty_queue_us),
+                "pty_writer_queue_ms": elapsed_ms(pty_queue_us, pty_write_start_us),
+                "pty_write_ms": elapsed_ms(pty_write_start_us, pty_write_end_us),
+                "pty_echo_ms": elapsed_ms(pty_write_end_us, pty_output_us),
+                "daemon_fanout_ms": elapsed_ms(pty_output_us, stream_us),
+                "return_transport_ms": elapsed_ms(stream_us, output_receive_us),
+                "client_parse_ms": elapsed_ms(output_receive_us, parsed_us),
+                "activity_emit_ms": elapsed_ms(parsed_us, activity_emit_us),
+                "activity_delivery_ms": elapsed_ms(activity_emit_us, activity_receive_us),
+                "throttle_ms": elapsed_ms(activity_receive_us, throttle_fire_us),
+                "notify_fanout_ms": elapsed_ms(throttle_fire_us, notify_us),
+                "notify_to_paint_ms": elapsed_ms(notify_us, paint_us),
+                "input_to_paint_ms": elapsed_ms(input_us, paint_us),
+                "paint_to_frame_ms": elapsed_ms(paint_us, frame_us),
+                "total_ms": elapsed_ms(input_us, frame_us),
+            }
+        )
+    return rows
+
+
+def percentile(values: list[float], percentile_value: float) -> float:
+    ordered = sorted(values)
+    index = max(0, math.ceil(len(ordered) * percentile_value) - 1)
+    return ordered[index]
+
+
+def print_summary(rows: list[dict[str, object]]) -> None:
+    print(f"Matched samples: {len(rows)}")
+    print()
+    print(f"{'Stage':43} {'median':>9} {'p95':>9} {'max':>9}")
+    for field, label in STAGES:
+        values = [row[field] for row in rows if isinstance(row[field], float)]
+        if not values:
+            continue
+        print(
+            f"{label:43} "
+            f"{statistics.median(values):8.3f} "
+            f"{percentile(values, 0.95):8.3f} "
+            f"{max(values):8.3f}"
+        )
+
+
+def print_csv(rows: list[dict[str, object]]) -> None:
+    fields = [
+        "terminal",
+        "sample",
+        "daemon_sample",
+        *(field for field, _label in STAGES),
+    ]
+    writer = csv.DictWriter(sys.stdout, fieldnames=fields)
+    writer.writeheader()
+    writer.writerows(rows)
+
+
+def main() -> int:
+    args = parse_args()
+    clients = parse_records(args.client_log, "terminal_latency_client ")
+    daemons = parse_records(args.daemon_log, "terminal_latency_daemon ")
+    rows = merge_samples(clients, daemons)
+    if args.terminal:
+        rows = [row for row in rows if row["terminal"] == args.terminal]
+    if args.last is not None:
+        rows = rows[-args.last :]
+    if not rows:
+        print("No matching latency samples found.", file=sys.stderr)
+        return 1
+    if args.csv:
+        print_csv(rows)
+    else:
+        print_summary(rows)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Present parsed output following terminal input immediately, then coalesce unrelated sustained terminal-only UI updates into one app-wide 20 ms (~50 FPS) cadence while keeping every open window live.
- Keep terminal parsing/input, notifications, key-window focus reporting, and OSC clipboard behavior immediate.
- Tier daemon Git polling by project relevance so visible/subscribed repositories remain responsive without continuously scanning every hidden repository.

## Changes
### GUI activity rendering
- Batch exact dirty terminal IDs across the application rather than letting independent streams drive separate presentation clocks.
- Use a leading edge: the first output after idle is presented immediately.
- Track a causal output epoch for user input so parsed post-input output bypasses an already-active batch; pre-input backlog cannot consume the priority request, while unrelated terminal IDs remain queued.
- Expire unanswered input-priority requests and do not arm them for empty input.
- Fan each frame out to every rendered pane copy and window sidebar, including visible non-key windows on other monitors.
- Do not infer visibility from key-window activation; focus reporting and notification suppression still follow the actual key window.
- Preserve immediate terminal parsing/input dispatch, bells/notifications, and OSC 52 clipboard reads and writes.

### Daemon Git polling
- Keep visible and remotely subscribed projects on 250 ms HEAD and 5 s full-status cadences.
- Move hidden, unsubscribed projects to 2 s HEAD and 30 s full-status fallback cadences.
- Keep targeted HEAD/action refreshes immediate, anchor periodic polling to wall-clock deadlines, and retain cached status for projects skipped in a cycle.

### Measurements
- 31 real repositories, 60 seconds: daemon mean 22.93% → 5.69%; p95 94.44% → 18.67%.
- Original controlled single-terminal GUI curve: 12.25% at 60 Hz and 19.20% at 120 Hz.
- Final release, verified-frontmost synthetic sustained output: GUI mean 17.17% at 60 Hz and 17.71% at 120 Hz. Doubling output frequency increased GUI CPU by only 3.1%, consistent with the ~50 FPS presentation cap.
- Earlier 33 ms/background-gated GUI figures are intentionally not claimed for the final implementation.

## Test plan
- `cargo test --workspace`
- `cargo test -p okena-terminal input_repaint`
- `cargo test -p okena-ui activity_repaint`
- `cargo test -p okena-app -p okena-views-terminal`
- `cargo build --release`
- `cargo fmt --all -- --check`
- LSP and pi-lens diagnostics across all changed Rust files
- Controlled before/after CPU sampling with macOS `proc_pid_rusage`
