### PR TITLE
fix(focus): keep keyboard navigation working across closes, hides, and empty projects

### DIFF
--- a/crates/okena-app/src/action_dispatch.rs
+++ b/crates/okena-app/src/action_dispatch.rs
@@ -161,6 +161,30 @@ impl ActionDispatcher {
         });
     }
 
+    /// Capture where focus should land once the daemon applies a close.
+    ///
+    /// The close itself still goes to the daemon; only the focus intent is
+    /// resolved here, while the client's layout still holds the pane being
+    /// closed. See `Workspace::queue_focus_after_close`.
+    fn queue_focus_after_close(
+        workspace: &Entity<Workspace>,
+        focus_manager: &Entity<FocusManager>,
+        window_id: WindowId,
+        project_id: &str,
+        closing_terminal_ids: &[String],
+        cx: &mut impl AppContext,
+    ) {
+        let focused = focus_manager.read_with(cx, |fm, _cx| fm.focused_terminal_state());
+        workspace.update(cx, |ws, _cx| {
+            ws.queue_focus_after_close(
+                window_id,
+                project_id,
+                closing_terminal_ids,
+                focused.as_ref(),
+            );
+        });
+    }
+
     /// Dispatch a standard action (split, close, create terminal, service action, etc.).
     pub fn dispatch(&self, action: ActionRequest, cx: &mut impl AppContext) {
         let Self::Remote {
@@ -264,6 +288,34 @@ impl ActionDispatcher {
                     rm.send_action(&cid, action, cx);
                 });
                 return;
+            }
+            ActionRequest::CloseTerminal {
+                project_id,
+                terminal_id,
+            } => {
+                Self::queue_focus_after_close(
+                    workspace,
+                    focus_manager,
+                    *window_id,
+                    project_id,
+                    std::slice::from_ref(terminal_id),
+                    cx,
+                );
+                // Don't return — the daemon still performs the close
+            }
+            ActionRequest::CloseTerminals {
+                project_id,
+                terminal_ids,
+            } => {
+                Self::queue_focus_after_close(
+                    workspace,
+                    focus_manager,
+                    *window_id,
+                    project_id,
+                    terminal_ids,
+                    cx,
+                );
+                // Don't return — the daemon still performs the close
             }
             ActionRequest::CreateTerminal { project_id } => {
                 // Record pending focus — the actual focus will happen when

--- a/crates/okena-app/src/app/extras.rs
+++ b/crates/okena-app/src/app/extras.rs
@@ -235,9 +235,15 @@ impl Okena {
 
     /// Focus the first visible terminal of an already-open project, activating
     /// the window it lives in. Prefers `origin` (the window the request came
-    /// from), then main, then any extra. No-op if the project is open nowhere
-    /// or has no terminals — the layout is never changed, this is purely a
-    /// "click into the first terminal" across windows.
+    /// from), then main, then any extra. No-op if the project is open nowhere —
+    /// the layout is never changed, this is purely a "click into the first
+    /// terminal" across windows.
+    ///
+    /// A project with no terminals is still a valid destination: focus lands on
+    /// the project itself (an empty path names no pane), which is what makes it
+    /// the current project for everything that resolves one. Refusing to enter
+    /// it left a bookmark project unreachable by keyboard — the only ways in
+    /// were a click or a project that already had a terminal.
     fn jump_to_project_terminal(
         &mut self,
         origin: WindowId,
@@ -246,13 +252,11 @@ impl Okena {
     ) {
         let workspace = self.workspace.clone();
 
-        // The project must have a layout (i.e. at least one terminal) to enter.
-        let path = match workspace
-            .read(cx)
-            .project(project_id)
-            .and_then(|p| p.layout.as_ref())
-        {
-            Some(layout) => layout.find_visible_terminal_path(),
+        let path = match workspace.read(cx).project(project_id) {
+            Some(project) => project
+                .layout
+                .as_ref()
+                .map_or_else(Vec::new, |layout| layout.find_visible_terminal_path()),
             None => return,
         };
 

--- a/crates/okena-app/src/keybindings/config.rs
+++ b/crates/okena-app/src/keybindings/config.rs
@@ -320,6 +320,14 @@ impl KeybindingConfig {
         );
 
         bindings.insert(
+            "ToggleProjectVisibility".to_string(),
+            vec![
+                KeybindingEntry::new("cmd-shift-h", None),
+                KeybindingEntry::new("ctrl-shift-h", None),
+            ],
+        );
+
+        bindings.insert(
             "ShowBranchSwitcher".to_string(),
             vec![
                 KeybindingEntry::new("cmd-alt-b", None),

--- a/crates/okena-app/src/keybindings/config.rs
+++ b/crates/okena-app/src/keybindings/config.rs
@@ -518,6 +518,34 @@ mod tests {
         );
     }
 
+    /// A default binding whose action name isn't wired up is not a compile
+    /// error — `create_keybinding` logs a warning and the shortcut is simply
+    /// dead, while a missing description hides it from the command palette and
+    /// the keybindings overlay. Both are silent at runtime, so pin them here.
+    #[test]
+    fn every_default_action_is_bindable_and_described() {
+        let config = KeybindingConfig::defaults();
+        let descriptions = crate::keybindings::get_action_descriptions();
+
+        for (action, entries) in &config.bindings {
+            assert!(
+                descriptions.contains_key(action.as_str()),
+                "{action} has default bindings but no description"
+            );
+            for entry in entries {
+                assert!(
+                    crate::keybindings::create_keybinding(
+                        action,
+                        &entry.keystroke,
+                        entry.context.as_deref(),
+                    )
+                    .is_some(),
+                    "{action} is not wired into create_keybinding — its shortcut would do nothing"
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_duplicate_keybinding_detected() {
         let mut config = KeybindingConfig::defaults();

--- a/crates/okena-app/src/keybindings/config.rs
+++ b/crates/okena-app/src/keybindings/config.rs
@@ -171,11 +171,17 @@ impl KeybindingConfig {
                 KeybindingEntry::new("ctrl-d", Some("TerminalPane")),
             ],
         );
+        // Also bound globally: a project with no terminals has no TerminalPane
+        // to dispatch through, so the pane-scoped binding alone leaves "Start
+        // Terminal" reachable only by mouse. The window-level handler only acts
+        // when there is genuinely no pane to take it (see `render.rs`).
         bindings.insert(
             "AddTab".to_string(),
             vec![
                 KeybindingEntry::new("cmd-t", Some("TerminalPane")),
                 KeybindingEntry::new("ctrl-shift-t", Some("TerminalPane")),
+                KeybindingEntry::new("cmd-t", None),
+                KeybindingEntry::new("ctrl-shift-t", None),
             ],
         );
         bindings.insert(

--- a/crates/okena-app/src/keybindings/descriptions.rs
+++ b/crates/okena-app/src/keybindings/descriptions.rs
@@ -12,7 +12,8 @@ use super::{
     ShowFileSearch, ShowHookLog, ShowKeybindings, ShowLogConsole, ShowProfileManager,
     ShowProjectSwitcher, ShowSessionManager, ShowSettings, ShowThemeSelector, SplitHorizontal,
     SplitVertical, StartAllServices, StopAllServices, ToggleFullscreen, TogglePaneSwitcher,
-    ToggleProjectLayout, ToggleSidebar, ToggleSidebarAutoHide, ZoomIn, ZoomOut,
+    ToggleProjectLayout, ToggleProjectVisibility, ToggleSidebar, ToggleSidebarAutoHide, ZoomIn,
+    ZoomOut,
 };
 
 /// Get human-readable descriptions for all actions
@@ -575,6 +576,15 @@ pub fn get_action_descriptions() -> HashMap<&'static str, ActionDescription> {
             description: "Switch the project grid between columns and rows",
             category: "Layout",
             factory: || Box::new(ToggleProjectLayout),
+        },
+    );
+    map.insert(
+        "ToggleProjectVisibility",
+        ActionDescription {
+            name: "Hide Project",
+            description: "Hide the active project from this window's overview (Cmd+E, Space to bring one back)",
+            category: "Layout",
+            factory: || Box::new(ToggleProjectVisibility),
         },
     );
     map.insert(

--- a/crates/okena-app/src/keybindings/mod.rs
+++ b/crates/okena-app/src/keybindings/mod.rs
@@ -50,6 +50,7 @@ actions!(
         ShowLogConsole,
         EqualizeLayout,
         ToggleProjectLayout,
+        ToggleProjectVisibility,
         ShowBranchSwitcher,
         ShowProfileManager,
         NewWindow,
@@ -434,6 +435,9 @@ fn create_keybinding(action: &str, keystroke: &str, context: Option<&str>) -> Op
         "StopAllServices" => Some(KeyBinding::new(keystroke, StopAllServices, context)),
         "EqualizeLayout" => Some(KeyBinding::new(keystroke, EqualizeLayout, context)),
         "ToggleProjectLayout" => Some(KeyBinding::new(keystroke, ToggleProjectLayout, context)),
+        "ToggleProjectVisibility" => {
+            Some(KeyBinding::new(keystroke, ToggleProjectVisibility, context))
+        }
         "ShowBranchSwitcher" => Some(KeyBinding::new(keystroke, ShowBranchSwitcher, context)),
         "ShowProfileManager" => Some(KeyBinding::new(keystroke, ShowProfileManager, context)),
         "ShowLogConsole" => Some(KeyBinding::new(keystroke, ShowLogConsole, context)),

--- a/crates/okena-app/src/views/overlays/project_switcher.rs
+++ b/crates/okena-app/src/views/overlays/project_switcher.rs
@@ -52,8 +52,12 @@ struct ProjectOpenState {
 pub struct ProjectSwitcher {
     focus_handle: FocusHandle,
     state: ListOverlayState<ProjectData>,
-    /// Per-project open state across every window, snapshotted at construction.
-    /// Drives the row's open/closed treatment and the multi-window marker.
+    /// Window the switcher was opened from — visibility is per-window, so this
+    /// is the "here" every row's open state is computed against.
+    window_id: WindowId,
+    /// Per-project open state across every window. Drives the row's open/closed
+    /// treatment and the multi-window marker, and is recomputed on every
+    /// workspace change so a Space toggle shows up immediately.
     open_states: HashMap<String, ProjectOpenState>,
     /// Kept so rows can read the daemon-mirrored git status (branch label).
     workspace: Entity<Workspace>,
@@ -72,21 +76,7 @@ impl ProjectSwitcher {
                 p
             })
             .collect();
-        // Snapshot per-project open state across every window so each row can
-        // distinguish "open here" / "open in another window" / "closed
-        // everywhere". `here` is the window the switcher was opened from.
-        let data = ws.data();
-        let mut windows: Vec<(WindowId, &HashSet<String>)> =
-            vec![(WindowId::Main, &data.main_window.hidden_project_ids)];
-        windows.extend(
-            data.extra_windows
-                .iter()
-                .map(|w| (WindowId::Extra(w.id), &w.hidden_project_ids)),
-        );
-        let open_states = projects
-            .iter()
-            .map(|p| (p.id.clone(), compute_open_state(&p.id, window_id, &windows)))
-            .collect();
+        let open_states = open_states_for(window_id, ws, &projects);
 
         let config = ListOverlayConfig::new("Switch Project")
             .subtitle("Type to search, Enter to focus, Space to toggle visibility")
@@ -103,9 +93,22 @@ impl ProjectSwitcher {
         let state = ListOverlayState::new(projects, config, cx);
         let focus_handle = state.focus_handle.clone();
 
+        // Space toggles visibility through the workspace: the row emits an
+        // event that only lands after this frame, so rows have to follow the
+        // workspace rather than the snapshot above — otherwise the toggle
+        // changes the state without changing anything the user can see.
+
+        cx.observe(&workspace, |this, workspace, cx| {
+            this.open_states =
+                open_states_for(this.window_id, workspace.read(cx), &this.state.items);
+            cx.notify();
+        })
+        .detach();
+
         Self {
             focus_handle,
             state,
+            window_id,
             open_states,
             workspace,
         }
@@ -382,6 +385,28 @@ fn ranked_project_filter(items: &[ProjectData], query: &str) -> Vec<FilterResult
 /// A project is "open" in a window iff its id is absent from that window's
 /// hidden set. `open_here` reflects the `here` window; `open_elsewhere` counts
 /// the other windows where it is open.
+/// Project → open state across every window, seen from the window the switcher
+/// was opened from. Lets each row distinguish "open here" / "open in another
+/// window" / "closed everywhere".
+fn open_states_for(
+    here: WindowId,
+    ws: &Workspace,
+    projects: &[ProjectData],
+) -> HashMap<String, ProjectOpenState> {
+    let data = ws.data();
+    let mut windows: Vec<(WindowId, &HashSet<String>)> =
+        vec![(WindowId::Main, &data.main_window.hidden_project_ids)];
+    windows.extend(
+        data.extra_windows
+            .iter()
+            .map(|w| (WindowId::Extra(w.id), &w.hidden_project_ids)),
+    );
+    projects
+        .iter()
+        .map(|p| (p.id.clone(), compute_open_state(&p.id, here, &windows)))
+        .collect()
+}
+
 fn compute_open_state(
     project_id: &str,
     here: WindowId,
@@ -657,6 +682,46 @@ mod tests {
 
         let closed = compute_open_state("p_closed", here, &windows);
         assert!(!closed.open_here && closed.open_elsewhere == 0);
+    }
+
+    /// Space toggles visibility through the workspace, and the event only
+    /// lands after the frame that handled the keypress. If the rows kept the
+    /// snapshot taken when the switcher opened, the toggle would change the
+    /// state while the modal carried on showing the old one.
+    #[gpui::test]
+    fn open_state_follows_the_workspace_after_a_visibility_toggle(cx: &mut gpui::TestAppContext) {
+        use crate::workspace::state::{WindowState, Workspace, WorkspaceData};
+        use gpui::AppContext as _;
+
+        let data = WorkspaceData {
+            version: 1,
+            projects: vec![make_project("p1", "/p1")],
+            project_order: vec!["p1".to_string()],
+            service_panel_heights: HashMap::new(),
+            hook_panel_heights: HashMap::new(),
+            folders: Vec::new(),
+            main_window: WindowState::default(),
+            extra_windows: Vec::new(),
+        };
+        let workspace = cx.new(|_cx| Workspace::new(data));
+        let switcher =
+            cx.new(|cx| super::ProjectSwitcher::new(WindowId::Main, workspace.clone(), cx));
+
+        switcher.read_with(cx, |switcher, _cx| {
+            assert!(switcher.open_states["p1"].open_here);
+        });
+
+        workspace.update(cx, |ws, cx| {
+            ws.toggle_hidden(WindowId::Main, "p1", cx);
+        });
+        cx.run_until_parked();
+
+        switcher.read_with(cx, |switcher, _cx| {
+            assert!(
+                !switcher.open_states["p1"].open_here,
+                "row still reports the project as open after it was hidden"
+            );
+        });
     }
 
     #[test]

--- a/crates/okena-app/src/views/window/render.rs
+++ b/crates/okena-app/src/views/window/render.rs
@@ -4,8 +4,8 @@ use crate::keybindings::{
     ReviewChanges, ShowBranchSwitcher, ShowCommandPalette, ShowContentSearch, ShowDiffViewer,
     ShowFileSearch, ShowHookLog, ShowKeybindings, ShowLogConsole, ShowPairingDialog,
     ShowProfileManager, ShowProjectSwitcher, ShowSessionManager, ShowSettings, ShowThemeSelector,
-    StartAllServices, StopAllServices, TogglePaneSwitcher, ToggleProjectLayout, ToggleSidebar,
-    ToggleSidebarAutoHide,
+    StartAllServices, StopAllServices, TogglePaneSwitcher, ToggleProjectLayout,
+    ToggleProjectVisibility, ToggleSidebar, ToggleSidebarAutoHide,
 };
 use crate::settings::{open_settings_file, settings_entity};
 use crate::theme::theme;
@@ -889,6 +889,40 @@ impl Render for WindowView {
                     ws.toggle_project_layout_mode(window_id, cx);
                 });
             }))
+            // Hide the active project from this window's overview — the
+            // keyboard route to the eye toggle in the project header. Scoped to
+            // this window, like every other visibility toggle. Resolving the
+            // target the same way the branch switcher does keeps it usable in a
+            // project that has no terminal yet.
+            //
+            // Only ever hides in practice: the shortcut acts on the project you
+            // are in, and once it's hidden focus has moved elsewhere. Bringing
+            // one back is the project switcher's job (Cmd+E, Space).
+            .on_action(
+                cx.listener(|this, _: &ToggleProjectVisibility, _window, cx| {
+                    let project_id = {
+                        let fm = this.focus_manager.read(cx);
+                        fm.focused_terminal_state()
+                            .map(|state| state.project_id)
+                            .or_else(|| fm.focused_project_id().map(String::from))
+                    };
+                    if let Some(project_id) = project_id {
+                        let window_id = this.window_id;
+                        let workspace = this.workspace.clone();
+                        this.focus_manager.update(cx, |fm, cx| {
+                            workspace.update(cx, |ws, cx| {
+                                ws.toggle_project_overview_visibility(
+                                    fm,
+                                    window_id,
+                                    &project_id,
+                                    cx,
+                                );
+                            });
+                            cx.notify();
+                        });
+                    }
+                }),
+            )
             // Spawn a new extra window onto the workspace. The data-layer
             // mutation pushes a fresh `WindowState` and bumps `data_version`
             // so the auto-save observer fires; the OS window itself opens

--- a/crates/okena-app/src/views/window/render.rs
+++ b/crates/okena-app/src/views/window/render.rs
@@ -1,10 +1,10 @@
 use crate::keybindings::{
-    CheckForUpdates, ClearFocus, CloseWindow, CreateWorktree, EqualizeLayout, FocusActiveProject,
-    FocusSidebar, InstallUpdate, NewProject, NewWindow, OpenSettingsFile, RestartDaemon,
-    ReviewChanges, ShowBranchSwitcher, ShowCommandPalette, ShowContentSearch, ShowDiffViewer,
-    ShowFileSearch, ShowHookLog, ShowKeybindings, ShowLogConsole, ShowPairingDialog,
-    ShowProfileManager, ShowProjectSwitcher, ShowSessionManager, ShowSettings, ShowThemeSelector,
-    StartAllServices, StopAllServices, TogglePaneSwitcher, ToggleProjectLayout,
+    AddTab, CheckForUpdates, ClearFocus, CloseWindow, CreateWorktree, EqualizeLayout,
+    FocusActiveProject, FocusSidebar, InstallUpdate, NewProject, NewWindow, OpenSettingsFile,
+    RestartDaemon, ReviewChanges, ShowBranchSwitcher, ShowCommandPalette, ShowContentSearch,
+    ShowDiffViewer, ShowFileSearch, ShowHookLog, ShowKeybindings, ShowLogConsole,
+    ShowPairingDialog, ShowProfileManager, ShowProjectSwitcher, ShowSessionManager, ShowSettings,
+    ShowThemeSelector, StartAllServices, StopAllServices, TogglePaneSwitcher, ToggleProjectLayout,
     ToggleProjectVisibility, ToggleSidebar, ToggleSidebarAutoHide,
 };
 use crate::settings::{open_settings_file, settings_entity};
@@ -888,6 +888,41 @@ impl Render for WindowView {
                 this.workspace.update(cx, |ws, cx| {
                     ws.toggle_project_layout_mode(window_id, cx);
                 });
+            }))
+            // Start the first terminal in a project that has none — the
+            // keyboard equivalent of the empty state's "Start Terminal" button.
+            //
+            // `AddTab` is normally handled by the focused TerminalPane; this
+            // only runs when the focused project has no pane to handle it,
+            // which is exactly the case the pane-scoped binding cannot reach. A
+            // project WITH a layout falls through untouched, so an open modal
+            // (which owns the keyboard while leaving a project focused) can't
+            // spawn terminals behind itself either.
+            .on_action(cx.listener(|this, _: &AddTab, _window, cx| {
+                if this.focus_manager.read(cx).is_modal() {
+                    return;
+                }
+                let project_id = {
+                    let fm = this.focus_manager.read(cx);
+                    fm.focused_terminal_state()
+                        .map(|state| state.project_id)
+                        .or_else(|| fm.focused_project_id().map(String::from))
+                };
+                let Some(project_id) = project_id else { return };
+                if this
+                    .workspace
+                    .read(cx)
+                    .project(&project_id)
+                    .is_none_or(|p| p.layout.is_some())
+                {
+                    return;
+                }
+                if let Some(dispatcher) = this.dispatcher_for_project(&project_id, cx) {
+                    dispatcher.dispatch(
+                        okena_core::api::ActionRequest::CreateTerminal { project_id },
+                        cx,
+                    );
+                }
             }))
             // Hide the active project from this window's overview — the
             // keyboard route to the eye toggle in the project header. Scoped to

--- a/crates/okena-layout/src/lib.rs
+++ b/crates/okena-layout/src/lib.rs
@@ -280,6 +280,66 @@ impl LayoutNode {
         }
     }
 
+    /// Terminal that should take focus once the node at `path` is closed.
+    ///
+    /// Mirrors what [`Self::remove_at_path`] will do to the tree, one level at
+    /// a time:
+    /// - **Tabs parent** — hand focus to whichever tab becomes active after the
+    ///   removal (the next tab, or the previous one when the last tab closes).
+    /// - **Split parent** — hand focus to the neighbouring pane (previous, or
+    ///   next when closing the first).
+    /// - **Container left with a single child** — it collapses into that child,
+    ///   so the rule re-applies one level up (closing the last tab of a group
+    ///   lands on the neighbouring pane, not inside the dying group).
+    ///
+    /// Returns `None` when the closed node is the whole tree (nothing left to
+    /// focus) or when the resolved terminal has no id yet (still spawning).
+    pub fn terminal_to_focus_after_closing(&self, path: &[usize]) -> Option<String> {
+        let (&child_index, parent_path) = path.split_last()?;
+        let children = match self.get_at_path(parent_path)? {
+            LayoutNode::Terminal { .. } => return None,
+            LayoutNode::Split { children, .. } | LayoutNode::Tabs { children, .. } => children,
+        };
+        if child_index >= children.len() {
+            return None;
+        }
+        if children.len() <= 2 {
+            // The parent collapses into its surviving child, which then sits at
+            // `parent_path`. With exactly one sibling that sibling IS the
+            // target; with none, the whole container disappears and the rule
+            // re-applies one level up.
+            return match children.len() {
+                2 => children[1 - child_index].visible_terminal_id(),
+                _ => self.terminal_to_focus_after_closing(parent_path),
+            };
+        }
+
+        // Index (in the *pre-removal* child list) of the node that ends up
+        // focused once the removal lands.
+        let sibling_index = match self.get_at_path(parent_path)? {
+            LayoutNode::Tabs { active_tab, .. } if *active_tab != child_index => *active_tab,
+            // The active tab is the one going away: the next tab slides into
+            // its index, except for the last tab where `remove_at_path` clamps
+            // `active_tab` back onto the previous one.
+            LayoutNode::Tabs { .. } if child_index + 1 < children.len() => child_index + 1,
+            LayoutNode::Tabs { .. } => child_index - 1,
+            // Splits keep every pane visible — pick the neighbour.
+            _ if child_index > 0 => child_index - 1,
+            _ => 1,
+        };
+        children.get(sibling_index)?.visible_terminal_id()
+    }
+
+    /// Id of the terminal that is visible in this subtree (follows active tabs).
+    /// `None` for a pane whose PTY hasn't been assigned an id yet.
+    pub fn visible_terminal_id(&self) -> Option<String> {
+        let path = self.find_visible_terminal_path();
+        match self.get_at_path(&path)? {
+            LayoutNode::Terminal { terminal_id, .. } => terminal_id.clone(),
+            _ => None,
+        }
+    }
+
     /// Find the `Terminal` node with the given id, returning a reference to it.
     /// Unlike `find_terminal_path`, this hands back the node itself so callers
     /// can clone its visual state (shell_type, zoom_level) — used by soft-close
@@ -1291,6 +1351,164 @@ mod tests {
             children,
             active_tab: 0,
         }
+    }
+
+    fn tabs_active(children: Vec<LayoutNode>, active_tab: usize) -> LayoutNode {
+        LayoutNode::Tabs {
+            children,
+            active_tab,
+        }
+    }
+
+    /// For a tab group, `terminal_to_focus_after_closing` must name exactly the
+    /// tab the user will be looking at once the close lands — otherwise the
+    /// client focuses a pane that isn't on screen. Replays the daemon's own
+    /// mutation (`Workspace::close_terminal`: `remove_at_path` plus the
+    /// active-tab fix-up for a tab removed before the active one) and reads
+    /// back what became visible where the group used to be.
+    fn assert_matches_removal(layout: &LayoutNode, path: &[usize]) {
+        let predicted = layout.terminal_to_focus_after_closing(path);
+        let (&child_index, parent_path) = path.split_last().expect("path must name a child");
+
+        let mut after = layout.clone();
+        let prev_active = match after.get_at_path(parent_path) {
+            Some(LayoutNode::Tabs { active_tab, .. }) if child_index < *active_tab => {
+                Some(*active_tab)
+            }
+            Some(LayoutNode::Tabs { .. }) => None,
+            _ => panic!("oracle only models Tabs parents"),
+        };
+        after.remove_at_path(path);
+        if let Some(prev_active) = prev_active
+            && let Some(LayoutNode::Tabs {
+                children,
+                active_tab,
+            }) = after.get_at_path_mut(parent_path)
+        {
+            *active_tab = (prev_active - 1).min(children.len().saturating_sub(1));
+        }
+
+        let surviving = after
+            .get_at_path(parent_path)
+            .expect("the parent slot survives the removal");
+        assert_eq!(
+            predicted,
+            surviving.visible_terminal_id(),
+            "focus prediction disagrees with the post-removal tree for path {path:?}"
+        );
+    }
+
+    #[test]
+    fn focus_after_closing_active_tab_follows_the_next_tab() {
+        let layout = tabs(vec![terminal("t1"), terminal("t2"), terminal("t3")]);
+        assert_eq!(
+            layout.terminal_to_focus_after_closing(&[0]),
+            Some("t2".to_string())
+        );
+        assert_matches_removal(&layout, &[0]);
+    }
+
+    #[test]
+    fn focus_after_closing_last_active_tab_falls_back_to_previous() {
+        let layout = tabs_active(vec![terminal("t1"), terminal("t2"), terminal("t3")], 2);
+        assert_eq!(
+            layout.terminal_to_focus_after_closing(&[2]),
+            Some("t2".to_string())
+        );
+        assert_matches_removal(&layout, &[2]);
+    }
+
+    #[test]
+    fn focus_after_closing_background_tab_keeps_the_active_one() {
+        let layout = tabs_active(vec![terminal("t1"), terminal("t2"), terminal("t3")], 1);
+        // Closing a tab before the active one shifts indices but not what the
+        // user is looking at.
+        assert_eq!(
+            layout.terminal_to_focus_after_closing(&[0]),
+            Some("t2".to_string())
+        );
+        assert_matches_removal(&layout, &[0]);
+        // ...and closing one after it changes nothing at all.
+        assert_eq!(
+            layout.terminal_to_focus_after_closing(&[2]),
+            Some("t2".to_string())
+        );
+        assert_matches_removal(&layout, &[2]);
+    }
+
+    #[test]
+    fn focus_after_closing_second_to_last_tab_dissolves_onto_the_survivor() {
+        let layout = tabs(vec![terminal("t1"), terminal("t2")]);
+        assert_eq!(
+            layout.terminal_to_focus_after_closing(&[0]),
+            Some("t2".to_string())
+        );
+        assert_matches_removal(&layout, &[0]);
+        assert_eq!(
+            layout.terminal_to_focus_after_closing(&[1]),
+            Some("t1".to_string())
+        );
+        assert_matches_removal(&layout, &[1]);
+    }
+
+    #[test]
+    fn focus_after_closing_last_tab_of_a_group_leaves_for_the_neighbouring_pane() {
+        // Split[ pane, Tabs[t2, t3] ]: closing t2 stays inside the group,
+        // closing the survivor afterwards hands focus to the sibling pane.
+        let layout = hsplit(vec![
+            terminal("t1"),
+            tabs(vec![terminal("t2"), terminal("t3")]),
+        ]);
+        assert_eq!(
+            layout.terminal_to_focus_after_closing(&[1, 0]),
+            Some("t3".to_string())
+        );
+        assert_matches_removal(&layout, &[1, 0]);
+
+        let collapsed = hsplit(vec![terminal("t1"), terminal("t3")]);
+        assert_eq!(
+            collapsed.terminal_to_focus_after_closing(&[1]),
+            Some("t1".to_string())
+        );
+    }
+
+    #[test]
+    fn focus_after_closing_split_pane_prefers_the_previous_neighbour() {
+        let layout = hsplit(vec![terminal("t1"), terminal("t2"), terminal("t3")]);
+        assert_eq!(
+            layout.terminal_to_focus_after_closing(&[1]),
+            Some("t1".to_string())
+        );
+        // Closing the first pane has no previous neighbour — take the next.
+        assert_eq!(
+            layout.terminal_to_focus_after_closing(&[0]),
+            Some("t2".to_string())
+        );
+    }
+
+    #[test]
+    fn focus_after_closing_descends_into_the_neighbours_visible_tab() {
+        let layout = hsplit(vec![
+            tabs_active(vec![terminal("t1"), terminal("t2")], 1),
+            terminal("t3"),
+        ]);
+        assert_eq!(
+            layout.terminal_to_focus_after_closing(&[1]),
+            Some("t2".to_string())
+        );
+    }
+
+    #[test]
+    fn focus_after_closing_the_only_terminal_is_none() {
+        let layout = terminal("t1");
+        assert_eq!(layout.terminal_to_focus_after_closing(&[]), None);
+    }
+
+    #[test]
+    fn focus_after_closing_out_of_range_path_is_none() {
+        let layout = hsplit(vec![terminal("t1"), terminal("t2")]);
+        assert_eq!(layout.terminal_to_focus_after_closing(&[5]), None);
+        assert_eq!(layout.terminal_to_focus_after_closing(&[0, 0]), None);
     }
 
     #[test]

--- a/crates/okena-workspace/src/actions/focus.rs
+++ b/crates/okena-workspace/src/actions/focus.rs
@@ -121,14 +121,22 @@ impl Workspace {
     /// Resolve a focusable project and focus its first terminal.
     ///
     /// If the project has no layout (e.g. only worktree children), drills into
-    /// the first worktree child that has a terminal.
+    /// the first worktree child that has a terminal. A project with no terminal
+    /// anywhere still takes focus, anchored on itself with an empty path: it
+    /// names no pane, but it makes the project the current one so whatever the
+    /// user does next targets it. Leaving focus on the *previous* project
+    /// instead is what made a bookmark project impossible to move into.
     pub(crate) fn focus_first_terminal_in(
         &mut self,
         focus_manager: &mut FocusManager,
         project_id: &str,
     ) {
-        if let Some(target) = self.first_terminal_target_in(project_id) {
-            focus_manager.focus_terminal(target.project_id, target.layout_path);
+        match self.first_terminal_target_in(project_id) {
+            Some(target) => focus_manager.focus_terminal(target.project_id, target.layout_path),
+            None if self.project(project_id).is_some() => {
+                focus_manager.focus_terminal(project_id.to_string(), Vec::new());
+            }
+            None => {}
         }
     }
 
@@ -272,6 +280,76 @@ mod gpui_tests {
             main_window: WindowState::default(),
             extra_windows: Vec::new(),
         }
+    }
+
+    /// A project with no terminals — what a project is before it's opened, and
+    /// what it becomes again when its last terminal closes.
+    fn make_bookmark(id: &str) -> crate::state::ProjectData {
+        crate::state::ProjectData {
+            id: id.to_string(),
+            name: id.to_string(),
+            path: format!("/tmp/{id}"),
+            layout: None,
+            terminal_names: HashMap::new(),
+            hidden_terminals: HashMap::new(),
+            worktree_info: None,
+            worktree_ids: Vec::new(),
+            folder_color: FolderColor::default(),
+            hooks: Default::default(),
+            is_remote: false,
+            connection_id: None,
+            service_terminals: HashMap::new(),
+            default_shell: None,
+            hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
+            is_creating: false,
+            is_closing: false,
+        }
+    }
+
+    /// A project with no terminals must still be able to take focus —
+    /// otherwise focus stays on whatever came before and the project can't be
+    /// moved into at all (the project switcher's Tab, folder focus, and
+    /// zooming all route through here).
+    #[gpui::test]
+    fn focusing_a_project_without_terminals_anchors_onto_the_project(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let mut data = make_workspace_data();
+        data.projects = vec![make_bookmark("p1"), make_bookmark("p2")];
+        data.project_order = vec!["p1".to_string(), "p2".to_string()];
+        let workspace = cx.new(|_cx| Workspace::new(data));
+        let mut fm = FocusManager::new();
+        fm.focus_terminal("p1".to_string(), Vec::new());
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            ws.set_focused_project(&mut fm, Some("p2".to_string()), cx);
+        });
+
+        let focused = fm.focused_terminal_state().expect("focus is anchored");
+        assert_eq!(focused.project_id, "p2");
+        // No pane to name — an empty path matches none, which is the point.
+        assert!(focused.layout_path.is_empty());
+    }
+
+    #[gpui::test]
+    fn focusing_an_unknown_project_leaves_focus_alone(cx: &mut gpui::TestAppContext) {
+        let mut data = make_workspace_data();
+        data.projects = vec![make_bookmark("p1")];
+        data.project_order = vec!["p1".to_string()];
+        let workspace = cx.new(|_cx| Workspace::new(data));
+        let mut fm = FocusManager::new();
+        fm.focus_terminal("p1".to_string(), Vec::new());
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            ws.set_focused_project(&mut fm, Some("ghost".to_string()), cx);
+        });
+
+        assert_eq!(
+            fm.focused_terminal_state().map(|f| f.project_id),
+            Some("p1".to_string())
+        );
     }
 
     #[gpui::test]

--- a/crates/okena-workspace/src/remote_apply.rs
+++ b/crates/okena-workspace/src/remote_apply.rs
@@ -381,9 +381,48 @@ pub fn apply_remote_snapshot(
     data.project_order
         .retain(|id| valid_ids.contains(id.as_str()));
 
+    let mut outcome = RemoteSyncOutcome::default();
+
+    // Land the window's focus after a close the daemon has now applied. Resolved
+    // by terminal id rather than path: the removal reshapes the tree (tab groups
+    // dissolve, splits collapse) so every surviving path may have moved.
+    if let Some(pending) = remote_sync.take_close_focus(window_id) {
+        match data.projects.iter().find(|p| p.id == pending.project_id) {
+            // Project gone — nothing to focus, and nothing to wait for.
+            None => {}
+            Some(project) => {
+                let layout = project.layout.as_ref();
+                let closed = layout.is_none_or(|layout| {
+                    let remaining = layout.collect_terminal_ids();
+                    !pending
+                        .closing_terminal_ids
+                        .iter()
+                        .any(|id| remaining.contains(id))
+                });
+                if closed {
+                    // An empty project keeps focus on the project itself (empty
+                    // path matches no pane), so the next action still targets it.
+                    let layout_path = layout.map_or_else(Vec::new, |layout| {
+                        pending
+                            .next_terminal_id
+                            .as_ref()
+                            .and_then(|id| layout.find_terminal_path(id))
+                            .unwrap_or_else(|| layout.find_visible_terminal_path())
+                    });
+                    outcome.focus_targets.push(RemoteFocusTarget {
+                        project_id: pending.project_id,
+                        layout_path,
+                    });
+                } else {
+                    // This sync predates the close — try again on the next one.
+                    remote_sync.retry_close_focus(window_id, pending);
+                }
+            }
+        }
+    }
+
     // Compute focus targets for projects that had a window-scoped pending
     // CreateTerminal and whose layout grew a new terminal during this sync.
-    let mut outcome = RemoteSyncOutcome::default();
     for pending_focus in remote_sync.drain_pending_focus(window_id) {
         let pid = pending_focus.project_id;
         let layout = match data
@@ -410,6 +449,25 @@ pub fn apply_remote_snapshot(
                 project_id: pid.clone(),
                 layout_path: path,
             });
+        }
+    }
+
+    // Selecting a tab is client-owned state (`SetActiveTab` never reaches the
+    // daemon), so `merge_visual_state` keeps the *local* selection whenever the
+    // group is still recognizable — and falls back to the daemon's whenever the
+    // sync reshaped it. Either way the terminal we just resolved can end up
+    // behind an inactive tab: a freshly added tab loses to the tab the user was
+    // on, and a group that absorbed a collapsed split inherits whatever the
+    // daemon had selected. Bring the target to the front so the pane taking
+    // keyboard focus is the one on screen.
+    for target in &outcome.focus_targets {
+        if let Some(layout) = data
+            .projects
+            .iter_mut()
+            .find(|p| p.id == target.project_id)
+            .and_then(|p| p.layout.as_mut())
+        {
+            layout.activate_tabs_along_path(&target.layout_path);
         }
     }
 
@@ -1115,6 +1173,272 @@ mod tests {
 
         assert!(outcome.focus_targets.is_empty());
         assert!(rs.drain_pending_focus(WindowId::Main).is_empty());
+    }
+
+    /// Sync a project layout for connection `c1` and return the outcome.
+    fn sync_layout(
+        data: &mut WorkspaceData,
+        rs: &mut RemoteSyncState,
+        layout: Option<ApiLayoutNode>,
+    ) -> RemoteSyncOutcome {
+        apply_remote_snapshot(
+            data,
+            rs,
+            &[RemoteSnapshot {
+                config: config("c1"),
+                state: Some(state_with(
+                    vec![api_project("a", layout)],
+                    vec!["a".into()],
+                    vec![],
+                )),
+            }],
+            WindowId::Main,
+        )
+    }
+
+    fn api_tabs(children: Vec<ApiLayoutNode>, active_tab: usize) -> ApiLayoutNode {
+        ApiLayoutNode::Tabs {
+            children,
+            active_tab,
+        }
+    }
+
+    /// Active tab of the tab group at `path` in the synced project layout.
+    fn active_tab_at(data: &WorkspaceData, path: &[usize]) -> usize {
+        match data
+            .projects
+            .iter()
+            .find(|p| p.id == "remote:c1:a")
+            .and_then(|p| p.layout.as_ref())
+            .and_then(|layout| layout.get_at_path(path))
+        {
+            Some(LayoutNode::Tabs { active_tab, .. }) => *active_tab,
+            other => panic!("expected a tab group at {path:?}, got {other:?}"),
+        }
+    }
+
+    fn split(children: Vec<ApiLayoutNode>) -> ApiLayoutNode {
+        ApiLayoutNode::Split {
+            direction: okena_core::types::SplitDirection::Horizontal,
+            sizes: vec![100.0 / children.len() as f32; children.len()],
+            children,
+        }
+    }
+
+    #[test]
+    fn close_focus_lands_once_the_daemon_applies_the_close() {
+        let mut data = empty_data();
+        let mut rs = RemoteSyncState::new();
+        sync_layout(
+            &mut data,
+            &mut rs,
+            Some(split(vec![terminal("t1"), terminal("t2")])),
+        );
+        rs.queue_close_focus(
+            WindowId::Main,
+            "remote:c1:a",
+            vec!["remote:c1:t1".to_string()],
+            Some("remote:c1:t2".to_string()),
+        );
+
+        // A sync that predates the close leaves the intent queued.
+        let outcome = sync_layout(
+            &mut data,
+            &mut rs,
+            Some(split(vec![terminal("t1"), terminal("t2")])),
+        );
+        assert!(outcome.focus_targets.is_empty());
+
+        // The close lands: t2 is now the whole layout, at the root path.
+        let outcome = sync_layout(&mut data, &mut rs, Some(terminal("t2")));
+        assert_eq!(
+            outcome.focus_targets,
+            vec![RemoteFocusTarget {
+                project_id: "remote:c1:a".to_string(),
+                layout_path: vec![],
+            }]
+        );
+        // Resolved exactly once.
+        assert!(
+            sync_layout(&mut data, &mut rs, Some(terminal("t2")))
+                .focus_targets
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn close_focus_falls_back_when_the_intended_terminal_also_went_away() {
+        let mut data = empty_data();
+        let mut rs = RemoteSyncState::new();
+        sync_layout(
+            &mut data,
+            &mut rs,
+            Some(split(vec![terminal("t1"), terminal("t2")])),
+        );
+        rs.queue_close_focus(
+            WindowId::Main,
+            "remote:c1:a",
+            vec!["remote:c1:t1".to_string()],
+            Some("remote:c1:t2".to_string()),
+        );
+
+        // Both panes are gone by the time the sync lands; a third one exists.
+        let outcome = sync_layout(&mut data, &mut rs, Some(terminal("t3")));
+        assert_eq!(
+            outcome.focus_targets,
+            vec![RemoteFocusTarget {
+                project_id: "remote:c1:a".to_string(),
+                layout_path: vec![],
+            }]
+        );
+    }
+
+    #[test]
+    fn close_focus_on_an_emptied_project_targets_the_project_itself() {
+        let mut data = empty_data();
+        let mut rs = RemoteSyncState::new();
+        sync_layout(&mut data, &mut rs, Some(terminal("t1")));
+        rs.queue_close_focus(
+            WindowId::Main,
+            "remote:c1:a",
+            vec!["remote:c1:t1".to_string()],
+            None,
+        );
+
+        // Closing the last terminal drops the layout — focus stays on the
+        // project (empty path matches no pane) so the next action targets it.
+        let outcome = sync_layout(&mut data, &mut rs, None);
+        assert_eq!(
+            outcome.focus_targets,
+            vec![RemoteFocusTarget {
+                project_id: "remote:c1:a".to_string(),
+                layout_path: vec![],
+            }]
+        );
+    }
+
+    #[test]
+    fn close_focus_is_given_up_on_when_the_close_never_lands() {
+        let mut data = empty_data();
+        let mut rs = RemoteSyncState::new();
+        sync_layout(
+            &mut data,
+            &mut rs,
+            Some(split(vec![terminal("t1"), terminal("t2")])),
+        );
+        rs.queue_close_focus(
+            WindowId::Main,
+            "remote:c1:a",
+            vec!["remote:c1:t1".to_string()],
+            Some("remote:c1:t2".to_string()),
+        );
+
+        // The daemon rejected the close: t1 stays put through many syncs.
+        for _ in 0..60 {
+            assert!(
+                sync_layout(
+                    &mut data,
+                    &mut rs,
+                    Some(split(vec![terminal("t1"), terminal("t2")])),
+                )
+                .focus_targets
+                .is_empty()
+            );
+        }
+
+        // A much later, unrelated close of t1 must not resurrect the intent.
+        assert!(
+            sync_layout(&mut data, &mut rs, Some(terminal("t2")))
+                .focus_targets
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn a_newly_added_tab_is_brought_to_the_front_when_focused() {
+        // Selecting a tab is client-owned, so `merge_visual_state` keeps the
+        // tab the user is on. Without an explicit activation the daemon's new
+        // tab would stay behind it and the focused pane would be off screen —
+        // the reason a second Cmd+T appeared to do nothing.
+        let mut data = empty_data();
+        let mut rs = RemoteSyncState::new();
+        sync_layout(
+            &mut data,
+            &mut rs,
+            Some(api_tabs(vec![terminal("t1"), terminal("t2")], 1)),
+        );
+        // The user switches back to the first tab (client-local state).
+        sync_layout(
+            &mut data,
+            &mut rs,
+            Some(api_tabs(vec![terminal("t1"), terminal("t2")], 1)),
+        );
+        match data.projects[0].layout.as_mut().expect("layout") {
+            LayoutNode::Tabs { active_tab, .. } => *active_tab = 0,
+            other => panic!("expected tabs, got {other:?}"),
+        }
+
+        rs.queue_focus(
+            WindowId::Main,
+            "remote:c1:a",
+            vec!["remote:c1:t1".to_string(), "remote:c1:t2".to_string()],
+        );
+        let outcome = sync_layout(
+            &mut data,
+            &mut rs,
+            Some(api_tabs(
+                vec![terminal("t1"), terminal("t2"), terminal("t3")],
+                2,
+            )),
+        );
+
+        assert_eq!(
+            outcome.focus_targets,
+            vec![RemoteFocusTarget {
+                project_id: "remote:c1:a".to_string(),
+                layout_path: vec![2],
+            }]
+        );
+        assert_eq!(active_tab_at(&data, &[]), 2);
+    }
+
+    #[test]
+    fn close_focus_brings_its_tab_to_the_front() {
+        // Closing the last pane of a split collapses the tree onto the
+        // neighbouring tab group. The local selection can't survive that
+        // reshape, so the merge falls back to the daemon's active tab — which
+        // is whichever tab was created last, not the one the user was on.
+        let mut data = empty_data();
+        let mut rs = RemoteSyncState::new();
+        sync_layout(
+            &mut data,
+            &mut rs,
+            Some(split(vec![
+                terminal("t1"),
+                api_tabs(vec![terminal("t2"), terminal("t3")], 0),
+            ])),
+        );
+        rs.queue_close_focus(
+            WindowId::Main,
+            "remote:c1:a",
+            vec!["remote:c1:t1".to_string()],
+            Some("remote:c1:t2".to_string()),
+        );
+
+        let outcome = sync_layout(
+            &mut data,
+            &mut rs,
+            Some(api_tabs(vec![terminal("t2"), terminal("t3")], 1)),
+        );
+
+        assert_eq!(
+            outcome.focus_targets,
+            vec![RemoteFocusTarget {
+                project_id: "remote:c1:a".to_string(),
+                layout_path: vec![0],
+            }]
+        );
+        assert_eq!(active_tab_at(&data, &[]), 0);
     }
 
     #[test]

--- a/crates/okena-workspace/src/remote_sync.rs
+++ b/crates/okena-workspace/src/remote_sync.rs
@@ -30,6 +30,16 @@ pub struct RemoteSyncState {
     /// originating window and project ID are recorded here. On that window's
     /// next sync, we detect the new terminal and focus it in the same window.
     pending_focus: HashMap<WindowId, HashMap<String, Vec<String>>>,
+    /// Where each window's focus should land once the daemon confirms a close.
+    ///
+    /// Closing is a daemon round-trip: the client sends the action, the daemon
+    /// mutates the layout, and the new tree arrives in a state sync. The window
+    /// resolves its focus intent here (see
+    /// [`crate::remote_apply::apply_remote_snapshot`]) rather than at dispatch
+    /// time, because until the sync lands the closed pane is still in the tree
+    /// and every surviving path may shift. One entry per window — a newer close
+    /// supersedes an unresolved older one.
+    pending_close_focus: HashMap<WindowId, PendingCloseFocus>,
     /// Per-project remote snapshots keyed by project ID.
     snapshots: HashMap<String, RemoteProjectSnapshot>,
     /// Remote project creates waiting for the created project to appear in a
@@ -46,6 +56,27 @@ pub struct PendingRemoteFocus {
     pub project_id: String,
     pub old_terminal_ids: Vec<String>,
 }
+
+/// A window's focus intent for an in-flight close.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingCloseFocus {
+    /// Project whose layout the close applies to.
+    pub project_id: String,
+    /// Terminals that must be gone from that layout before the intent applies.
+    pub closing_terminal_ids: Vec<String>,
+    /// Terminal to focus afterwards, or `None` when the close empties the
+    /// project and focus should simply stay on the project itself.
+    pub next_terminal_id: Option<String>,
+    /// Syncs this intent has waited through, so a close the daemon never
+    /// applies (rejected, or the terminal was already gone) can't sit around
+    /// waiting to hijack focus later.
+    attempts: u8,
+}
+
+/// Give up on an unresolved close intent after this many syncs. Generous: a
+/// sync fires on every remote-manager notification, not just the one carrying
+/// the close.
+const MAX_CLOSE_FOCUS_ATTEMPTS: u8 = 50;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct PendingRemoteProjectVisibility {
@@ -89,6 +120,40 @@ impl RemoteSyncState {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    // === pending close focus ===
+
+    pub fn queue_close_focus(
+        &mut self,
+        window_id: WindowId,
+        project_id: &str,
+        closing_terminal_ids: Vec<String>,
+        next_terminal_id: Option<String>,
+    ) {
+        self.pending_close_focus.insert(
+            window_id,
+            PendingCloseFocus {
+                project_id: project_id.to_string(),
+                closing_terminal_ids,
+                next_terminal_id,
+                attempts: 0,
+            },
+        );
+    }
+
+    /// Take a window's close-focus intent for resolution against a fresh sync.
+    pub fn take_close_focus(&mut self, window_id: WindowId) -> Option<PendingCloseFocus> {
+        self.pending_close_focus.remove(&window_id)
+    }
+
+    /// Put an intent back because the sync that just landed doesn't reflect the
+    /// close yet. Dropped once it has waited too long.
+    pub fn retry_close_focus(&mut self, window_id: WindowId, mut pending: PendingCloseFocus) {
+        pending.attempts += 1;
+        if pending.attempts < MAX_CLOSE_FOCUS_ATTEMPTS {
+            self.pending_close_focus.insert(window_id, pending);
+        }
     }
 
     // === pending project visibility ===
@@ -201,6 +266,8 @@ impl RemoteSyncState {
         }
         self.pending_focus
             .retain(|_, projects| !projects.is_empty());
+        self.pending_close_focus
+            .retain(|_, pending| pending.project_id != project_id);
     }
 
     /// Drop cached project presentation after a connection disappears or a

--- a/crates/okena-workspace/src/state.rs
+++ b/crates/okena-workspace/src/state.rs
@@ -28,6 +28,28 @@ pub use okena_state::{
     WorkspaceData, WorktreeMetadata,
 };
 
+/// What a window is focused on, captured before a sync reshapes the layout.
+/// See `Workspace::reanchor_focus`.
+struct FocusAnchor {
+    /// The window's focus at capture time, so a focus target applied during
+    /// this sync can be told apart from an untouched window.
+    previous: FocusedTerminalState,
+    /// Terminal the focused path named — the thing to follow.
+    terminal_id: String,
+    /// Where focus goes if that terminal is gone once the sync lands, resolved
+    /// against the tree it still lived in.
+    replacement: Option<String>,
+}
+
+/// The terminal slot at `path`: `Some(None)` for a pane whose PTY is still
+/// spawning, `None` when the path doesn't name a pane at all.
+fn terminal_slot_at<'a>(layout: &'a LayoutNode, path: &[usize]) -> Option<Option<&'a str>> {
+    match layout.get_at_path(path) {
+        Some(LayoutNode::Terminal { terminal_id, .. }) => Some(terminal_id.as_deref()),
+        _ => None,
+    }
+}
+
 /// Diagnostics returned after atomically aborting a vanished before-remove hook.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AbortedWorktreeClose {
@@ -2111,6 +2133,10 @@ impl Workspace {
         focus_manager: &mut FocusManager,
         cx: &mut impl WorkspaceCx,
     ) {
+        // Capture what this window is looking at before reconciliation reshapes
+        // the tree — see `reanchor_focus`.
+        let anchor = self.capture_focus_anchor(focus_manager);
+
         let outcome = crate::remote_apply::apply_remote_snapshot(
             &mut self.data,
             &mut self.remote_sync,
@@ -2139,36 +2165,91 @@ impl Workspace {
             self.set_focused_terminal(focus_manager, target.project_id, target.layout_path, cx);
         }
 
-        // Focus can also be orphaned by a close this window never asked for —
-        // a shell that exited on its own, or another window closing the pane.
-        // Nothing else re-anchors the path, so it would keep pointing at a slot
-        // that no longer holds a terminal and the window would end up with no
-        // keyboard focus at all. Modal context is left alone: the modal owns
-        // focus and restores its own target when it closes.
-        //
-        // The replacement has to be a terminal too. On a degenerate tree (an
-        // empty container) `find_visible_terminal_path` hands back the
-        // container's own path, which would leave focus just as orphaned and
-        // re-run this on every single sync — each pass paying for a
-        // `bump_activity` notify, a debounced save and a sidebar re-sort.
-        if !focus_manager.is_modal()
-            && let Some(focused) = focus_manager.focused_terminal_state()
-            && let Some(layout) = self
-                .project(&focused.project_id)
-                .and_then(|p| p.layout.as_ref())
-            && !matches!(
-                layout.get_at_path(&focused.layout_path),
-                Some(LayoutNode::Terminal { .. })
-            )
-        {
-            let path = layout.find_visible_terminal_path();
-            if matches!(layout.get_at_path(&path), Some(LayoutNode::Terminal { .. })) {
-                self.set_focused_terminal(focus_manager, focused.project_id, path, cx);
-            }
-        }
+        self.reanchor_focus(focus_manager, anchor.as_ref());
 
         // Notify UI without bumping data_version (remote changes shouldn't trigger auto-save)
         self.notify_ui_only(cx);
+    }
+
+    /// Record which terminal a window is focused on, before a sync reshapes the
+    /// layout under it. `None` when the window has no focus, or its path no
+    /// longer names a pane (already orphaned — nothing to follow).
+    fn capture_focus_anchor(&self, focus_manager: &FocusManager) -> Option<FocusAnchor> {
+        let previous = focus_manager.focused_terminal_state()?;
+        let layout = self.project(&previous.project_id)?.layout.as_ref()?;
+        let terminal_id = terminal_slot_at(layout, &previous.layout_path)??.to_string();
+        // Computed on the pre-sync tree, while the focused pane's position is
+        // still known: where focus goes if this sync took that pane away.
+        let replacement = layout.terminal_to_focus_after_closing(&previous.layout_path);
+        Some(FocusAnchor {
+            previous,
+            terminal_id,
+            replacement,
+        })
+    }
+
+    /// Keep a window pointed at the terminal it was on across a sync.
+    ///
+    /// Focus is a layout *path*, and any change to the tree can move it: a pane
+    /// closed in another window, a shell that exited on its own, a daemon-side
+    /// move. The path then silently addresses a different terminal, or nothing
+    /// at all — leaving the window with no keyboard focus. Windows that issued
+    /// the change get an explicit target (`queue_focus_after_close`); this is
+    /// the passive counterpart every window gets for changes it didn't make, so
+    /// it defers to a target that already moved focus this pass.
+    ///
+    /// Ordinary focus changes (clicks, navigation) are not activity in the
+    /// project sense, so this deliberately bypasses `set_focused_terminal`: no
+    /// `bump_activity`, no sidebar re-sort, no debounced save.
+    fn reanchor_focus(&self, focus_manager: &mut FocusManager, anchor: Option<&FocusAnchor>) {
+        // A modal owns focus and restores its own target when it closes.
+        if focus_manager.is_modal() {
+            return;
+        }
+        let Some(current) = focus_manager.focused_terminal_state() else {
+            return;
+        };
+        // An explicit focus target already moved this window — it wins.
+        if anchor.is_some_and(|anchor| anchor.previous != current) {
+            return;
+        }
+        let Some(layout) = self
+            .project(&current.project_id)
+            .and_then(|p| p.layout.as_ref())
+        else {
+            // A project with no layout keeps focus on the project itself.
+            return;
+        };
+
+        let replacement = match anchor {
+            Some(anchor) => {
+                if terminal_slot_at(layout, &current.layout_path)
+                    == Some(Some(anchor.terminal_id.as_str()))
+                {
+                    return; // Still on the same terminal.
+                }
+                // Follow it if it merely moved; otherwise take the neighbour
+                // resolved against the tree it lived in.
+                layout.find_terminal_path(&anchor.terminal_id).or_else(|| {
+                    anchor
+                        .replacement
+                        .as_ref()
+                        .and_then(|id| layout.find_terminal_path(id))
+                })
+            }
+            // Focus was already orphaned before this sync, so there is nothing
+            // to follow — but if the path names a pane again, leave it be.
+            None if terminal_slot_at(layout, &current.layout_path).is_some() => return,
+            None => None,
+        };
+
+        let path = replacement.unwrap_or_else(|| layout.find_visible_terminal_path());
+        // A degenerate tree (an empty container) has no terminal to offer, and
+        // `find_visible_terminal_path` would hand back the container's own path
+        // — leaving focus just as orphaned and re-running this every sync.
+        if path != current.layout_path && terminal_slot_at(layout, &path).is_some() {
+            focus_manager.focus_terminal(current.project_id, path);
+        }
     }
 
     /// Helper to mutate a layout node at a path, with automatic notify.
@@ -3556,24 +3637,132 @@ mod gpui_tests {
         }
     }
 
+    fn pane(terminal_id: &str) -> LayoutNode {
+        LayoutNode::Terminal {
+            terminal_id: Some(terminal_id.to_string()),
+            minimized: false,
+            detached: false,
+            shell_type: ShellType::Default,
+            zoom_level: 1.0,
+        }
+    }
+
+    fn split_of(terminal_ids: &[&str]) -> LayoutNode {
+        LayoutNode::Split {
+            direction: crate::state::SplitDirection::Horizontal,
+            sizes: vec![100.0 / terminal_ids.len() as f32; terminal_ids.len()],
+            children: terminal_ids.iter().map(|tid| pane(tid)).collect(),
+        }
+    }
+
+    fn tabs_of(terminal_ids: &[&str], active_tab: usize) -> LayoutNode {
+        LayoutNode::Tabs {
+            children: terminal_ids.iter().map(|tid| pane(tid)).collect(),
+            active_tab,
+        }
+    }
+
     /// Project whose layout is a two-pane horizontal split.
     fn project_with_split(id: &str, terminal_ids: [&str; 2]) -> ProjectData {
         let mut project = make_project(id);
-        project.layout = Some(LayoutNode::Split {
-            direction: crate::state::SplitDirection::Horizontal,
-            sizes: vec![50.0, 50.0],
-            children: terminal_ids
-                .iter()
-                .map(|tid| LayoutNode::Terminal {
-                    terminal_id: Some((*tid).to_string()),
-                    minimized: false,
-                    detached: false,
-                    shell_type: ShellType::Default,
-                    zoom_level: 1.0,
-                })
-                .collect(),
-        });
+        project.layout = Some(split_of(&terminal_ids));
         project
+    }
+
+    /// Focus `path` in `p1`, then replay what a sync brings: capture the anchor,
+    /// swap in the layout the sync produced, resolve. Reports where focus landed
+    /// and which terminal is there.
+    fn reanchor_across(
+        cx: &mut gpui::TestAppContext,
+        before: LayoutNode,
+        focus_path: Vec<usize>,
+        after: LayoutNode,
+    ) -> (Vec<usize>, Option<String>) {
+        let mut project = make_project("p1");
+        project.layout = Some(before);
+        let workspace =
+            cx.new(|_cx| Workspace::new(make_workspace_data(vec![project], vec!["p1"])));
+        let mut fm = crate::focus::FocusManager::new();
+        fm.focus_terminal("p1".to_string(), focus_path);
+
+        workspace.update(cx, |ws: &mut Workspace, _cx| {
+            let anchor = ws.capture_focus_anchor(&fm);
+            ws.project_mut("p1").unwrap().layout = Some(after);
+            ws.reanchor_focus(&mut fm, anchor.as_ref());
+        });
+
+        let focused = fm.focused_terminal_state().expect("focus retained");
+        let terminal = workspace.read_with(cx, |ws: &Workspace, _cx| {
+            ws.project("p1")
+                .and_then(|p| p.layout.as_ref())
+                .and_then(|layout| match layout.get_at_path(&focused.layout_path) {
+                    Some(LayoutNode::Terminal { terminal_id, .. }) => terminal_id.clone(),
+                    _ => None,
+                })
+        });
+        (focused.layout_path, terminal)
+    }
+
+    #[gpui::test]
+    fn focus_follows_its_terminal_when_another_window_reshapes_the_layout(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        // Focused on t3, the third pane; another window closes t1, shifting
+        // every surviving pane one slot left. Focus has to follow t3 to [1] —
+        // not fall back to whatever is first on screen.
+        let (path, terminal) = reanchor_across(
+            cx,
+            split_of(&["t1", "t2", "t3"]),
+            vec![2],
+            split_of(&["t2", "t3"]),
+        );
+
+        assert_eq!(path, vec![1]);
+        assert_eq!(terminal.as_deref(), Some("t3"));
+    }
+
+    #[gpui::test]
+    fn focus_moves_to_the_neighbour_when_another_window_closes_its_terminal(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        // Focused on t3; another window closes it. The neighbour is resolved
+        // against the tree t3 lived in — the same rule this window's own close
+        // would have used — landing on t2, not on whatever is first on screen.
+        let (path, terminal) = reanchor_across(
+            cx,
+            split_of(&["t1", "t2", "t3"]),
+            vec![2],
+            split_of(&["t1", "t2"]),
+        );
+
+        assert_eq!(path, vec![1]);
+        assert_eq!(terminal.as_deref(), Some("t2"));
+    }
+
+    #[gpui::test]
+    fn reanchoring_defers_to_a_focus_target_applied_this_sync(cx: &mut gpui::TestAppContext) {
+        // Cmd+T: the sync brings a new tab and an explicit target focuses it.
+        // The terminal this window was on is still very much alive, so a
+        // re-anchor that followed it blindly would yank focus straight back
+        // out of the tab the user just opened.
+        let mut project = make_project("p1");
+        project.layout = Some(tabs_of(&["t1", "t2"], 0));
+        let workspace =
+            cx.new(|_cx| Workspace::new(make_workspace_data(vec![project], vec!["p1"])));
+        let mut fm = crate::focus::FocusManager::new();
+        fm.focus_terminal("p1".to_string(), vec![0]);
+
+        workspace.update(cx, |ws: &mut Workspace, _cx| {
+            let anchor = ws.capture_focus_anchor(&fm);
+            ws.project_mut("p1").unwrap().layout = Some(tabs_of(&["t1", "t2", "t3"], 2));
+            fm.focus_terminal("p1".to_string(), vec![2]);
+            ws.reanchor_focus(&mut fm, anchor.as_ref());
+        });
+
+        assert_eq!(
+            fm.focused_terminal_state().map(|f| f.layout_path),
+            Some(vec![2])
+        );
     }
 
     /// Run a no-op remote sync (no connections) and report where focus ended up.

--- a/crates/okena-workspace/src/state.rs
+++ b/crates/okena-workspace/src/state.rs
@@ -1561,6 +1561,72 @@ impl Workspace {
         self.remote_sync.drain_pending_focus(window_id)
     }
 
+    /// Record where a window's focus should land once the daemon applies a
+    /// close, so keyboard focus survives the round-trip.
+    ///
+    /// Closing is not a local mutation: the client sends the action and the new
+    /// layout comes back in a state sync. Nothing re-anchors the window's focus
+    /// path across that sync, so without this a close either strands focus on a
+    /// pane that no longer exists at that path or drops it entirely. The intent
+    /// is captured here — while the pre-close tree is still available to reason
+    /// about — and resolved by terminal id after the sync.
+    ///
+    /// `focused` is the window's current focus. Focus in another project is
+    /// left alone; focus on a terminal that survives the close is re-anchored
+    /// to that same terminal (its path may shift); focus on a closing terminal
+    /// (or no focus at all) moves to the neighbour that takes its place.
+    pub fn queue_focus_after_close(
+        &mut self,
+        window_id: WindowId,
+        project_id: &str,
+        closing_terminal_ids: &[String],
+        focused: Option<&FocusedTerminalState>,
+    ) {
+        let Some(layout) = self.project(project_id).and_then(|p| p.layout.as_ref()) else {
+            return;
+        };
+        let closing: HashSet<&str> = closing_terminal_ids.iter().map(String::as_str).collect();
+
+        let focused_id = focused
+            .filter(|f| f.project_id == project_id)
+            .and_then(|f| layout.get_at_path(&f.layout_path))
+            .and_then(|node| match node {
+                LayoutNode::Terminal { terminal_id, .. } => terminal_id.clone(),
+                _ => None,
+            });
+
+        let next = match focused_id {
+            Some(id) if !closing.contains(id.as_str()) => Some(id),
+            focused_id => {
+                // Focus is on one of the closing terminals, or the window has no
+                // terminal focus at all and this close is its chance to recover.
+                if focused_id.is_none() && focused.is_some_and(|f| f.project_id != project_id) {
+                    return;
+                }
+                let neighbour = focused_id
+                    .or_else(|| closing_terminal_ids.first().cloned())
+                    .and_then(|id| layout.find_terminal_path(&id))
+                    .and_then(|path| layout.terminal_to_focus_after_closing(&path))
+                    .filter(|id| !closing.contains(id.as_str()));
+                // A bulk close (close others / close to the right) can swallow
+                // the neighbour too — fall back to whatever the pruned tree
+                // leaves visible.
+                neighbour.or_else(|| {
+                    let mut remaining = Some(layout.clone());
+                    LayoutNode::remove_terminal_ids(&mut remaining, &closing);
+                    remaining.and_then(|layout| layout.visible_terminal_id())
+                })
+            }
+        };
+
+        self.remote_sync.queue_close_focus(
+            window_id,
+            project_id,
+            closing_terminal_ids.to_vec(),
+            next,
+        );
+    }
+
     pub fn queue_pending_remote_project_visibility(
         &mut self,
         window_id: WindowId,
@@ -2073,6 +2139,26 @@ impl Workspace {
             self.set_focused_terminal(focus_manager, target.project_id, target.layout_path, cx);
         }
 
+        // Focus can also be orphaned by a close this window never asked for —
+        // a shell that exited on its own, or another window closing the pane.
+        // Nothing else re-anchors the path, so it would keep pointing at a slot
+        // that no longer holds a terminal and the window would end up with no
+        // keyboard focus at all. Modal context is left alone: the modal owns
+        // focus and restores its own target when it closes.
+        if !focus_manager.is_modal()
+            && let Some(focused) = focus_manager.focused_terminal_state()
+            && let Some(layout) = self
+                .project(&focused.project_id)
+                .and_then(|p| p.layout.as_ref())
+            && !matches!(
+                layout.get_at_path(&focused.layout_path),
+                Some(LayoutNode::Terminal { .. })
+            )
+        {
+            let path = layout.find_visible_terminal_path();
+            self.set_focused_terminal(focus_manager, focused.project_id, path, cx);
+        }
+
         // Notify UI without bumping data_version (remote changes shouldn't trigger auto-save)
         self.notify_ui_only(cx);
     }
@@ -2419,6 +2505,140 @@ mod workspace_tests {
             main_window: WindowState::default(),
             extra_windows: Vec::new(),
         }
+    }
+
+    /// Project whose layout is a tab group over `terminal_ids`.
+    fn project_with_tabs(id: &str, terminal_ids: &[&str], active_tab: usize) -> ProjectData {
+        let mut project = make_project(id);
+        project.layout = Some(LayoutNode::Tabs {
+            children: terminal_ids
+                .iter()
+                .map(|tid| LayoutNode::Terminal {
+                    terminal_id: Some((*tid).to_string()),
+                    minimized: false,
+                    detached: false,
+                    shell_type: ShellType::Default,
+                    zoom_level: 1.0,
+                })
+                .collect(),
+            active_tab,
+        });
+        project
+    }
+
+    fn focused(project_id: &str, layout_path: Vec<usize>) -> crate::state::FocusedTerminalState {
+        crate::state::FocusedTerminalState {
+            project_id: project_id.to_string(),
+            layout_path,
+        }
+    }
+
+    /// Queue a close intent and read back the terminal it resolved to.
+    fn close_intent(
+        workspace: &mut Workspace,
+        closing: &[&str],
+        focus: Option<crate::state::FocusedTerminalState>,
+    ) -> Option<String> {
+        let closing: Vec<String> = closing.iter().map(|id| (*id).to_string()).collect();
+        workspace.queue_focus_after_close(WindowId::Main, "p1", &closing, focus.as_ref());
+        workspace
+            .remote_sync
+            .take_close_focus(WindowId::Main)
+            .expect("close intent queued")
+            .next_terminal_id
+    }
+
+    #[test]
+    fn closing_the_focused_tab_hands_focus_to_the_tab_that_becomes_visible() {
+        let mut workspace = Workspace::new(make_workspace_data(
+            vec![project_with_tabs("p1", &["t1", "t2", "t3"], 0)],
+            vec!["p1"],
+        ));
+
+        assert_eq!(
+            close_intent(&mut workspace, &["t1"], Some(focused("p1", vec![0]))),
+            Some("t2".to_string())
+        );
+    }
+
+    #[test]
+    fn closing_a_background_tab_re_anchors_focus_onto_the_same_terminal() {
+        // t2 is focused and survives; its path shifts from [1] to [0] when t1
+        // goes away, so the intent must name t2 rather than keep the path.
+        let mut workspace = Workspace::new(make_workspace_data(
+            vec![project_with_tabs("p1", &["t1", "t2", "t3"], 1)],
+            vec!["p1"],
+        ));
+
+        assert_eq!(
+            close_intent(&mut workspace, &["t1"], Some(focused("p1", vec![1]))),
+            Some("t2".to_string())
+        );
+    }
+
+    #[test]
+    fn closing_the_last_terminal_leaves_focus_on_the_project() {
+        let mut workspace =
+            Workspace::new(make_workspace_data(vec![make_project("p1")], vec!["p1"]));
+
+        assert_eq!(
+            close_intent(&mut workspace, &["term_p1"], Some(focused("p1", vec![]))),
+            None
+        );
+    }
+
+    #[test]
+    fn bulk_close_that_swallows_the_neighbour_falls_back_to_a_survivor() {
+        // "Close other tabs" from t3: t1 (focused) and t2 both go, so the
+        // neighbouring-tab rule is useless and only t3 is left to focus.
+        let mut workspace = Workspace::new(make_workspace_data(
+            vec![project_with_tabs("p1", &["t1", "t2", "t3"], 0)],
+            vec!["p1"],
+        ));
+
+        assert_eq!(
+            close_intent(&mut workspace, &["t1", "t2"], Some(focused("p1", vec![0]))),
+            Some("t3".to_string())
+        );
+    }
+
+    #[test]
+    fn closing_a_terminal_in_another_project_leaves_focus_alone() {
+        let mut workspace = Workspace::new(make_workspace_data(
+            vec![
+                project_with_tabs("p1", &["t1", "t2"], 0),
+                make_project("p2"),
+            ],
+            vec!["p1", "p2"],
+        ));
+
+        let closing = vec!["t1".to_string()];
+        workspace.queue_focus_after_close(
+            WindowId::Main,
+            "p1",
+            &closing,
+            Some(&focused("p2", vec![])),
+        );
+
+        assert!(
+            workspace
+                .remote_sync
+                .take_close_focus(WindowId::Main)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn closing_with_nothing_focused_recovers_focus_into_the_project() {
+        let mut workspace = Workspace::new(make_workspace_data(
+            vec![project_with_tabs("p1", &["t1", "t2"], 0)],
+            vec!["p1"],
+        ));
+
+        assert_eq!(
+            close_intent(&mut workspace, &["t1"], None),
+            Some("t2".to_string())
+        );
     }
 
     #[test]

--- a/crates/okena-workspace/src/state.rs
+++ b/crates/okena-workspace/src/state.rs
@@ -2145,6 +2145,12 @@ impl Workspace {
         // that no longer holds a terminal and the window would end up with no
         // keyboard focus at all. Modal context is left alone: the modal owns
         // focus and restores its own target when it closes.
+        //
+        // The replacement has to be a terminal too. On a degenerate tree (an
+        // empty container) `find_visible_terminal_path` hands back the
+        // container's own path, which would leave focus just as orphaned and
+        // re-run this on every single sync — each pass paying for a
+        // `bump_activity` notify, a debounced save and a sidebar re-sort.
         if !focus_manager.is_modal()
             && let Some(focused) = focus_manager.focused_terminal_state()
             && let Some(layout) = self
@@ -2156,7 +2162,9 @@ impl Workspace {
             )
         {
             let path = layout.find_visible_terminal_path();
-            self.set_focused_terminal(focus_manager, focused.project_id, path, cx);
+            if matches!(layout.get_at_path(&path), Some(LayoutNode::Terminal { .. })) {
+                self.set_focused_terminal(focus_manager, focused.project_id, path, cx);
+            }
         }
 
         // Notify UI without bumping data_version (remote changes shouldn't trigger auto-save)
@@ -3546,6 +3554,111 @@ mod gpui_tests {
             main_window: WindowState::default(),
             extra_windows: Vec::new(),
         }
+    }
+
+    /// Project whose layout is a two-pane horizontal split.
+    fn project_with_split(id: &str, terminal_ids: [&str; 2]) -> ProjectData {
+        let mut project = make_project(id);
+        project.layout = Some(LayoutNode::Split {
+            direction: crate::state::SplitDirection::Horizontal,
+            sizes: vec![50.0, 50.0],
+            children: terminal_ids
+                .iter()
+                .map(|tid| LayoutNode::Terminal {
+                    terminal_id: Some((*tid).to_string()),
+                    minimized: false,
+                    detached: false,
+                    shell_type: ShellType::Default,
+                    zoom_level: 1.0,
+                })
+                .collect(),
+        });
+        project
+    }
+
+    /// Run a no-op remote sync (no connections) and report where focus ended up.
+    fn sync_and_read_focus(
+        workspace: &gpui::Entity<Workspace>,
+        fm: &mut crate::focus::FocusManager,
+        cx: &mut gpui::TestAppContext,
+    ) -> Option<Vec<usize>> {
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            ws.apply_remote_snapshot(&[], WindowId::Main, fm, cx);
+        });
+        fm.focused_terminal_state().map(|f| f.layout_path)
+    }
+
+    #[gpui::test]
+    fn sync_re_anchors_focus_orphaned_by_a_close_this_window_did_not_make(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        // A shell exits on its own (or another window closes the pane): the
+        // split collapses and the focused path stops naming a terminal.
+        let workspace = cx.new(|_cx| {
+            Workspace::new(make_workspace_data(
+                vec![project_with_split("p1", ["t1", "t2"])],
+                vec!["p1"],
+            ))
+        });
+        let mut fm = crate::focus::FocusManager::new();
+        fm.focus_terminal("p1".to_string(), vec![1]);
+
+        workspace.update(cx, |ws: &mut Workspace, _cx| {
+            ws.project_mut("p1").unwrap().layout = Some(LayoutNode::Terminal {
+                terminal_id: Some("t1".to_string()),
+                minimized: false,
+                detached: false,
+                shell_type: ShellType::Default,
+                zoom_level: 1.0,
+            });
+        });
+
+        assert_eq!(sync_and_read_focus(&workspace, &mut fm, cx), Some(vec![]));
+    }
+
+    #[gpui::test]
+    fn sync_leaves_a_focus_path_that_still_names_a_terminal_alone(cx: &mut gpui::TestAppContext) {
+        let workspace = cx.new(|_cx| {
+            Workspace::new(make_workspace_data(
+                vec![project_with_split("p1", ["t1", "t2"])],
+                vec!["p1"],
+            ))
+        });
+        let mut fm = crate::focus::FocusManager::new();
+        fm.focus_terminal("p1".to_string(), vec![1]);
+
+        assert_eq!(sync_and_read_focus(&workspace, &mut fm, cx), Some(vec![1]));
+    }
+
+    #[gpui::test]
+    fn sync_does_not_re_anchor_focus_onto_a_non_terminal(cx: &mut gpui::TestAppContext) {
+        // A degenerate tree has no terminal to offer. Re-anchoring onto the
+        // empty container would leave focus just as orphaned and re-run the
+        // heal — with its notify + debounced save — on every later sync.
+        let workspace = cx.new(|_cx| {
+            Workspace::new(make_workspace_data(
+                vec![project_with_split("p1", ["t1", "t2"])],
+                vec!["p1"],
+            ))
+        });
+        let mut fm = crate::focus::FocusManager::new();
+        fm.focus_terminal("p1".to_string(), vec![1]);
+
+        workspace.update(cx, |ws: &mut Workspace, _cx| {
+            ws.project_mut("p1").unwrap().layout = Some(LayoutNode::Split {
+                direction: crate::state::SplitDirection::Horizontal,
+                sizes: Vec::new(),
+                children: Vec::new(),
+            });
+        });
+
+        assert_eq!(sync_and_read_focus(&workspace, &mut fm, cx), Some(vec![1]));
+        let version = workspace.read_with(cx, |ws: &Workspace, _cx| ws.data_version());
+        // Still inert on the next sync — no repeated activity bumps.
+        assert_eq!(sync_and_read_focus(&workspace, &mut fm, cx), Some(vec![1]));
+        workspace.read_with(cx, |ws: &Workspace, _cx| {
+            assert_eq!(ws.data_version(), version);
+        });
     }
 
     #[gpui::test]


### PR DESCRIPTION
Keyboard-only navigation had several dead ends. Each one alone stranded focus somewhere it couldn't leave; together they made the keyboard unusable for moving around.

## 1. Closing a terminal left nothing focused

Since the headless refactor, closing is a daemon round-trip: the client dispatches `CloseTerminal`, the daemon mutates the layout, and the new tree arrives in a state sync. Nothing re-anchored the window's focus across that sync — and focus is a layout *path*. A close reshapes the tree (tab groups dissolve, splits collapse), so the stored path either pointed at a slot that no longer held a terminal — no pane matched, nothing took keyboard focus — or silently at a different terminal.

**The focus rule, stated once** — `LayoutNode::terminal_to_focus_after_closing`, mirroring what `remove_at_path` will do to the tree:

| closing | focus lands on |
|---|---|
| a tab | the tab that becomes visible |
| the last tab of a group | the neighbouring pane in the same project (the group collapses, so the rule re-applies one level up) |
| the last terminal in the project | the project itself — an empty path matches no pane but keeps the project targeted by the next action |
| a pane elsewhere in the tree | the same terminal it was already on, re-anchored by id because its path shifted |

**Resolved by id, not path.** The intent is captured at dispatch time while the pre-close tree is still there, waits for the sync that actually reflects the close, and is given up on if the daemon never applies it. Bulk closes ("close others" / "close to the right") that swallow the neighbour fall back to what the pruned tree leaves visible.

**Every window, not just the closer.** Only the window that issued a close got an explicit target; any other window showing that project kept its old path. If the path still named a terminal it silently named a *different* one, and the window was typing into the wrong pane with no outward sign. Each window now captures which terminal it is on before reconciliation and follows that terminal by id afterwards, falling back to the neighbour rule if it's gone. A window that received an explicit target this pass is left alone — otherwise a newly created terminal (Cmd+T) gets dragged back to the tab the window came from.

**Focused ⇒ visible.** Which tab is selected is client-owned (`SetActiveTab` never reaches the daemon), so `merge_visual_state` can leave the resolved terminal behind an inactive tab. Activating the tabs along each focus target fixes two symptoms with one change:

- *Cmd+T focused the new tab only the first time* — the daemon's `add_tab` selects the new tab, but the merge finds the tab you were on still present and keeps that selection, so focus landed off screen. The first Cmd+T worked only because the local layout was still a bare `Terminal` with no selection to preserve.
- *Closing the last tab focused the neighbouring group's last tab instead of its active one* — the split collapsing onto that group defeats identity matching, so the merge falls back to the daemon's `active_tab`, which is whichever tab was created last.

## 2. Project visibility was mouse-only

`ToggleProjectVisibility` (`cmd-shift-h`) is new — there was no bindable action at all, so it couldn't be bound in `keybindings.json` and never appeared in the command palette or keybindings overlay. It delegates to the existing per-window toggle, which already redirects focus off a project it hides.

In practice it only ever hides: it acts on the project you are in, and once hidden your focus has moved elsewhere. Bringing one back stays the project switcher's job.

## 3. Space in the project switcher changed nothing visible

Each project's open/closed state was snapshotted when the switcher opened and never recomputed, so `space` toggled visibility in the workspace while the modal carried on rendering the old state. Recomputing after emitting the toggle wouldn't help — the event only reaches the workspace after that frame — so the switcher observes the workspace instead, which also picks up changes made from the sidebar or another window while it's open.

## 4. A project without terminals couldn't be entered

Jumping to one from the switcher returned early (entering a project was gated on having a layout), and focusing one through zoom or folder focus silently left focus on the *previous* project — it looked selected without being current. Both now anchor on the project itself with an empty path, the same anchor a project falls back to when its last terminal closes.

That landed you somewhere with no way out: `cmd-t` is bound under `TerminalPane`, so a project with no pane could only be started by clicking "Start Terminal". `AddTab` is now also bound globally and handled at the window level **only** when the focused project has no layout — a focused pane always takes the action first, and modal context bails out so an overlay can't spawn terminals behind itself.

The whole journey now works from the keyboard: `cmd-e` → arrows → `space` → `Tab` → `cmd-t`.

## Tests

~30 new tests. The tab cases in `okena-layout` assert against a replay of the daemon's actual `close_terminal` mutation rather than a hand-written expectation, so the prediction can't drift from what the daemon does. Every test pinning a behaviour here was checked to fail with that behaviour removed — which caught two of them passing by coincidence through a fallback path.

Also added a registry test covering all 65 keybinding actions: every default binding must resolve in `create_keybinding` and have a description. Both failure modes are silent today — a mistyped action name logs a warning and leaves a dead shortcut; a missing description hides the action from the palette.

`cargo test`, `cargo clippy --workspace --all-targets` and `cargo fmt` clean.

## Not verified

The view-layer wiring — the two action handlers and `jump_to_project_terminal` — isn't unit tested; it needs real windows. Worth a manual pass on the keyboard flow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud5F7z9cXJtzSjaJVRhzeN
