### PR TITLE
Reduce terminal activity rendering work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,10 @@ mimalloc = ["dep:mimalloc"]
 # Runtime collection still requires OKENA_TERMINAL_LATENCY_PROBE=1.
 terminal-latency-probe = ["okena-core/terminal-latency-probe"]
 
+# Compile aggregate render-performance counters into the desktop app.
+# Runtime collection still requires OKENA_RENDER_PERF_PROBE=1.
+render-perf-probe = ["okena-core/render-perf-probe"]
+
 # jemalloc: default on Unix. Shares a small fixed set of arenas across all
 # threads (narenas:N in src/main.rs) instead of mimalloc's per-thread heaps, so
 # okena's ~90 threads don't each pin their own segments — cut anon-heap RSS

--- a/crates/okena-app/src/app/mod.rs
+++ b/crates/okena-app/src/app/mod.rs
@@ -12,7 +12,7 @@ use crate::views::window::{
 };
 use crate::workspace::state::{GlobalWorkspace, WindowId, Workspace, WorkspaceData};
 use gpui::*;
-use okena_ui::activity_repaint::ActivityRepaintBatch;
+use okena_ui::activity_repaint::{ActivityRepaintBatch, ActivityRepaintThrottle};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -23,6 +23,9 @@ use std::time::Duration;
 /// independent TUI animations to drive the same OS window at aggregate rates.
 /// Parsing, notifications, and OSC clipboard replies are intentionally not delayed.
 const TERMINAL_ACTIVITY_REPAINT_INTERVAL: Duration = Duration::from_millis(20);
+/// Sidebar state does not need terminal-scene frame rates. Preserve the first
+/// activity edge, then coalesce sustained and trailing updates to ~4 FPS.
+const SIDEBAR_ACTIVITY_REPAINT_INTERVAL: Duration = Duration::from_millis(250);
 
 #[derive(Default)]
 struct WindowLayoutSaveTracker {
@@ -201,6 +204,9 @@ pub struct Okena {
     /// The idle-to-active edge is presented immediately; sustained activity is
     /// coalesced while parsing and notification handling remain immediate.
     terminal_activity_repaints: ActivityRepaintBatch<String>,
+    /// Independent, lower-frequency presentation stream for sidebar activity
+    /// indicators and activity ordering. Terminal panes retain their 20 ms path.
+    sidebar_activity_repaints: ActivityRepaintThrottle,
     /// Sender handed to desktop-notification threads. When a user clicks an
     /// XDG notification, the thread sends a `NotificationJump` here and the
     /// click loop focuses the originating pane. See `app/notifications.rs`.
@@ -324,6 +330,7 @@ impl Okena {
             opened_detached_windows: HashSet::new(),
             remote_manager: remote_manager.clone(),
             terminal_activity_repaints: ActivityRepaintBatch::default(),
+            sidebar_activity_repaints: ActivityRepaintThrottle::default(),
             notification_jump_tx,
             spawned_daemon,
             preserve_daemon_on_quit: false,
@@ -724,13 +731,54 @@ impl Okena {
             okena_core::latency_probe::client_repaint_dispatched(terminal_id);
         }
 
-        // Pane and sidebar notifications happen in one app update so GPUI can
-        // present one frame for all windows rather than racing per-view timers.
-        {
+        // Terminal content keeps the ~50 FPS activity cadence for interactive
+        // output. Sidebar activity is queued independently below.
+        let repaint_stats = {
             let mut registry = content_pane_registry().lock();
-            request_registered_content_pane_repaints(&mut registry, terminal_ids, cx);
+            request_registered_content_pane_repaints(&mut registry, terminal_ids, cx)
+        };
+        okena_core::render_probe::terminal_activity_frame(
+            terminal_ids.len(),
+            repaint_stats.terminals,
+            repaint_stats.panes,
+        );
+
+        self.queue_sidebar_activity_repaint(cx);
+    }
+
+    fn queue_sidebar_activity_repaint(&mut self, cx: &mut Context<Self>) {
+        let decision = self.sidebar_activity_repaints.on_activity();
+        if decision.repaint_now {
+            self.present_sidebar_activity_repaint(cx);
+        }
+        if !decision.start_timer {
+            return;
         }
 
+        cx.spawn(async move |this: WeakEntity<Self>, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(SIDEBAR_ACTIVITY_REPAINT_INTERVAL)
+                    .await;
+                let keep_scheduled = this
+                    .update(cx, |this, cx| {
+                        if this.sidebar_activity_repaints.timer_tick() {
+                            this.present_sidebar_activity_repaint(cx);
+                            true
+                        } else {
+                            false
+                        }
+                    })
+                    .unwrap_or(false);
+                if !keep_scheduled {
+                    break;
+                }
+            }
+        })
+        .detach();
+    }
+
+    fn present_sidebar_activity_repaint(&mut self, cx: &mut Context<Self>) {
         let mut window_views = Vec::with_capacity(1 + self.extra_windows.len());
         window_views.push(self.main_window.clone());
         window_views.extend(self.extra_windows.values().cloned());

--- a/crates/okena-app/src/simple_root.rs
+++ b/crates/okena-app/src/simple_root.rs
@@ -140,6 +140,7 @@ impl Render for SimpleRoot {
             // nested caching: render-stats showed every column and pane
             // re-rendering on every window draw. Render the root uncached so
             // nested caches actually work and only dirty views re-render.
+            // `tests::view_cache_cascade` pins both halves of this.
             .child(self.view.clone())
     }
 }
@@ -166,4 +167,141 @@ fn detect_resize_edge(pos: Point<Pixels>, size: Size<Pixels>) -> Option<ResizeEd
         return None;
     };
     Some(edge)
+}
+
+/// Pins the GPUI view-caching behaviour the terminal grid cache is sized for.
+///
+/// One `cx.notify()` on a terminal's content view (what
+/// `TerminalContent::request_activity_repaint` does on every activity tick)
+/// does *not* repaint only that pane: GPUI marks the whole ancestor path dirty
+/// (`Window::mark_view_dirty`), and a dirty `.cached()` ancestor re-renders with
+/// `window.refreshing = true` for its entire subtree, bypassing every nested
+/// `.cached()`. So the notified pane's whole project column repaints — which is
+/// exactly why `TerminalRenderCache` exists, and why the cache's value scales
+/// with panes-per-column rather than being a fixed percentage.
+///
+/// Sibling *columns* stay cached. If that ever stops holding, the cost of one
+/// terminal's output grows to the whole window and this needs revisiting.
+#[cfg(test)]
+mod view_cache_cascade {
+    use gpui::{
+        AnyView, AppContext as _, Context, Entity, IntoElement, ParentElement, Render,
+        StyleRefinement, Styled, TestAppContext, Window, div,
+    };
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Stands in for `TerminalContent` — the view that gets notified.
+    struct Content {
+        renders: Arc<AtomicUsize>,
+    }
+
+    impl Render for Content {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            self.renders.fetch_add(1, Ordering::SeqCst);
+            div().size_full()
+        }
+    }
+
+    /// Stands in for the `.cached()` chain above it: terminal pane -> layout
+    /// container -> project column. One level is enough; `refreshing` propagates.
+    struct Column {
+        contents: Vec<Entity<Content>>,
+    }
+
+    impl Render for Column {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div().size_full().children(
+                self.contents.iter().map(|c| {
+                    AnyView::from(c.clone()).cached(StyleRefinement::default().size_full())
+                }),
+            )
+        }
+    }
+
+    /// Stands in for `SimpleRoot`: uncached, one `.cached()` child per column.
+    struct Root {
+        columns: Vec<Entity<Column>>,
+    }
+
+    impl Render for Root {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div().size_full().children(
+                self.columns.iter().map(|c| {
+                    AnyView::from(c.clone()).cached(StyleRefinement::default().size_full())
+                }),
+            )
+        }
+    }
+
+    #[gpui::test]
+    fn one_notify_repaints_its_whole_column_and_no_other(cx: &mut TestAppContext) {
+        const COLUMNS: usize = 2;
+        const PANES_PER_COLUMN: usize = 3;
+
+        let counters: Vec<Vec<Arc<AtomicUsize>>> = (0..COLUMNS)
+            .map(|_| {
+                (0..PANES_PER_COLUMN)
+                    .map(|_| Arc::new(AtomicUsize::new(0)))
+                    .collect()
+            })
+            .collect();
+
+        let mut notified = None;
+        let window = {
+            let counters = counters.clone();
+            let notified = &mut notified;
+            cx.add_window(move |_, cx| {
+                let columns = counters
+                    .iter()
+                    .enumerate()
+                    .map(|(col_idx, column)| {
+                        let contents: Vec<_> = column
+                            .iter()
+                            .enumerate()
+                            .map(|(pane_idx, renders)| {
+                                let content = cx.new(|_| Content {
+                                    renders: renders.clone(),
+                                });
+                                if (col_idx, pane_idx) == (0, 0) {
+                                    *notified = Some(content.clone());
+                                }
+                                content
+                            })
+                            .collect();
+                        cx.new(|_| Column { contents })
+                    })
+                    .collect();
+                Root { columns }
+            })
+        };
+        let notified = notified.expect("first pane registered");
+
+        // `add_window` already drew once; start counting from a settled tree.
+        cx.update_window(window.into(), |_, window, cx| window.draw(cx).clear(cx))
+            .unwrap();
+        for renders in counters.iter().flatten() {
+            renders.store(0, Ordering::SeqCst);
+        }
+
+        cx.update(|cx| notified.update(cx, |_, cx| cx.notify()));
+        cx.update_window(window.into(), |_, window, cx| window.draw(cx).clear(cx))
+            .unwrap();
+
+        let repaints: Vec<Vec<usize>> = counters
+            .iter()
+            .map(|column| column.iter().map(|c| c.load(Ordering::SeqCst)).collect())
+            .collect();
+
+        assert_eq!(
+            repaints[0],
+            vec![1; PANES_PER_COLUMN],
+            "notifying one pane repaints every pane in its column"
+        );
+        assert_eq!(
+            repaints[1],
+            vec![0; PANES_PER_COLUMN],
+            "other columns stay cached"
+        );
+    }
 }

--- a/crates/okena-app/src/views/window/mod.rs
+++ b/crates/okena-app/src/views/window/mod.rs
@@ -79,6 +79,12 @@ pub fn notify_registered_panes<T: 'static>(
     update_registered_panes(registry, terminal_ids, cx, notify_pane_weaks)
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ContentPaneRepaintStats {
+    pub terminals: usize,
+    pub panes: usize,
+}
+
 /// Request activity repaints from concrete terminal-content panes. Calls are
 /// already limited by the app-wide presentation cadence, so every visible copy
 /// remains live without each stream driving an independent clock.
@@ -86,8 +92,8 @@ pub fn request_registered_content_pane_repaints(
     registry: &mut HashMap<String, Vec<WeakEntity<super::layout::terminal_pane::TerminalContent>>>,
     terminal_ids: &[String],
     cx: &mut App,
-) -> usize {
-    update_registered_panes(registry, terminal_ids, cx, |weaks, cx| {
+) -> ContentPaneRepaintStats {
+    update_registered_panes_with_stats(registry, terminal_ids, cx, |weaks, cx| {
         update_pane_weaks(weaks, cx, |pane, cx| {
             pane.request_activity_repaint(cx);
         })
@@ -98,14 +104,24 @@ fn update_registered_panes<T: 'static>(
     registry: &mut HashMap<String, Vec<WeakEntity<T>>>,
     terminal_ids: &[String],
     cx: &mut App,
-    mut update: impl FnMut(&mut Vec<WeakEntity<T>>, &mut App) -> bool,
+    update: impl FnMut(&mut Vec<WeakEntity<T>>, &mut App) -> bool,
 ) -> usize {
-    let mut notified = 0;
+    update_registered_panes_with_stats(registry, terminal_ids, cx, update).terminals
+}
+
+fn update_registered_panes_with_stats<T: 'static>(
+    registry: &mut HashMap<String, Vec<WeakEntity<T>>>,
+    terminal_ids: &[String],
+    cx: &mut App,
+    mut update: impl FnMut(&mut Vec<WeakEntity<T>>, &mut App) -> bool,
+) -> ContentPaneRepaintStats {
+    let mut stats = ContentPaneRepaintStats::default();
     let mut empty = Vec::new();
     for terminal_id in terminal_ids {
         if let Some(weaks) = registry.get_mut(terminal_id) {
             if update(weaks, cx) {
-                notified += 1;
+                stats.terminals = stats.terminals.saturating_add(1);
+                stats.panes = stats.panes.saturating_add(weaks.len());
             }
             if weaks.is_empty() {
                 empty.push(terminal_id.clone());
@@ -115,7 +131,7 @@ fn update_registered_panes<T: 'static>(
     for terminal_id in empty {
         registry.remove(&terminal_id);
     }
-    notified
+    stats
 }
 
 /// Per-window view of the application: one instance per OS window.
@@ -635,6 +651,7 @@ impl WindowView {
     /// Parsing and notifications already ran; this only presents current bell /
     /// idle state at the shared capped cadence.
     pub(crate) fn request_sidebar_activity_repaint(&mut self, cx: &mut Context<Self>) {
+        okena_core::render_probe::sidebar_activity_invalidation();
         self.sidebar.update(cx, |_, cx| cx.notify());
     }
 
@@ -932,7 +949,7 @@ impl EventEmitter<WindowViewEvent> for WindowView {}
 
 #[cfg(test)]
 mod tests {
-    use super::{notify_pane_weaks, notify_registered_panes};
+    use super::{notify_pane_weaks, notify_registered_panes, update_registered_panes_with_stats};
     use gpui::AppContext as _;
     use std::collections::HashMap;
 
@@ -967,6 +984,32 @@ mod tests {
             assert!(!registry.contains_key("target"), "dead pane key is pruned");
         });
         drop(other);
+    }
+
+    #[gpui::test]
+    fn activity_stats_count_each_live_viewer(cx: &mut gpui::TestAppContext) {
+        let (_a, _b, _other, mut registry) = cx.update(|cx| {
+            let a = cx.new(|_| Stub);
+            let b = cx.new(|_| Stub);
+            let other = cx.new(|_| Stub);
+            let registry = HashMap::from([
+                ("target".to_string(), vec![a.downgrade(), b.downgrade()]),
+                ("other".to_string(), vec![other.downgrade()]),
+            ]);
+            (a, b, other, registry)
+        });
+
+        cx.update(|cx| {
+            let stats = update_registered_panes_with_stats(
+                &mut registry,
+                &["target".to_string()],
+                cx,
+                notify_pane_weaks,
+            );
+            assert_eq!(stats.terminals, 1);
+            assert_eq!(stats.panes, 2);
+            assert_eq!(registry.len(), 2, "unrelated registrations stay intact");
+        });
     }
 
     #[gpui::test]

--- a/crates/okena-core/Cargo.toml
+++ b/crates/okena-core/Cargo.toml
@@ -10,6 +10,8 @@ default = []
 test-support = []
 # Compiles opt-in terminal input latency instrumentation.
 terminal-latency-probe = []
+# Compiles opt-in aggregate render-performance instrumentation.
+render-perf-probe = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/okena-core/src/lib.rs
+++ b/crates/okena-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod keys;
 pub mod latency_probe;
 pub mod process;
 pub mod profiles;
+pub mod render_probe;
 pub mod selection;
 pub mod send_payload;
 pub mod shell;

--- a/crates/okena-core/src/render_probe.rs
+++ b/crates/okena-core/src/render_probe.rs
@@ -1,0 +1,632 @@
+//! Opt-in aggregate render-performance instrumentation.
+//!
+//! Build with `render-perf-probe`, then set `OKENA_RENDER_PERF_PROBE=1` before
+//! starting Okena. The probe emits one bounded, aggregate-only summary after
+//! roughly every 10 seconds of observed render activity. It never accepts or
+//! logs terminal content, paths, commands, or per-terminal/window identifiers.
+//!
+//! Summaries are event-driven: a quiet process does not keep a reporting timer
+//! alive, and an elapsed window is emitted when the next measured event arrives.
+
+/// Aggregate statistics produced by one terminal paint.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TerminalPaintStats {
+    /// Number of live pane viewers registered for this terminal at paint time.
+    pub live_viewers: usize,
+    /// Whether grid layout was reused instead of scanning the terminal model.
+    pub grid_cache_hit: bool,
+    pub cells_scanned: usize,
+    /// Model cells reported as changed when a safe damage source is available.
+    /// `None` means the current renderer cannot measure this without consuming
+    /// shared multi-view state.
+    pub cells_changed: Option<usize>,
+    pub text_runs: usize,
+    pub background_rects: usize,
+}
+
+#[cfg(feature = "render-perf-probe")]
+mod imp {
+    use super::TerminalPaintStats;
+    use std::sync::{Mutex, OnceLock};
+    use std::time::{Duration, Instant};
+
+    const REPORT_INTERVAL: Duration = Duration::from_secs(10);
+    const MAX_TIMING_SAMPLES: usize = 8_192;
+
+    #[derive(Debug, Default)]
+    struct TimingSamples {
+        /// Rolling sample used for percentiles. Counts and max still cover every event.
+        values_us: Vec<u64>,
+        count: u64,
+        next_replace: usize,
+        overwritten: u64,
+        max_us: u64,
+    }
+
+    impl TimingSamples {
+        fn record(&mut self, duration: Duration) {
+            let value = duration_us(duration);
+            self.count = self.count.saturating_add(1);
+            self.max_us = self.max_us.max(value);
+            if self.values_us.len() < MAX_TIMING_SAMPLES {
+                self.values_us.push(value);
+            } else {
+                self.values_us[self.next_replace] = value;
+                self.next_replace = (self.next_replace + 1) % MAX_TIMING_SAMPLES;
+                self.overwritten = self.overwritten.saturating_add(1);
+            }
+        }
+
+        fn summarize(mut self) -> TimingSummary {
+            self.values_us.sort_unstable();
+            TimingSummary {
+                count: self.count,
+                retained: as_u64(self.values_us.len()),
+                p50_us: nearest_rank(&self.values_us, 50),
+                p95_us: nearest_rank(&self.values_us, 95),
+                max_us: self.max_us,
+                overwritten: self.overwritten,
+            }
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    struct TimingSummary {
+        count: u64,
+        retained: u64,
+        p50_us: u64,
+        p95_us: u64,
+        max_us: u64,
+        overwritten: u64,
+    }
+
+    #[derive(Debug)]
+    struct MetricsWindow {
+        started: Instant,
+        activity_frames: u64,
+        repaint_terminal_total: u64,
+        repaint_terminal_max: u64,
+        registered_terminal_total: u64,
+        registered_terminal_max: u64,
+        repaint_pane_total: u64,
+        repaint_pane_max: u64,
+        terminal_paints: TimingSamples,
+        terminal_live_viewers_total: u64,
+        terminal_live_viewers_max: u64,
+        terminal_grid_cache_hits: u64,
+        terminal_grid_cache_misses: u64,
+        cells_scanned: u64,
+        changed_cell_samples: u64,
+        cells_changed: u64,
+        text_runs: u64,
+        background_rects: u64,
+        sidebar_activity_invalidations: u64,
+        sidebar_renders: TimingSamples,
+    }
+
+    impl MetricsWindow {
+        fn new(started: Instant) -> Self {
+            Self {
+                started,
+                activity_frames: 0,
+                repaint_terminal_total: 0,
+                repaint_terminal_max: 0,
+                registered_terminal_total: 0,
+                registered_terminal_max: 0,
+                repaint_pane_total: 0,
+                repaint_pane_max: 0,
+                terminal_paints: TimingSamples::default(),
+                terminal_live_viewers_total: 0,
+                terminal_live_viewers_max: 0,
+                terminal_grid_cache_hits: 0,
+                terminal_grid_cache_misses: 0,
+                cells_scanned: 0,
+                changed_cell_samples: 0,
+                cells_changed: 0,
+                text_runs: 0,
+                background_rects: 0,
+                sidebar_activity_invalidations: 0,
+                sidebar_renders: TimingSamples::default(),
+            }
+        }
+
+        fn record_activity_frame(
+            &mut self,
+            repaint_terminals: usize,
+            registered_terminals: usize,
+            repaint_panes: usize,
+        ) {
+            let repaint_terminals = as_u64(repaint_terminals);
+            let registered_terminals = as_u64(registered_terminals);
+            let repaint_panes = as_u64(repaint_panes);
+            self.activity_frames = self.activity_frames.saturating_add(1);
+            self.repaint_terminal_total = self
+                .repaint_terminal_total
+                .saturating_add(repaint_terminals);
+            self.repaint_terminal_max = self.repaint_terminal_max.max(repaint_terminals);
+            self.registered_terminal_total = self
+                .registered_terminal_total
+                .saturating_add(registered_terminals);
+            self.registered_terminal_max = self.registered_terminal_max.max(registered_terminals);
+            self.repaint_pane_total = self.repaint_pane_total.saturating_add(repaint_panes);
+            self.repaint_pane_max = self.repaint_pane_max.max(repaint_panes);
+        }
+
+        fn record_terminal_paint(&mut self, duration: Duration, stats: TerminalPaintStats) {
+            self.terminal_paints.record(duration);
+            let live_viewers = as_u64(stats.live_viewers);
+            self.terminal_live_viewers_total = self
+                .terminal_live_viewers_total
+                .saturating_add(live_viewers);
+            self.terminal_live_viewers_max = self.terminal_live_viewers_max.max(live_viewers);
+            if stats.grid_cache_hit {
+                self.terminal_grid_cache_hits = self.terminal_grid_cache_hits.saturating_add(1);
+            } else {
+                self.terminal_grid_cache_misses = self.terminal_grid_cache_misses.saturating_add(1);
+            }
+            self.cells_scanned = self
+                .cells_scanned
+                .saturating_add(as_u64(stats.cells_scanned));
+            if let Some(changed) = stats.cells_changed {
+                self.changed_cell_samples = self.changed_cell_samples.saturating_add(1);
+                self.cells_changed = self.cells_changed.saturating_add(as_u64(changed));
+            }
+            self.text_runs = self.text_runs.saturating_add(as_u64(stats.text_runs));
+            self.background_rects = self
+                .background_rects
+                .saturating_add(as_u64(stats.background_rects));
+        }
+
+        fn record_sidebar_activity_invalidation(&mut self) {
+            self.sidebar_activity_invalidations =
+                self.sidebar_activity_invalidations.saturating_add(1);
+        }
+
+        fn record_sidebar_render(&mut self, duration: Duration) {
+            self.sidebar_renders.record(duration);
+        }
+
+        fn update(
+            &mut self,
+            now: Instant,
+            update: impl FnOnce(&mut MetricsWindow),
+        ) -> Option<Summary> {
+            let summary = self.take_summary_if_due(now);
+            update(self);
+            summary
+        }
+
+        fn take_summary_if_due(&mut self, now: Instant) -> Option<Summary> {
+            let elapsed = now.saturating_duration_since(self.started);
+            if elapsed < REPORT_INTERVAL {
+                return None;
+            }
+
+            let completed = std::mem::replace(self, Self::new(now));
+            Some(completed.into_summary(elapsed))
+        }
+
+        fn into_summary(self, elapsed: Duration) -> Summary {
+            let terminal_paints = self.terminal_paints.summarize();
+            let sidebar_renders = self.sidebar_renders.summarize();
+            Summary {
+                window_ms: duration_ms(elapsed),
+                activity_frames: self.activity_frames,
+                repaint_terminal_total: self.repaint_terminal_total,
+                repaint_terminal_max: self.repaint_terminal_max,
+                registered_terminal_total: self.registered_terminal_total,
+                registered_terminal_max: self.registered_terminal_max,
+                repaint_pane_total: self.repaint_pane_total,
+                repaint_pane_max: self.repaint_pane_max,
+                terminal_paints,
+                terminal_live_viewers_total: self.terminal_live_viewers_total,
+                terminal_live_viewers_max: self.terminal_live_viewers_max,
+                terminal_grid_cache_hits: self.terminal_grid_cache_hits,
+                terminal_grid_cache_misses: self.terminal_grid_cache_misses,
+                cells_scanned: self.cells_scanned,
+                changed_cell_samples: self.changed_cell_samples,
+                cells_changed: self.cells_changed,
+                text_runs: self.text_runs,
+                background_rects: self.background_rects,
+                sidebar_activity_invalidations: self.sidebar_activity_invalidations,
+                sidebar_renders,
+            }
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    struct Summary {
+        window_ms: u64,
+        activity_frames: u64,
+        repaint_terminal_total: u64,
+        repaint_terminal_max: u64,
+        registered_terminal_total: u64,
+        registered_terminal_max: u64,
+        repaint_pane_total: u64,
+        repaint_pane_max: u64,
+        terminal_paints: TimingSummary,
+        terminal_live_viewers_total: u64,
+        terminal_live_viewers_max: u64,
+        terminal_grid_cache_hits: u64,
+        terminal_grid_cache_misses: u64,
+        cells_scanned: u64,
+        changed_cell_samples: u64,
+        cells_changed: u64,
+        text_runs: u64,
+        background_rects: u64,
+        sidebar_activity_invalidations: u64,
+        sidebar_renders: TimingSummary,
+    }
+
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    static METRICS: OnceLock<Mutex<MetricsWindow>> = OnceLock::new();
+
+    pub fn enabled() -> bool {
+        *ENABLED.get_or_init(|| {
+            std::env::var("OKENA_RENDER_PERF_PROBE")
+                .ok()
+                .is_some_and(|value| !matches!(value.as_str(), "" | "0" | "false" | "off"))
+        })
+    }
+
+    pub fn terminal_activity_frame(
+        repaint_terminals: usize,
+        registered_terminals: usize,
+        repaint_panes: usize,
+    ) {
+        record(|metrics| {
+            metrics.record_activity_frame(repaint_terminals, registered_terminals, repaint_panes);
+        });
+    }
+
+    pub fn sidebar_activity_invalidation() {
+        record(MetricsWindow::record_sidebar_activity_invalidation);
+    }
+
+    pub struct TerminalPaintGuard {
+        started: Option<Instant>,
+    }
+
+    impl TerminalPaintGuard {
+        pub fn finish(mut self, stats: TerminalPaintStats) {
+            let Some(started) = self.started.take() else {
+                return;
+            };
+            record(|metrics| metrics.record_terminal_paint(started.elapsed(), stats));
+        }
+    }
+
+    pub fn terminal_paint() -> TerminalPaintGuard {
+        TerminalPaintGuard {
+            started: enabled().then(Instant::now),
+        }
+    }
+
+    pub struct SidebarRenderGuard {
+        started: Option<Instant>,
+    }
+
+    impl Drop for SidebarRenderGuard {
+        fn drop(&mut self) {
+            let Some(started) = self.started.take() else {
+                return;
+            };
+            record(|metrics| metrics.record_sidebar_render(started.elapsed()));
+        }
+    }
+
+    pub fn sidebar_render() -> SidebarRenderGuard {
+        SidebarRenderGuard {
+            started: enabled().then(Instant::now),
+        }
+    }
+
+    fn record(update: impl FnOnce(&mut MetricsWindow)) {
+        if !enabled() {
+            return;
+        }
+
+        let now = Instant::now();
+        let summary = METRICS
+            .get_or_init(|| Mutex::new(MetricsWindow::new(now)))
+            .lock()
+            .ok()
+            .and_then(|mut metrics| metrics.update(now, update));
+
+        if let Some(summary) = summary {
+            log::info!(target: "okena::render_perf", "{}", format_summary(summary));
+        }
+    }
+
+    fn format_summary(summary: Summary) -> String {
+        format!(
+            "render_perf window_ms={} activity_frames={} repaint_terminal_total={} repaint_terminal_max={} registered_terminal_total={} registered_terminal_max={} repaint_pane_total={} repaint_pane_max={} terminal_paints={} terminal_timing_retained={} terminal_paint_us_p50={} terminal_paint_us_p95={} terminal_paint_us_max={} terminal_live_viewers_total={} terminal_live_viewers_max={} terminal_grid_cache_hits={} terminal_grid_cache_misses={} cells_scanned={} changed_cell_samples={} cells_changed={} text_runs={} background_rects={} sidebar_activity_invalidations={} sidebar_renders={} sidebar_timing_retained={} sidebar_render_us_p50={} sidebar_render_us_p95={} sidebar_render_us_max={} terminal_timing_overwritten={} sidebar_timing_overwritten={}",
+            summary.window_ms,
+            summary.activity_frames,
+            summary.repaint_terminal_total,
+            summary.repaint_terminal_max,
+            summary.registered_terminal_total,
+            summary.registered_terminal_max,
+            summary.repaint_pane_total,
+            summary.repaint_pane_max,
+            summary.terminal_paints.count,
+            summary.terminal_paints.retained,
+            summary.terminal_paints.p50_us,
+            summary.terminal_paints.p95_us,
+            summary.terminal_paints.max_us,
+            summary.terminal_live_viewers_total,
+            summary.terminal_live_viewers_max,
+            summary.terminal_grid_cache_hits,
+            summary.terminal_grid_cache_misses,
+            summary.cells_scanned,
+            summary.changed_cell_samples,
+            summary.cells_changed,
+            summary.text_runs,
+            summary.background_rects,
+            summary.sidebar_activity_invalidations,
+            summary.sidebar_renders.count,
+            summary.sidebar_renders.retained,
+            summary.sidebar_renders.p50_us,
+            summary.sidebar_renders.p95_us,
+            summary.sidebar_renders.max_us,
+            summary.terminal_paints.overwritten,
+            summary.sidebar_renders.overwritten,
+        )
+    }
+
+    fn nearest_rank(sorted: &[u64], percentile: usize) -> u64 {
+        if sorted.is_empty() {
+            return 0;
+        }
+        let rank = percentile.saturating_mul(sorted.len()).saturating_add(99) / 100;
+        sorted[rank.max(1).saturating_sub(1).min(sorted.len() - 1)]
+    }
+
+    fn as_u64(value: usize) -> u64 {
+        u64::try_from(value).unwrap_or(u64::MAX)
+    }
+
+    fn duration_us(duration: Duration) -> u64 {
+        u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
+    }
+
+    fn duration_ms(duration: Duration) -> u64 {
+        u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn stats(cells_changed: Option<usize>, grid_cache_hit: bool) -> TerminalPaintStats {
+            TerminalPaintStats {
+                live_viewers: 2,
+                grid_cache_hit,
+                cells_scanned: 2_000,
+                cells_changed,
+                text_runs: 40,
+                background_rects: 8,
+            }
+        }
+
+        #[test]
+        fn percentile_uses_nearest_rank_for_empty_singleton_odd_and_even_samples() {
+            assert_eq!(nearest_rank(&[], 50), 0);
+            assert_eq!(nearest_rank(&[7], 95), 7);
+            assert_eq!(nearest_rank(&[10, 20, 30], 50), 20);
+            assert_eq!(nearest_rank(&[10, 20, 30, 40], 50), 20);
+            assert_eq!(nearest_rank(&[10, 20, 30, 40], 95), 40);
+        }
+
+        #[test]
+        fn summary_accumulates_aggregate_counts_and_timings() {
+            let start = Instant::now();
+            let mut metrics = MetricsWindow::new(start);
+            metrics.record_activity_frame(3, 2, 4);
+            metrics.record_activity_frame(5, 4, 7);
+            metrics.record_terminal_paint(Duration::from_micros(100), stats(Some(12), false));
+            metrics.record_terminal_paint(Duration::from_micros(300), stats(None, true));
+            metrics.record_sidebar_activity_invalidation();
+            metrics.record_sidebar_render(Duration::from_micros(50));
+
+            let summary = metrics
+                .take_summary_if_due(start + REPORT_INTERVAL)
+                .expect("summary should be due");
+
+            assert_eq!(summary.activity_frames, 2);
+            assert_eq!(summary.repaint_terminal_total, 8);
+            assert_eq!(summary.repaint_terminal_max, 5);
+            assert_eq!(summary.registered_terminal_total, 6);
+            assert_eq!(summary.registered_terminal_max, 4);
+            assert_eq!(summary.repaint_pane_total, 11);
+            assert_eq!(summary.repaint_pane_max, 7);
+            assert_eq!(summary.terminal_paints.count, 2);
+            assert_eq!(summary.terminal_live_viewers_total, 4);
+            assert_eq!(summary.terminal_live_viewers_max, 2);
+            assert_eq!(summary.terminal_grid_cache_hits, 1);
+            assert_eq!(summary.terminal_grid_cache_misses, 1);
+            assert_eq!(summary.terminal_paints.retained, 2);
+            assert_eq!(summary.terminal_paints.p50_us, 100);
+            assert_eq!(summary.terminal_paints.p95_us, 300);
+            assert_eq!(summary.cells_scanned, 4_000);
+            assert_eq!(summary.changed_cell_samples, 1);
+            assert_eq!(summary.cells_changed, 12);
+            assert_eq!(summary.text_runs, 80);
+            assert_eq!(summary.background_rects, 16);
+            assert_eq!(summary.sidebar_activity_invalidations, 1);
+            assert_eq!(summary.sidebar_renders.count, 1);
+            assert_eq!(summary.sidebar_renders.max_us, 50);
+        }
+
+        #[test]
+        fn timing_storage_is_bounded_and_rolls_forward_to_late_samples() {
+            let mut timings = TimingSamples::default();
+            for _ in 0..MAX_TIMING_SAMPLES {
+                timings.record(Duration::from_micros(10));
+            }
+            for value in [1_000, 2_000, 3_000] {
+                timings.record(Duration::from_micros(value));
+            }
+
+            assert!(timings.values_us.contains(&3_000));
+            let summary = timings.summarize();
+            assert_eq!(summary.count, as_u64(MAX_TIMING_SAMPLES + 3));
+            assert_eq!(summary.retained, as_u64(MAX_TIMING_SAMPLES));
+            assert_eq!(summary.max_us, 3_000);
+            assert_eq!(summary.overwritten, 3);
+        }
+
+        #[test]
+        fn completed_window_resets_every_counter() {
+            let start = Instant::now();
+            let mut metrics = MetricsWindow::new(start);
+            metrics.record_activity_frame(4, 3, 6);
+            let first = metrics
+                .take_summary_if_due(start + REPORT_INTERVAL)
+                .expect("first summary");
+            assert_eq!(first.activity_frames, 1);
+
+            metrics.record_sidebar_activity_invalidation();
+            let second = metrics
+                .take_summary_if_due(start + REPORT_INTERVAL + REPORT_INTERVAL)
+                .expect("second summary");
+            assert_eq!(second.activity_frames, 0);
+            assert_eq!(second.repaint_terminal_total, 0);
+            assert_eq!(second.sidebar_activity_invalidations, 1);
+            assert_eq!(second.terminal_paints, TimingSummary::default());
+        }
+
+        #[test]
+        fn elapsed_window_closes_before_the_next_event_is_recorded() {
+            let start = Instant::now();
+            let mut metrics = MetricsWindow::new(start);
+            metrics.record_activity_frame(2, 1, 2);
+
+            let first = metrics
+                .update(start + REPORT_INTERVAL, |next| {
+                    next.record_activity_frame(7, 5, 9);
+                })
+                .expect("elapsed window");
+            assert_eq!(first.activity_frames, 1);
+            assert_eq!(first.repaint_terminal_total, 2);
+
+            let second = metrics
+                .take_summary_if_due(start + REPORT_INTERVAL + REPORT_INTERVAL)
+                .expect("new window");
+            assert_eq!(second.activity_frames, 1);
+            assert_eq!(second.repaint_terminal_total, 7);
+        }
+
+        #[test]
+        fn formatted_summary_has_only_the_fixed_aggregate_schema() {
+            let line = format_summary(Summary::default());
+            for prohibited in [
+                " terminal=",
+                " viewer=",
+                " window=",
+                " path=",
+                " command=",
+                " content=",
+                " id=",
+            ] {
+                assert!(!line.contains(prohibited), "found {prohibited} in {line}");
+            }
+            let fields: Vec<_> = line
+                .split_whitespace()
+                .skip(1)
+                .map(|field| field.split('=').next().unwrap_or_default())
+                .collect();
+            assert_eq!(
+                fields,
+                [
+                    "window_ms",
+                    "activity_frames",
+                    "repaint_terminal_total",
+                    "repaint_terminal_max",
+                    "registered_terminal_total",
+                    "registered_terminal_max",
+                    "repaint_pane_total",
+                    "repaint_pane_max",
+                    "terminal_paints",
+                    "terminal_timing_retained",
+                    "terminal_paint_us_p50",
+                    "terminal_paint_us_p95",
+                    "terminal_paint_us_max",
+                    "terminal_live_viewers_total",
+                    "terminal_live_viewers_max",
+                    "terminal_grid_cache_hits",
+                    "terminal_grid_cache_misses",
+                    "cells_scanned",
+                    "changed_cell_samples",
+                    "cells_changed",
+                    "text_runs",
+                    "background_rects",
+                    "sidebar_activity_invalidations",
+                    "sidebar_renders",
+                    "sidebar_timing_retained",
+                    "sidebar_render_us_p50",
+                    "sidebar_render_us_p95",
+                    "sidebar_render_us_max",
+                    "terminal_timing_overwritten",
+                    "sidebar_timing_overwritten",
+                ]
+            );
+        }
+    }
+}
+
+#[cfg(not(feature = "render-perf-probe"))]
+mod imp {
+    use super::TerminalPaintStats;
+
+    #[inline(always)]
+    pub fn enabled() -> bool {
+        false
+    }
+
+    #[inline(always)]
+    pub fn terminal_activity_frame(
+        _repaint_terminals: usize,
+        _registered_terminals: usize,
+        _repaint_panes: usize,
+    ) {
+    }
+
+    #[inline(always)]
+    pub fn sidebar_activity_invalidation() {}
+
+    pub struct TerminalPaintGuard;
+
+    impl TerminalPaintGuard {
+        #[inline(always)]
+        pub fn finish(self, _stats: TerminalPaintStats) {}
+    }
+
+    #[inline(always)]
+    pub fn terminal_paint() -> TerminalPaintGuard {
+        TerminalPaintGuard
+    }
+
+    pub struct SidebarRenderGuard;
+
+    #[inline(always)]
+    pub fn sidebar_render() -> SidebarRenderGuard {
+        SidebarRenderGuard
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn feature_off_api_is_a_noop() {
+            assert!(!enabled());
+            terminal_activity_frame(3, 2, 4);
+            sidebar_activity_invalidation();
+            terminal_paint().finish(TerminalPaintStats::default());
+            drop(sidebar_render());
+        }
+    }
+}
+
+pub use imp::*;

--- a/crates/okena-core/src/render_probe.rs
+++ b/crates/okena-core/src/render_probe.rs
@@ -624,7 +624,7 @@ mod imp {
             terminal_activity_frame(3, 2, 4);
             sidebar_activity_invalidation();
             terminal_paint().finish(TerminalPaintStats::default());
-            drop(sidebar_render());
+            let _sidebar_render = sidebar_render();
         }
     }
 }

--- a/crates/okena-core/src/theme/colors.rs
+++ b/crates/okena-core/src/theme/colors.rs
@@ -1,7 +1,7 @@
 use super::types::FolderColor;
 
 /// Theme colors - all UI colors in one struct
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ThemeColors {
     // Background colors
     pub bg_primary: u32,

--- a/crates/okena-ui/src/activity_repaint.rs
+++ b/crates/okena-ui/src/activity_repaint.rs
@@ -10,6 +10,55 @@ pub struct ActivityRepaintDecision<T> {
     pub start_timer: bool,
 }
 
+/// Decision produced when activity enters a throttled repaint stream.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ActivityRepaintThrottleDecision {
+    /// Present immediately on the idle-to-active edge.
+    pub repaint_now: bool,
+    /// Start the stream's sole cadence timer.
+    pub start_timer: bool,
+}
+
+/// Leading-edge repaint plus coalesced sustained/trailing updates.
+///
+/// The caller presents [`ActivityRepaintThrottleDecision::repaint_now`]
+/// immediately and starts one timer when requested. Each timer tick calls
+/// [`timer_tick`](Self::timer_tick): `true` presents one coalesced repaint and
+/// keeps the timer alive; `false` returns the stream to idle.
+#[derive(Debug, Default)]
+pub struct ActivityRepaintThrottle {
+    pending: bool,
+    scheduled: bool,
+}
+
+impl ActivityRepaintThrottle {
+    pub fn on_activity(&mut self) -> ActivityRepaintThrottleDecision {
+        self.pending = true;
+        if self.scheduled {
+            return ActivityRepaintThrottleDecision::default();
+        }
+
+        self.pending = false;
+        self.scheduled = true;
+        ActivityRepaintThrottleDecision {
+            repaint_now: true,
+            start_timer: true,
+        }
+    }
+
+    /// Advance one cadence tick. A pending event produces the trailing/sustained
+    /// repaint; an empty tick stops the timer and rearms the leading edge.
+    pub fn timer_tick(&mut self) -> bool {
+        if self.pending {
+            self.pending = false;
+            true
+        } else {
+            self.scheduled = false;
+            false
+        }
+    }
+}
+
 /// Collects exact repaint keys behind a leading-edge presentation batch.
 ///
 /// [`queue_activity`](Self::queue_activity) presents the idle-to-active edge
@@ -72,7 +121,7 @@ impl<T: Eq + Hash> ActivityRepaintBatch<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::ActivityRepaintBatch;
+    use super::{ActivityRepaintBatch, ActivityRepaintThrottle};
     use std::collections::HashSet;
 
     #[test]
@@ -105,6 +154,39 @@ mod tests {
         let next = batch.queue_activity(["next"], []);
         assert!(next.start_timer);
         assert_eq!(next.immediate, HashSet::from(["next"]));
+    }
+
+    #[test]
+    fn throttled_activity_has_one_leading_edge_trailing_ticks_and_idle_rearming() {
+        let mut throttle = ActivityRepaintThrottle::default();
+
+        let leading = throttle.on_activity();
+        assert!(leading.repaint_now);
+        assert!(leading.start_timer);
+
+        let repeated = throttle.on_activity();
+        assert!(!repeated.repaint_now);
+        assert!(!repeated.start_timer);
+        assert!(
+            throttle.timer_tick(),
+            "pending activity gets one trailing repaint"
+        );
+
+        let sustained = throttle.on_activity();
+        assert!(!sustained.repaint_now);
+        assert!(!sustained.start_timer);
+        assert!(
+            throttle.timer_tick(),
+            "the existing timer handles sustained activity"
+        );
+        assert!(
+            !throttle.timer_tick(),
+            "an empty tick returns the stream to idle"
+        );
+
+        let rearmed = throttle.on_activity();
+        assert!(rearmed.repaint_now);
+        assert!(rearmed.start_timer);
     }
 
     #[test]

--- a/crates/okena-ui/src/icon_button.rs
+++ b/crates/okena-ui/src/icon_button.rs
@@ -33,6 +33,29 @@ pub fn icon_button_sized(
     icon_size: f32,
     t: &ThemeColors,
 ) -> Stateful<Div> {
+    icon_button_bare_sized(id, icon, button_size, icon_size, t).hover(|s| s.bg(rgb(t.bg_hover)))
+}
+
+/// Icon button without the built-in hover style, for callers that need to own
+/// `.hover()` themselves — e.g. a button that also reveals itself on hover.
+/// GPUI permits only one hover style per element and `debug_assert!`s on the
+/// second call, so layering another `.hover()` on [`icon_button`] would panic.
+pub fn icon_button_bare(
+    id: impl Into<ElementId>,
+    icon: impl Into<SharedString>,
+    t: &ThemeColors,
+) -> Stateful<Div> {
+    icon_button_bare_sized(id, icon, 18.0, 12.0, t)
+}
+
+/// [`icon_button_sized`] without the hover style. See [`icon_button_bare`].
+pub fn icon_button_bare_sized(
+    id: impl Into<ElementId>,
+    icon: impl Into<SharedString>,
+    button_size: f32,
+    icon_size: f32,
+    t: &ThemeColors,
+) -> Stateful<Div> {
     div()
         .id(id)
         .flex_shrink_0()
@@ -43,7 +66,6 @@ pub fn icon_button_sized(
         .items_center()
         .justify_center()
         .rounded(px(3.0))
-        .hover(|s| s.bg(rgb(t.bg_hover)))
         .child(
             svg()
                 .path(icon)

--- a/crates/okena-views-sidebar/src/folder_list.rs
+++ b/crates/okena-views-sidebar/src/folder_list.rs
@@ -4,7 +4,6 @@ use gpui::prelude::*;
 use gpui::*;
 use gpui_component::tooltip::Tooltip;
 use okena_ui::color_dot::color_dot;
-use okena_ui::icon_button::icon_button;
 use okena_ui::rename_state::is_renaming;
 use okena_ui::theme::theme;
 
@@ -192,13 +191,27 @@ impl Sidebar {
                 // Delete folder button (on hover)
                 {
                     let folder_id = folder_id.clone();
-                    icon_button(
-                        ElementId::Name(format!("folder-delete-{}", folder_id).into()),
-                        "icons/close.svg",
-                        &t,
-                    )
+                    // `icon_button` already owns a hover style; this button also
+                    // reveals itself on hover, and GPUI permits only one style.
+                    div()
+                        .id(ElementId::Name(
+                            format!("folder-delete-{}", folder_id).into(),
+                        ))
+                        .flex_shrink_0()
+                        .cursor_pointer()
+                        .size(px(18.0))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .rounded(px(3.0))
                         .opacity(0.0)
                         .hover(|s| s.bg(rgb(t.bg_hover)).opacity(1.0))
+                        .child(
+                            svg()
+                                .path("icons/close.svg")
+                                .size(px(12.0))
+                                .text_color(rgb(t.text_secondary)),
+                        )
                         .on_mouse_down(MouseButton::Left, cx.listener(|_this, _, _, cx| {
                             cx.stop_propagation();
                         }))

--- a/crates/okena-views-sidebar/src/folder_list.rs
+++ b/crates/okena-views-sidebar/src/folder_list.rs
@@ -4,6 +4,7 @@ use gpui::prelude::*;
 use gpui::*;
 use gpui_component::tooltip::Tooltip;
 use okena_ui::color_dot::color_dot;
+use okena_ui::icon_button::icon_button_bare;
 use okena_ui::rename_state::is_renaming;
 use okena_ui::theme::theme;
 
@@ -191,27 +192,15 @@ impl Sidebar {
                 // Delete folder button (on hover)
                 {
                     let folder_id = folder_id.clone();
-                    // `icon_button` already owns a hover style; this button also
-                    // reveals itself on hover, and GPUI permits only one style.
-                    div()
-                        .id(ElementId::Name(
-                            format!("folder-delete-{}", folder_id).into(),
-                        ))
-                        .flex_shrink_0()
-                        .cursor_pointer()
-                        .size(px(18.0))
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .rounded(px(3.0))
+                    // Bare variant: this button owns its own hover style because
+                    // it also has to reveal itself on hover.
+                    icon_button_bare(
+                        ElementId::Name(format!("folder-delete-{}", folder_id).into()),
+                        "icons/close.svg",
+                        &t,
+                    )
                         .opacity(0.0)
                         .hover(|s| s.bg(rgb(t.bg_hover)).opacity(1.0))
-                        .child(
-                            svg()
-                                .path("icons/close.svg")
-                                .size(px(12.0))
-                                .text_color(rgb(t.text_secondary)),
-                        )
                         .on_mouse_down(MouseButton::Left, cx.listener(|_this, _, _, cx| {
                             cx.stop_propagation();
                         }))

--- a/crates/okena-views-sidebar/src/sidebar/render.rs
+++ b/crates/okena-views-sidebar/src/sidebar/render.rs
@@ -708,6 +708,7 @@ impl Sidebar {
 
 impl Render for Sidebar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let _render_probe = okena_core::render_probe::sidebar_render();
         let t = theme(cx);
 
         // Process pending sidebar requests (drained from Workspace by observer)

--- a/crates/okena-views-terminal/src/elements/terminal_element.rs
+++ b/crates/okena-views-terminal/src/elements/terminal_element.rs
@@ -4,6 +4,7 @@ use alacritty_terminal::index::{Column, Line};
 use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::vte::ansi::{Color, NamedColor};
 use gpui::*;
+use okena_core::theme::ThemeColors;
 use okena_files::theme::theme;
 use okena_terminal::terminal::{Terminal, TerminalSize};
 use okena_ui::color_utils::tint_color;
@@ -33,7 +34,12 @@ pub(crate) fn next_resize_viewer_id() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{deregister_resize_viewer, shared_resize_target};
+    use super::{
+        TerminalGridLayout, TerminalRenderCache, TerminalRenderCacheKey, deregister_resize_viewer,
+        shared_resize_target,
+    };
+    use gpui::{Font, FontFeatures, FontStyle, FontWeight};
+    use okena_core::theme::{DARK_THEME, LIGHT_THEME};
     use okena_terminal::terminal::TerminalSize;
 
     fn size(cols: u16, rows: u16) -> TerminalSize {
@@ -88,6 +94,75 @@ mod tests {
         assert_eq!((target.cols, target.rows), (120, 40));
 
         deregister_resize_viewer(terminal_id, 2);
+    }
+
+    fn cache_key() -> TerminalRenderCacheKey {
+        TerminalRenderCacheKey {
+            content_generation: 7,
+            selection: None,
+            font: Font {
+                family: "Test Mono".into(),
+                features: FontFeatures::disable_ligatures(),
+                fallbacks: None,
+                weight: FontWeight::NORMAL,
+                style: FontStyle::Normal,
+            },
+            theme: DARK_THEME,
+        }
+    }
+
+    fn empty_layout() -> TerminalGridLayout {
+        TerminalGridLayout {
+            batched_runs: Vec::new(),
+            rects: Vec::new(),
+            screen_lines: 0,
+            display_offset: 0,
+            cursor_col: 0,
+            cursor_visual_line: 0,
+            cells_scanned: 0,
+        }
+    }
+
+    #[test]
+    fn render_cache_hits_only_for_an_exact_key_with_layout() {
+        let key = cache_key();
+        let mut cache = TerminalRenderCache::default();
+        assert!(!cache.matches(&key));
+
+        cache.store(key.clone(), empty_layout());
+        assert!(cache.matches(&key));
+
+        let mut changed_generation = key.clone();
+        changed_generation.content_generation += 1;
+        assert!(!cache.matches(&changed_generation));
+
+        let mut changed_selection = key.clone();
+        changed_selection.selection = Some(((1, 2), (3, 4)));
+        assert!(!cache.matches(&changed_selection));
+
+        let mut changed_font = key.clone();
+        changed_font.font.weight = FontWeight::BOLD;
+        assert!(!cache.matches(&changed_font));
+
+        let mut changed_theme = key;
+        changed_theme.theme = LIGHT_THEME;
+        assert!(!cache.matches(&changed_theme));
+
+        cache.layout = None;
+        assert!(!cache.matches(&cache_key()));
+    }
+
+    #[test]
+    fn render_cache_invalidate_drops_key_and_layout() {
+        let key = cache_key();
+        let mut cache = TerminalRenderCache::default();
+        cache.store(key.clone(), empty_layout());
+
+        cache.invalidate();
+
+        assert!(!cache.matches(&key));
+        assert!(cache.key.is_none());
+        assert!(cache.layout.is_none());
     }
 }
 
@@ -229,6 +304,7 @@ pub struct TerminalElement {
     terminal: Arc<Terminal>,
     focus_handle: FocusHandle,
     resize_viewer_id: u64,
+    render_cache: Arc<Mutex<TerminalRenderCache>>,
     search_matches: Arc<Vec<SearchMatch>>,
     current_match_index: Option<usize>,
     url_matches: Arc<Vec<URLMatch>>,
@@ -246,6 +322,7 @@ impl TerminalElement {
             terminal,
             focus_handle,
             resize_viewer_id,
+            render_cache: Arc::new(Mutex::new(TerminalRenderCache::default())),
             search_matches: Arc::new(Vec::new()),
             current_match_index: None,
             url_matches: Arc::new(Vec::new()),
@@ -255,6 +332,14 @@ impl TerminalElement {
             zoom_level: 1.0,
             bg_tint: None,
         }
+    }
+
+    pub(crate) fn with_render_cache(
+        mut self,
+        render_cache: Arc<Mutex<TerminalRenderCache>>,
+    ) -> Self {
+        self.render_cache = render_cache;
+        self
     }
 
     pub fn with_bg_tint(mut self, tint: Option<u32>) -> Self {
@@ -316,6 +401,274 @@ pub struct TerminalElementState {
     font_bold: Font,
     font_italic: Font,
     font_bold_italic: Font,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct TerminalRenderCacheKey {
+    content_generation: u64,
+    selection: Option<((usize, i32), (usize, i32))>,
+    font: Font,
+    theme: ThemeColors,
+}
+
+#[derive(Debug)]
+struct TerminalGridLayout {
+    batched_runs: Vec<BatchedTextRun>,
+    rects: Vec<LayoutRect>,
+    screen_lines: usize,
+    display_offset: i32,
+    cursor_col: usize,
+    cursor_visual_line: i32,
+    cells_scanned: usize,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct TerminalRenderCache {
+    key: Option<TerminalRenderCacheKey>,
+    layout: Option<Arc<TerminalGridLayout>>,
+}
+
+impl TerminalRenderCache {
+    fn matches(&self, key: &TerminalRenderCacheKey) -> bool {
+        self.key.as_ref() == Some(key) && self.layout.is_some()
+    }
+
+    fn store(&mut self, key: TerminalRenderCacheKey, layout: TerminalGridLayout) {
+        self.key = Some(key);
+        self.layout = Some(Arc::new(layout));
+    }
+
+    pub(crate) fn invalidate(&mut self) {
+        self.key = None;
+        self.layout = None;
+    }
+}
+
+fn build_terminal_grid_layout(
+    terminal: &Terminal,
+    selection: Option<((usize, i32), (usize, i32))>,
+    t: &ThemeColors,
+    state: &TerminalElementState,
+) -> TerminalGridLayout {
+    let (batched_runs, rects, screen_lines, display_offset, cursor_point, cols) = terminal
+        .with_content(|term| {
+            let grid = term.grid();
+            let screen_lines = grid.screen_lines();
+            let cols = grid.columns();
+            let display_offset = grid.display_offset() as i32;
+            let cursor_point = grid.cursor.point;
+
+            let mut batched_runs: Vec<BatchedTextRun> = Vec::new();
+            let mut rects: Vec<LayoutRect> = Vec::new();
+            let mut current_batch: Option<BatchedTextRun> = None;
+            let mut current_rect: Option<LayoutRect> = None;
+
+            for row in 0..screen_lines {
+                let visual_line = row as i32;
+                let buffer_line = visual_line - display_offset;
+
+                if let Some(batch) = current_batch.take() {
+                    batched_runs.push(batch);
+                }
+                if let Some(rect) = current_rect.take() {
+                    rects.push(rect);
+                }
+
+                for col in 0..cols {
+                    let cell_point = alacritty_terminal::index::Point {
+                        line: Line(buffer_line),
+                        column: Column(col),
+                    };
+                    let cell = &grid[cell_point];
+                    let col_i32 = col as i32;
+
+                    let mut fg = cell.fg;
+                    let mut bg = cell.bg;
+
+                    if cell.flags.contains(Flags::BOLD) {
+                        fg = match fg {
+                            Color::Named(NamedColor::Black) => {
+                                Color::Named(NamedColor::BrightBlack)
+                            }
+                            Color::Named(NamedColor::Red) => Color::Named(NamedColor::BrightRed),
+                            Color::Named(NamedColor::Green) => {
+                                Color::Named(NamedColor::BrightGreen)
+                            }
+                            Color::Named(NamedColor::Yellow) => {
+                                Color::Named(NamedColor::BrightYellow)
+                            }
+                            Color::Named(NamedColor::Blue) => Color::Named(NamedColor::BrightBlue),
+                            Color::Named(NamedColor::Magenta) => {
+                                Color::Named(NamedColor::BrightMagenta)
+                            }
+                            Color::Named(NamedColor::Cyan) => Color::Named(NamedColor::BrightCyan),
+                            Color::Named(NamedColor::White) => {
+                                Color::Named(NamedColor::BrightWhite)
+                            }
+                            Color::Indexed(idx @ 0..=7) => Color::Indexed(idx + 8),
+                            other => other,
+                        };
+                    }
+
+                    if cell.flags.contains(Flags::INVERSE) {
+                        std::mem::swap(&mut fg, &mut bg);
+                    }
+
+                    let is_selected =
+                        if let Some(((start_col, start_row), (end_col, end_row))) = selection {
+                            let (start_row, start_col, end_row, end_col) = if start_row < end_row
+                                || (start_row == end_row && start_col <= end_col)
+                            {
+                                (start_row, start_col, end_row, end_col)
+                            } else {
+                                (end_row, end_col, start_row, start_col)
+                            };
+                            if buffer_line >= start_row && buffer_line <= end_row {
+                                if start_row == end_row {
+                                    col >= start_col && col <= end_col
+                                } else if buffer_line == start_row {
+                                    col >= start_col
+                                } else if buffer_line == end_row {
+                                    col <= end_col
+                                } else {
+                                    true
+                                }
+                            } else {
+                                false
+                            }
+                        } else {
+                            false
+                        };
+
+                    let bg_color = if is_selected {
+                        Some(rgb(t.selection_bg).into())
+                    } else if !is_default_bg(&bg, t) {
+                        Some(ansi_to_hsla(t, &bg))
+                    } else {
+                        None
+                    };
+
+                    if let Some(color) = bg_color {
+                        let can_extend = current_rect.as_ref().is_some_and(|rect| {
+                            rect.line == visual_line
+                                && rect.start_col + rect.num_cells as i32 == col_i32
+                                && rect.color == color
+                        });
+                        if can_extend {
+                            if let Some(rect) = current_rect.as_mut() {
+                                rect.extend();
+                            }
+                        } else {
+                            if let Some(previous) = current_rect.take() {
+                                rects.push(previous);
+                            }
+                            current_rect = Some(LayoutRect::new(visual_line, col_i32, color));
+                        }
+                    } else if let Some(rect) = current_rect.take() {
+                        rects.push(rect);
+                    }
+
+                    if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                        continue;
+                    }
+                    if cell.c == ' ' && !cell.flags.intersects(Flags::UNDERLINE | Flags::STRIKEOUT)
+                    {
+                        continue;
+                    }
+
+                    let mut fg_color = if is_selected {
+                        rgb(t.selection_fg).into()
+                    } else {
+                        ansi_to_hsla(t, &fg)
+                    };
+
+                    if cell.flags.contains(Flags::DIM) && !cell.flags.contains(Flags::BOLD) {
+                        fg_color.l = (fg_color.l * 0.66).clamp(0.0, 1.0);
+                    }
+
+                    let is_bold = cell.flags.contains(Flags::BOLD);
+                    let is_italic = cell.flags.contains(Flags::ITALIC);
+                    let font = match (is_bold, is_italic) {
+                        (true, true) => state.font_bold_italic.clone(),
+                        (true, false) => state.font_bold.clone(),
+                        (false, true) => state.font_italic.clone(),
+                        (false, false) => state.font.clone(),
+                    };
+
+                    let text_style = TextRun {
+                        len: cell.c.len_utf8(),
+                        font,
+                        color: fg_color,
+                        background_color: None,
+                        underline: if cell.flags.intersects(Flags::ALL_UNDERLINES) {
+                            let line_color = cell
+                                .underline_color()
+                                .map(|color| ansi_to_hsla(t, &color))
+                                .unwrap_or(fg_color);
+                            Some(UnderlineStyle {
+                                color: Some(line_color),
+                                thickness: px(1.0),
+                                wavy: cell.flags.contains(Flags::UNDERCURL),
+                            })
+                        } else {
+                            None
+                        },
+                        strikethrough: if cell.flags.contains(Flags::STRIKEOUT) {
+                            Some(StrikethroughStyle {
+                                color: Some(fg_color),
+                                thickness: px(1.0),
+                            })
+                        } else {
+                            None
+                        },
+                    };
+
+                    let can_append = current_batch
+                        .as_ref()
+                        .is_some_and(|batch| batch.can_append(&text_style, visual_line, col_i32));
+                    if can_append {
+                        if let Some(batch) = current_batch.as_mut() {
+                            batch.append_char(cell.c);
+                        }
+                    } else {
+                        if let Some(previous) = current_batch.take() {
+                            batched_runs.push(previous);
+                        }
+                        current_batch = Some(BatchedTextRun::new(
+                            visual_line,
+                            col_i32,
+                            cell.c,
+                            text_style,
+                        ));
+                    }
+                }
+            }
+
+            if let Some(batch) = current_batch {
+                batched_runs.push(batch);
+            }
+            if let Some(rect) = current_rect {
+                rects.push(rect);
+            }
+
+            (
+                batched_runs,
+                rects,
+                screen_lines,
+                display_offset,
+                cursor_point,
+                cols,
+            )
+        });
+    TerminalGridLayout {
+        batched_runs,
+        rects,
+        screen_lines,
+        display_offset,
+        cursor_col: cursor_point.column.0,
+        cursor_visual_line: cursor_point.line.0 + display_offset,
+        cells_scanned: screen_lines.saturating_mul(cols),
+    }
 }
 
 impl Element for TerminalElement {
@@ -446,6 +799,8 @@ impl Element for TerminalElement {
         window: &mut Window,
         cx: &mut App,
     ) {
+        let render_probe = okena_core::render_probe::terminal_paint();
+
         // Get theme colors
         let t = theme(cx);
 
@@ -455,6 +810,11 @@ impl Element for TerminalElement {
             viewer_id: self.resize_viewer_id,
         };
         window.handle_input(&self.focus_handle, input_handler, cx);
+
+        // Remote readers enqueue bytes without advancing `content_generation`;
+        // drain before sampling the cache key so newly arrived output can never
+        // be mistaken for an unchanged frame.
+        self.terminal.process_pending_output();
 
         let cell_width = state.cell_width;
         let line_height = state.line_height;
@@ -554,344 +914,177 @@ impl Element for TerminalElement {
             None => self.cursor_style,
         };
 
-        self.terminal.with_content(|term| {
-            let grid = term.grid();
-            let screen_lines = grid.screen_lines();
-            let cols = grid.columns();
-            let display_offset = grid.display_offset() as i32;
+        let mut cache_key = TerminalRenderCacheKey {
+            content_generation: self.terminal.content_generation(),
+            selection,
+            font: state.font.clone(),
+            theme: t,
+        };
+        let mut render_cache = self.render_cache.lock();
+        let grid_cache_hit = render_cache.matches(&cache_key);
+        if !grid_cache_hit {
+            let layout = build_terminal_grid_layout(&self.terminal, selection, &t, state);
+            // `with_content` drains pending remote output before taking the grid
+            // snapshot, so retain the generation that the cached layout actually
+            // represents rather than the value observed before the drain.
+            cache_key.content_generation = self.terminal.content_generation();
+            render_cache.store(cache_key, layout);
+        }
+        let layout = render_cache.layout.as_ref().cloned();
+        drop(render_cache);
+        let Some(layout) = layout else {
+            debug_assert!(false, "terminal render cache missing after initialization");
+            return;
+        };
 
-            let origin = bounds.origin;
+        // Phase 2: Paint backgrounds
+        for rect in &layout.rects {
+            rect.paint(bounds.origin, cell_width, line_height, window);
+        }
 
-            // Phase 1: Layout grid - collect batched runs and background rects
-            let mut batched_runs: Vec<BatchedTextRun> = Vec::new();
-            let mut rects: Vec<LayoutRect> = Vec::new();
-            let mut current_batch: Option<BatchedTextRun> = None;
-            let mut current_rect: Option<LayoutRect> = None;
-
-            for row in 0..screen_lines {
-                let visual_line = row as i32;
-                let buffer_line = visual_line - display_offset;
-
-                if let Some(batch) = current_batch.take() {
-                    batched_runs.push(batch);
-                }
-                if let Some(rect) = current_rect.take() {
-                    rects.push(rect);
-                }
-
-                for col in 0..cols {
-                    let cell_point = alacritty_terminal::index::Point {
-                        line: Line(buffer_line),
-                        column: Column(col),
-                    };
-                    let cell = &grid[cell_point];
-                    let col_i32 = col as i32;
-
-                    let mut fg = cell.fg;
-                    let mut bg = cell.bg;
-
-                    if cell.flags.contains(Flags::BOLD) {
-                        fg = match fg {
-                            Color::Named(NamedColor::Black) => {
-                                Color::Named(NamedColor::BrightBlack)
-                            }
-                            Color::Named(NamedColor::Red) => Color::Named(NamedColor::BrightRed),
-                            Color::Named(NamedColor::Green) => {
-                                Color::Named(NamedColor::BrightGreen)
-                            }
-                            Color::Named(NamedColor::Yellow) => {
-                                Color::Named(NamedColor::BrightYellow)
-                            }
-                            Color::Named(NamedColor::Blue) => Color::Named(NamedColor::BrightBlue),
-                            Color::Named(NamedColor::Magenta) => {
-                                Color::Named(NamedColor::BrightMagenta)
-                            }
-                            Color::Named(NamedColor::Cyan) => Color::Named(NamedColor::BrightCyan),
-                            Color::Named(NamedColor::White) => {
-                                Color::Named(NamedColor::BrightWhite)
-                            }
-                            Color::Indexed(idx @ 0..=7) => Color::Indexed(idx + 8),
-                            other => other,
-                        };
-                    }
-
-                    if cell.flags.contains(Flags::INVERSE) {
-                        std::mem::swap(&mut fg, &mut bg);
-                    }
-
-                    let is_selected =
-                        if let Some(((start_col, start_row), (end_col, end_row))) = selection {
-                            let (start_row, start_col, end_row, end_col) = if start_row < end_row
-                                || (start_row == end_row && start_col <= end_col)
-                            {
-                                (start_row, start_col, end_row, end_col)
-                            } else {
-                                (end_row, end_col, start_row, start_col)
-                            };
-                            if buffer_line >= start_row && buffer_line <= end_row {
-                                if start_row == end_row {
-                                    col >= start_col && col <= end_col
-                                } else if buffer_line == start_row {
-                                    col >= start_col
-                                } else if buffer_line == end_row {
-                                    col <= end_col
-                                } else {
-                                    true
-                                }
-                            } else {
-                                false
-                            }
-                        } else {
-                            false
-                        };
-
-                    let bg_color = if is_selected {
-                        Some(rgb(t.selection_bg).into())
-                    } else if !is_default_bg(&bg, &t) {
-                        Some(ansi_to_hsla(&t, &bg))
-                    } else {
-                        None
-                    };
-
-                    if let Some(color) = bg_color {
-                        let can_extend = current_rect.as_ref().is_some_and(|rect| {
-                            rect.line == visual_line
-                                && rect.start_col + rect.num_cells as i32 == col_i32
-                                && rect.color == color
-                        });
-                        if can_extend {
-                            if let Some(rect) = current_rect.as_mut() {
-                                rect.extend();
-                            }
-                        } else {
-                            if let Some(prev) = current_rect.take() {
-                                rects.push(prev);
-                            }
-                            current_rect = Some(LayoutRect::new(visual_line, col_i32, color));
-                        }
-                    } else if let Some(rect) = current_rect.take() {
-                        rects.push(rect);
-                    }
-
-                    if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
-                        continue;
-                    }
-                    if cell.c == ' ' && !cell.flags.intersects(Flags::UNDERLINE | Flags::STRIKEOUT)
-                    {
-                        continue;
-                    }
-
-                    let mut fg_color = if is_selected {
-                        rgb(t.selection_fg).into()
-                    } else {
-                        ansi_to_hsla(&t, &fg)
-                    };
-
-                    if cell.flags.contains(Flags::DIM) && !cell.flags.contains(Flags::BOLD) {
-                        fg_color.l = (fg_color.l * 0.66).clamp(0.0, 1.0);
-                    }
-
-                    let is_bold = cell.flags.contains(Flags::BOLD);
-                    let is_italic = cell.flags.contains(Flags::ITALIC);
-                    let font = match (is_bold, is_italic) {
-                        (true, true) => state.font_bold_italic.clone(),
-                        (true, false) => state.font_bold.clone(),
-                        (false, true) => state.font_italic.clone(),
-                        (false, false) => state.font.clone(),
-                    };
-
-                    let text_style = TextRun {
-                        len: cell.c.len_utf8(),
-                        font,
-                        color: fg_color,
-                        background_color: None,
-                        underline: if cell.flags.intersects(Flags::ALL_UNDERLINES) {
-                            let line_color = cell
-                                .underline_color()
-                                .map(|c| ansi_to_hsla(&t, &c))
-                                .unwrap_or(fg_color);
-                            Some(UnderlineStyle {
-                                color: Some(line_color),
-                                thickness: px(1.0),
-                                wavy: cell.flags.contains(Flags::UNDERCURL),
-                            })
-                        } else {
-                            None
-                        },
-                        strikethrough: if cell.flags.contains(Flags::STRIKEOUT) {
-                            Some(StrikethroughStyle {
-                                color: Some(fg_color),
-                                thickness: px(1.0),
-                            })
-                        } else {
-                            None
-                        },
-                    };
-
-                    let can_append = current_batch
-                        .as_ref()
-                        .is_some_and(|batch| batch.can_append(&text_style, visual_line, col_i32));
-                    if can_append {
-                        if let Some(batch) = current_batch.as_mut() {
-                            batch.append_char(cell.c);
-                        }
-                    } else {
-                        if let Some(prev) = current_batch.take() {
-                            batched_runs.push(prev);
-                        }
-                        current_batch = Some(BatchedTextRun::new(
-                            visual_line,
-                            col_i32,
-                            cell.c,
-                            text_style,
-                        ));
-                    }
-                }
+        // Phase 2.5: Paint search highlights
+        // search_match.line is an absolute grid line; convert to visual row
+        for (idx, search_match) in self.search_matches.iter().enumerate() {
+            let visual_line = search_match.line + layout.display_offset;
+            if visual_line < 0 || visual_line >= layout.screen_lines as i32 {
+                continue;
             }
 
-            if let Some(batch) = current_batch {
-                batched_runs.push(batch);
-            }
-            if let Some(rect) = current_rect {
-                rects.push(rect);
+            let is_current = self.current_match_index == Some(idx);
+            let highlight_color = if is_current {
+                let c = rgb(t.search_current_bg);
+                Hsla::from(Rgba {
+                    r: c.r,
+                    g: c.g,
+                    b: c.b,
+                    a: 0.7,
+                })
+            } else {
+                let c = rgb(t.search_match_bg);
+                Hsla::from(Rgba {
+                    r: c.r,
+                    g: c.g,
+                    b: c.b,
+                    a: 0.5,
+                })
+            };
+
+            let position = point(
+                px((f32::from(bounds.origin.x) + search_match.col as f32 * cell_width_f).floor()),
+                bounds.origin.y + line_height * visual_line as f32,
+            );
+            let size = size(
+                px((cell_width_f * search_match.len as f32).ceil()),
+                line_height,
+            );
+
+            window.paint_quad(fill(Bounds::new(position, size), highlight_color));
+        }
+
+        // Phase 2.6: Paint URL underlines
+        for url_match in self.url_matches.iter() {
+            let is_hovered = self.hovered_url_group == Some(url_match.link_group);
+
+            if url_match.line < 0 || url_match.line >= layout.screen_lines as i32 {
+                continue;
             }
 
-            // Phase 2: Paint backgrounds
-            for rect in &rects {
-                rect.paint(origin, cell_width, line_height, window);
-            }
+            let url_x =
+                px((f32::from(bounds.origin.x) + url_match.col as f32 * cell_width_f).floor());
+            let url_y = bounds.origin.y + line_height * url_match.line as f32;
+            let url_width = px((cell_width_f * url_match.len as f32).ceil());
 
-            // Phase 2.5: Paint search highlights
-            // search_match.line is an absolute grid line; convert to visual row
-            for (idx, search_match) in self.search_matches.iter().enumerate() {
-                let visual_line = search_match.line + display_offset;
-                if visual_line < 0 || visual_line >= screen_lines as i32 {
-                    continue;
-                }
-
-                let is_current = self.current_match_index == Some(idx);
-                let highlight_color = if is_current {
-                    let c = rgb(t.search_current_bg);
-                    Hsla::from(Rgba {
-                        r: c.r,
-                        g: c.g,
-                        b: c.b,
-                        a: 0.7,
-                    })
-                } else {
-                    let c = rgb(t.search_match_bg);
-                    Hsla::from(Rgba {
-                        r: c.r,
-                        g: c.g,
-                        b: c.b,
-                        a: 0.5,
-                    })
+            if is_hovered {
+                let hover_bg = Hsla::from(Rgba {
+                    r: 0.0,
+                    g: 0.48,
+                    b: 0.8,
+                    a: 0.2,
+                });
+                let hover_bounds = Bounds {
+                    origin: point(url_x, url_y),
+                    size: size(url_width, line_height),
                 };
+                window.paint_quad(fill(hover_bounds, hover_bg));
 
-                let position = point(
-                    px((f32::from(origin.x) + search_match.col as f32 * cell_width_f).floor()),
-                    origin.y + line_height * visual_line as f32,
-                );
-                let size = size(
-                    px((cell_width_f * search_match.len as f32).ceil()),
-                    line_height,
-                );
-
-                window.paint_quad(fill(Bounds::new(position, size), highlight_color));
+                let underline_color = rgb(t.border_active);
+                let underline_y = url_y + line_height - px(2.0);
+                let underline_bounds = Bounds {
+                    origin: point(url_x, underline_y),
+                    size: size(url_width, px(1.0)),
+                };
+                window.paint_quad(fill(underline_bounds, underline_color));
+            } else {
+                let underline_color = Hsla::from(Rgba {
+                    r: 0.5,
+                    g: 0.5,
+                    b: 0.5,
+                    a: 0.5,
+                });
+                let underline_y = url_y + line_height - px(2.0);
+                let underline_bounds = Bounds {
+                    origin: point(url_x, underline_y),
+                    size: size(url_width, px(1.0)),
+                };
+                window.paint_quad(fill(underline_bounds, underline_color));
             }
+        }
 
-            // Phase 2.6: Paint URL underlines
-            for url_match in self.url_matches.iter() {
-                let is_hovered = self.hovered_url_group == Some(url_match.link_group);
+        // Phase 3: Paint text runs
+        for batch in &layout.batched_runs {
+            batch.paint(
+                bounds.origin,
+                cell_width,
+                line_height,
+                font_size,
+                window,
+                cx,
+            );
+        }
 
-                if url_match.line < 0 || url_match.line >= screen_lines as i32 {
-                    continue;
-                }
+        // Phase 4: Paint cursor
+        if cursor_visible
+            && layout.cursor_visual_line >= 0
+            && layout.cursor_visual_line < layout.screen_lines as i32
+        {
+            let cursor_x =
+                px((f32::from(bounds.origin.x) + layout.cursor_col as f32 * cell_width_f).floor());
+            let cursor_y = px((f32::from(bounds.origin.y)
+                + layout.cursor_visual_line as f32 * line_height_f)
+                .floor());
 
-                let url_x = px((f32::from(origin.x) + url_match.col as f32 * cell_width_f).floor());
-                let url_y = origin.y + line_height * url_match.line as f32;
-                let url_width = px((cell_width_f * url_match.len as f32).ceil());
+            let cursor_rgba = rgb(t.cursor);
+            let cursor_color = Hsla::from(Rgba {
+                r: cursor_rgba.r,
+                g: cursor_rgba.g,
+                b: cursor_rgba.b,
+                a: 0.8,
+            });
 
-                if is_hovered {
-                    let hover_bg = Hsla::from(Rgba {
-                        r: 0.0,
-                        g: 0.48,
-                        b: 0.8,
-                        a: 0.2,
-                    });
-                    let hover_bounds = Bounds {
-                        origin: point(url_x, url_y),
-                        size: size(url_width, line_height),
-                    };
-                    window.paint_quad(fill(hover_bounds, hover_bg));
+            let cursor_bounds = match cursor_style {
+                CursorShape::Block => Bounds {
+                    origin: point(cursor_x, cursor_y),
+                    size: size(cell_width, line_height),
+                },
+                CursorShape::Bar => Bounds {
+                    origin: point(cursor_x, cursor_y),
+                    size: size(px(2.0), line_height),
+                },
+                CursorShape::Underline => Bounds {
+                    origin: point(cursor_x, cursor_y + line_height - px(2.0)),
+                    size: size(cell_width, px(2.0)),
+                },
+            };
+            window.paint_quad(fill(cursor_bounds, cursor_color));
+        }
 
-                    let underline_color = rgb(t.border_active);
-                    let underline_y = url_y + line_height - px(2.0);
-                    let underline_bounds = Bounds {
-                        origin: point(url_x, underline_y),
-                        size: size(url_width, px(1.0)),
-                    };
-                    window.paint_quad(fill(underline_bounds, underline_color));
-                } else {
-                    let underline_color = Hsla::from(Rgba {
-                        r: 0.5,
-                        g: 0.5,
-                        b: 0.5,
-                        a: 0.5,
-                    });
-                    let underline_y = url_y + line_height - px(2.0);
-                    let underline_bounds = Bounds {
-                        origin: point(url_x, underline_y),
-                        size: size(url_width, px(1.0)),
-                    };
-                    window.paint_quad(fill(underline_bounds, underline_color));
-                }
-            }
-
-            // Phase 3: Paint text runs
-            for batch in &batched_runs {
-                batch.paint(origin, cell_width, line_height, font_size, window, cx);
-            }
-
-            // Phase 4: Paint cursor
-            if cursor_visible {
-                let cursor_point = term.grid().cursor.point;
-                let cursor_visual_line = cursor_point.line.0 + display_offset;
-
-                if cursor_visual_line >= 0 && cursor_visual_line < screen_lines as i32 {
-                    let cursor_x = px((f32::from(origin.x)
-                        + cursor_point.column.0 as f32 * cell_width_f)
-                        .floor());
-                    let cursor_y = px((f32::from(origin.y)
-                        + cursor_visual_line as f32 * line_height_f)
-                        .floor());
-
-                    let cursor_rgba = rgb(t.cursor);
-                    let cursor_color = Hsla::from(Rgba {
-                        r: cursor_rgba.r,
-                        g: cursor_rgba.g,
-                        b: cursor_rgba.b,
-                        a: 0.8,
-                    });
-
-                    let cursor_bounds = match cursor_style {
-                        CursorShape::Block => Bounds {
-                            origin: point(cursor_x, cursor_y),
-                            size: size(cell_width, line_height),
-                        },
-                        CursorShape::Bar => Bounds {
-                            origin: point(cursor_x, cursor_y),
-                            size: size(px(2.0), line_height),
-                        },
-                        CursorShape::Underline => Bounds {
-                            origin: point(cursor_x, cursor_y + line_height - px(2.0)),
-                            size: size(cell_width, px(2.0)),
-                        },
-                    };
-                    window.paint_quad(fill(cursor_bounds, cursor_color));
-                }
-            }
-        });
+        let cells_scanned = if grid_cache_hit {
+            0
+        } else {
+            layout.cells_scanned
+        };
+        let text_runs = layout.batched_runs.len();
+        let background_rects = layout.rects.len();
 
         // Phase 5: Paint fog overlay for unfocused terminals
         if !is_focused {
@@ -904,6 +1097,15 @@ impl Element for TerminalElement {
             });
             window.paint_quad(fill(bounds, fog));
         }
+
+        render_probe.finish(okena_core::render_probe::TerminalPaintStats {
+            live_viewers: n_viewers,
+            grid_cache_hit,
+            cells_scanned,
+            cells_changed: None,
+            text_runs,
+            background_rects,
+        });
 
         let painted_samples = okena_core::latency_probe::client_painted(
             &self.terminal.terminal_id,

--- a/crates/okena-views-terminal/src/elements/terminal_element.rs
+++ b/crates/okena-views-terminal/src/elements/terminal_element.rs
@@ -41,6 +41,7 @@ mod tests {
     use gpui::{Font, FontFeatures, FontStyle, FontWeight};
     use okena_core::theme::{DARK_THEME, LIGHT_THEME};
     use okena_terminal::terminal::TerminalSize;
+    use std::sync::Arc;
 
     fn size(cols: u16, rows: u16) -> TerminalSize {
         TerminalSize {
@@ -127,29 +128,33 @@ mod tests {
     fn render_cache_hits_only_for_an_exact_key_with_layout() {
         let key = cache_key();
         let mut cache = TerminalRenderCache::default();
-        assert!(!cache.matches(&key));
+        assert!(cache.get(&key).is_none());
 
-        cache.store(key.clone(), empty_layout());
-        assert!(cache.matches(&key));
+        let stored = cache.store(key.clone(), empty_layout());
+        let hit = cache.get(&key).expect("exact key hits");
+        assert!(
+            Arc::ptr_eq(&stored, &hit),
+            "the hit reuses the stored layout"
+        );
 
         let mut changed_generation = key.clone();
         changed_generation.content_generation += 1;
-        assert!(!cache.matches(&changed_generation));
+        assert!(cache.get(&changed_generation).is_none());
 
         let mut changed_selection = key.clone();
         changed_selection.selection = Some(((1, 2), (3, 4)));
-        assert!(!cache.matches(&changed_selection));
+        assert!(cache.get(&changed_selection).is_none());
 
         let mut changed_font = key.clone();
         changed_font.font.weight = FontWeight::BOLD;
-        assert!(!cache.matches(&changed_font));
+        assert!(cache.get(&changed_font).is_none());
 
         let mut changed_theme = key;
         changed_theme.theme = LIGHT_THEME;
-        assert!(!cache.matches(&changed_theme));
+        assert!(cache.get(&changed_theme).is_none());
 
         cache.layout = None;
-        assert!(!cache.matches(&cache_key()));
+        assert!(cache.get(&cache_key()).is_none());
     }
 
     #[test]
@@ -160,7 +165,7 @@ mod tests {
 
         cache.invalidate();
 
-        assert!(!cache.matches(&key));
+        assert!(cache.get(&key).is_none());
         assert!(cache.key.is_none());
         assert!(cache.layout.is_none());
     }
@@ -407,6 +412,9 @@ pub struct TerminalElementState {
 struct TerminalRenderCacheKey {
     content_generation: u64,
     selection: Option<((usize, i32), (usize, i32))>,
+    /// Only the regular font: `state.font_bold` / `_italic` / `_bold_italic` are
+    /// derived from it by overriding weight and style, so it alone pins all four.
+    /// A separately configurable bold face would have to be added here too.
     font: Font,
     theme: ThemeColors,
 }
@@ -429,13 +437,22 @@ pub(crate) struct TerminalRenderCache {
 }
 
 impl TerminalRenderCache {
-    fn matches(&self, key: &TerminalRenderCacheKey) -> bool {
-        self.key.as_ref() == Some(key) && self.layout.is_some()
+    fn get(&self, key: &TerminalRenderCacheKey) -> Option<Arc<TerminalGridLayout>> {
+        if self.key.as_ref() != Some(key) {
+            return None;
+        }
+        self.layout.clone()
     }
 
-    fn store(&mut self, key: TerminalRenderCacheKey, layout: TerminalGridLayout) {
+    fn store(
+        &mut self,
+        key: TerminalRenderCacheKey,
+        layout: TerminalGridLayout,
+    ) -> Arc<TerminalGridLayout> {
+        let layout = Arc::new(layout);
         self.key = Some(key);
-        self.layout = Some(Arc::new(layout));
+        self.layout = Some(layout.clone());
+        layout
     }
 
     pub(crate) fn invalidate(&mut self) {
@@ -444,14 +461,20 @@ impl TerminalRenderCache {
     }
 }
 
+/// Builds the grid layout and reports the `content_generation` it was built
+/// from. The generation is sampled inside `with_content`, i.e. under the same
+/// `term` lock that every grid mutation takes — reading it after the lock is
+/// released would let a layout be filed under a generation it never saw, and
+/// that pane would then hold a stale frame until some other input changed.
 fn build_terminal_grid_layout(
     terminal: &Terminal,
     selection: Option<((usize, i32), (usize, i32))>,
     t: &ThemeColors,
     state: &TerminalElementState,
-) -> TerminalGridLayout {
-    let (batched_runs, rects, screen_lines, display_offset, cursor_point, cols) = terminal
-        .with_content(|term| {
+) -> (u64, TerminalGridLayout) {
+    let (content_generation, batched_runs, rects, screen_lines, display_offset, cursor_point, cols) =
+        terminal.with_content(|term| {
+            let content_generation = terminal.content_generation();
             let grid = term.grid();
             let screen_lines = grid.screen_lines();
             let cols = grid.columns();
@@ -652,6 +675,7 @@ fn build_terminal_grid_layout(
             }
 
             (
+                content_generation,
                 batched_runs,
                 rects,
                 screen_lines,
@@ -660,7 +684,7 @@ fn build_terminal_grid_layout(
                 cols,
             )
         });
-    TerminalGridLayout {
+    let layout = TerminalGridLayout {
         batched_runs,
         rects,
         screen_lines,
@@ -668,7 +692,8 @@ fn build_terminal_grid_layout(
         cursor_col: cursor_point.column.0,
         cursor_visual_line: cursor_point.line.0 + display_offset,
         cells_scanned: screen_lines.saturating_mul(cols),
-    }
+    };
+    (content_generation, layout)
 }
 
 impl Element for TerminalElement {
@@ -921,21 +946,21 @@ impl Element for TerminalElement {
             theme: t,
         };
         let mut render_cache = self.render_cache.lock();
-        let grid_cache_hit = render_cache.matches(&cache_key);
-        if !grid_cache_hit {
-            let layout = build_terminal_grid_layout(&self.terminal, selection, &t, state);
-            // `with_content` drains pending remote output before taking the grid
-            // snapshot, so retain the generation that the cached layout actually
-            // represents rather than the value observed before the drain.
-            cache_key.content_generation = self.terminal.content_generation();
-            render_cache.store(cache_key, layout);
-        }
-        let layout = render_cache.layout.as_ref().cloned();
-        drop(render_cache);
-        let Some(layout) = layout else {
-            debug_assert!(false, "terminal render cache missing after initialization");
-            return;
+        let cached_layout = render_cache.get(&cache_key);
+        let grid_cache_hit = cached_layout.is_some();
+        let layout = match cached_layout {
+            Some(layout) => layout,
+            None => {
+                let (content_generation, layout) =
+                    build_terminal_grid_layout(&self.terminal, selection, &t, state);
+                // File the layout under the generation observed while building it:
+                // `with_content` drains pending remote output first, so the value
+                // sampled before the call can already be one behind.
+                cache_key.content_generation = content_generation;
+                render_cache.store(cache_key, layout)
+            }
         };
+        drop(render_cache);
 
         // Phase 2: Paint backgrounds
         for rect in &layout.rects {

--- a/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
@@ -1,7 +1,7 @@
 //! Terminal content component.
 
 use crate::elements::terminal_element::{
-    LinkKind, SearchMatch, TerminalElement,
+    LinkKind, SearchMatch, TerminalElement, TerminalRenderCache,
     deregister_resize_viewer as deregister_shared_resize_viewer, next_resize_viewer_id,
 };
 use crate::layout::navigation::register_pane_bounds;
@@ -31,6 +31,7 @@ pub enum TerminalContentEvent {
 pub struct TerminalContent {
     terminal: Option<Arc<Terminal>>,
     resize_viewer_id: u64,
+    render_cache: Arc<parking_lot::Mutex<TerminalRenderCache>>,
     focus_handle: FocusHandle,
     window_activation_subscription: Option<Subscription>,
     url_detector: UrlDetector,
@@ -79,6 +80,7 @@ impl TerminalContent {
         Self {
             terminal: None,
             resize_viewer_id: next_resize_viewer_id(),
+            render_cache: Arc::new(parking_lot::Mutex::new(TerminalRenderCache::default())),
             focus_handle,
             window_activation_subscription: None,
             url_detector: UrlDetector::new(),
@@ -218,6 +220,7 @@ impl TerminalContent {
             }
         }
         self.terminal = terminal.clone();
+        self.render_cache.lock().invalidate();
         self.scrollbar.update(cx, |scrollbar, _| {
             scrollbar.set_terminal(terminal);
         });
@@ -879,6 +882,7 @@ impl Render for TerminalContent {
             .child(
                 div().size_full().p(px(4.0)).bg(rgb(term_bg)).child(
                     TerminalElement::new(terminal_clone, focus_handle, self.resize_viewer_id)
+                        .with_render_cache(self.render_cache.clone())
                         .with_zoom(zoom_level)
                         .with_bg_tint(bg_tint)
                         .with_search(self.search_matches.clone(), self.search_current_index)


### PR DESCRIPTION
## Summary
- cut the repeated UI work caused by one terminal's output repainting every pane in its project column, without lowering the 20 ms terminal repaint cadence
- separate sidebar refresh scheduling from terminal panes and cap sustained sidebar refreshes at 250 ms with immediate leading and trailing updates
- add opt-in, aggregate-only diagnostics for measuring the result

## Why the panes repaint

`TerminalContent::request_activity_repaint` calls `cx.notify()` on **one** pane, but that does not repaint only that pane:

1. `Window::mark_view_dirty` marks the **whole ancestor path** dirty — content → pane → layout container → project column → window.
2. A `.cached()` view may reuse its paint only while `!dirty_views.contains(id) && !window.refreshing`.
3. When a dirty `.cached()` view re-renders, GPUI sets `window.refreshing = true` for its **entire subtree**, bypassing every nested `.cached()`.

So the project column containing the active terminal re-renders in full, and with it every pane inside it — each one rescanning its whole grid. Sibling columns stay cached.

Measured on this view tree (`simple_root::view_cache_cascade` pins it):

| layout | panes repainted per notify | resulting grid-cache hit rate |
|---|---|---|
| 1 column x 2 panes | 2 of 2 | 50 % |
| 1 column x 4 panes | 4 of 4 | 75 % |
| 2 columns x 3 panes | 3 of 6 | 67 % |
| 3 columns x 4 panes | 4 of 12 | 75 % |

The saving therefore scales with panes-per-column; it is not a fixed percentage. `simple_root.rs` already documented the mechanism for the root view — the same rule turns out to govern every column.

## Changes

### Terminal grid cache
- cache model-derived text runs and background rectangles by content generation, selection, font, and theme
- sample `content_generation` inside `with_content`, under the same `term` lock every grid mutation takes, so a layout can never be filed under a generation it was not built from
- process pending terminal output before sampling the cache key
- keep cursor, search, URL, focus, tint, and geometry-dependent overlays dynamic
- invalidate retained layout state when replacing the terminal model

### Repaint scheduling
- add a dedicated activity repaint throttle for sidebar updates
- keep terminal-pane activity and input-response repaint behavior unchanged
- report terminal/sidebar repaint attribution separately

### Diagnostics and compatibility
- add a disabled-by-default `render-perf-probe` feature with bounded, identifier-free aggregate metrics
- report pane/viewer fan-out, cache hits and misses, scanned cells, and render timings
- fix a debug-build panic: the folder delete button layered a second `.hover()` on `icon_button`, which GPUI `debug_assert!`s on. Added `icon_button_bare` to okena-ui for buttons that own their hover style.
- add focused repaint-throttle, viewer fan-out, cache-key, invalidation, view-cache-cascade, and probe-schema coverage

## Measurements
- matched Stage 1 release pair: GUI mean CPU decreased 17.4 %; combined GUI/daemon mean decreased 14.1 %
- grid-cache diagnostic pair: 53.4 % cache-hit rate and 53.4 % fewer cells scanned per paint — consistent with the 2-panes-in-one-column case above
- the same grid-cache pair showed GUI mean CPU down 4.7 % and p95 down 9.1 %

CPU figures come from single controlled pairs under variable host load; the count-based cache and scan reductions are the stronger evidence. Because the win scales with panes-per-column, a 4-way split should show roughly 75 % rather than the measured 53 % — that case has not been benchmarked yet.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`, default and `render-perf-probe`
- [x] `cargo test --workspace` — 1690 passed, 0 failed
- [x] terminal tests, including focused cache-key and invalidation coverage
- [x] render-probe tests with the feature enabled and disabled
- [x] `cargo build --release`
- [x] deterministic matched-release terminal benchmarks with host-contention gates
- [x] rebased onto `main` (gpui 1.13); the view-cache cascade still holds on the new pin
- [ ] manually exercise selection, search highlights, URL hover, resizing, theme/font changes, split panes, and focus overlays
- [ ] benchmark a 4-way split to confirm the hit rate scales as predicted
