### PR TITLE
fix(git-poll): stop the PR/CI poller burning the GitHub API budget

### DIFF
--- a/crates/okena-core/src/git_poll.rs
+++ b/crates/okena-core/src/git_poll.rs
@@ -1,4 +1,204 @@
+use std::collections::{HashMap, HashSet};
+
 use crate::api::ActionRequest;
+
+/// One poll cycle is one tick of the 5s git-status cadence, in both the daemon
+/// poller and the GUI watcher. Every constant below is expressed in cycles.
+pub const POLL_CYCLE_SECS: u64 = 5;
+/// `gh pr list` cadence per project (~60s).
+pub const PR_POLL_EVERY_N_CYCLES: u64 = 12;
+/// CI cadence for a project whose own checks are still running (~15s).
+pub const CI_PENDING_POLL_EVERY_N_CYCLES: u64 = 3;
+/// CI cadence for a project whose checks have settled (~60s).
+pub const CI_SETTLED_POLL_EVERY_N_CYCLES: u64 = 12;
+/// A settled result is revalidated on the wire this often (~10min) even when
+/// the commit hasn't moved, so a re-run of an old commit's checks is noticed.
+pub const CI_REVALIDATE_EVERY_N_CYCLES: u64 = 120;
+/// First backoff after GitHub reports the API rate limit as exhausted (~60s).
+pub const RATE_LIMIT_BACKOFF_MIN_CYCLES: u64 = 12;
+/// Ceiling for the doubling backoff (~30min — GitHub's window is an hour).
+pub const RATE_LIMIT_BACKOFF_MAX_CYCLES: u64 = 360;
+
+/// Per-project scheduling for the `gh` PR/CI fan-out, shared by the daemon
+/// poller and the GUI watcher.
+///
+/// It answers three questions the poll loops used to answer with global state:
+/// *is this project due?* (per project, so one repo with running CI cannot pull
+/// every other repo onto the fast cadence), *can the fetch be skipped
+/// outright?* (the cached result still describes the current upstream commit),
+/// and *should we be talking to GitHub at all?* (a rate-limit gate).
+#[derive(Debug, Default)]
+pub struct GithubPollSchedule {
+    projects: HashMap<String, ProjectSchedule>,
+    /// Cycle at which `gh` may run again after a rate-limit refusal.
+    gate_until_cycle: Option<u64>,
+    /// Current backoff length; doubles per consecutive refusal.
+    backoff_cycles: u64,
+}
+
+#[derive(Debug, Clone)]
+struct ProjectSchedule {
+    next_pr_cycle: u64,
+    next_ci_cycle: u64,
+    /// Upstream commit the cached CI summary describes. Only set while that
+    /// summary is settled — a pending one has to be re-fetched to make progress.
+    settled_ci_sha: Option<String>,
+    /// Cycle at which a settled result is re-fetched even if the commit is
+    /// unchanged.
+    ci_revalidate_cycle: u64,
+    /// Fetch on the next pass without waiting for the cadence tick.
+    urgent: bool,
+}
+
+impl Default for ProjectSchedule {
+    fn default() -> Self {
+        // Cycle 0 is startup — the app is already busy spawning terminals and
+        // the gix status renders without `gh`. First fetch lands on cycle 1.
+        Self {
+            next_pr_cycle: 1,
+            next_ci_cycle: 1,
+            settled_ci_sha: None,
+            ci_revalidate_cycle: 0,
+            urgent: false,
+        }
+    }
+}
+
+impl GithubPollSchedule {
+    /// Drop bookkeeping for projects that no longer exist.
+    pub fn retain(&mut self, active: &HashSet<String>) {
+        self.projects.retain(|id, _| active.contains(id));
+    }
+
+    /// Cached PR/CI is invalid (branch changed): fetch as soon as possible.
+    pub fn force(&mut self, id: &str) {
+        let entry = self.entry(id);
+        entry.urgent = true;
+        entry.next_pr_cycle = 0;
+        entry.next_ci_cycle = 0;
+        entry.settled_ci_sha = None;
+        entry.ci_revalidate_cycle = 0;
+    }
+
+    /// A project became relevant. Only worth an off-cadence fetch when we have
+    /// never fetched it — otherwise the cached badge is still good.
+    pub fn force_if_unfetched(&mut self, id: &str) {
+        if !self.projects.contains_key(id) {
+            self.force(id);
+        }
+    }
+
+    /// Whether any project wants an off-cadence fetch right now.
+    pub fn has_urgent(&self) -> bool {
+        self.projects.values().any(|entry| entry.urgent)
+    }
+
+    pub fn pr_due(&self, id: &str, cycle: u64, cadence_due: bool) -> bool {
+        match self.projects.get(id) {
+            Some(entry) => entry.urgent || (cadence_due && cycle >= entry.next_pr_cycle),
+            None => cadence_due && cycle >= ProjectSchedule::default().next_pr_cycle,
+        }
+    }
+
+    pub fn ci_due(&self, id: &str, cycle: u64, cadence_due: bool) -> bool {
+        match self.projects.get(id) {
+            Some(entry) => entry.urgent || (cadence_due && cycle >= entry.next_ci_cycle),
+            None => cadence_due && cycle >= ProjectSchedule::default().next_ci_cycle,
+        }
+    }
+
+    /// The commit whose CI result the caller already holds, so the fetch can be
+    /// skipped when the upstream commit still matches. `None` forces a real
+    /// request — nothing cached, the last result was pending, or the
+    /// revalidation deadline has passed.
+    pub fn ci_skip_sha(&self, id: &str, cycle: u64) -> Option<String> {
+        let entry = self.projects.get(id)?;
+        if cycle >= entry.ci_revalidate_cycle {
+            return None;
+        }
+        entry.settled_ci_sha.clone()
+    }
+
+    /// A PR fetch is on its way out. Pushes the next due cycle forward so an
+    /// in-flight pass is never dispatched twice; the result refines it.
+    pub fn pr_dispatched(&mut self, id: &str, cycle: u64) {
+        let entry = self.entry(id);
+        entry.next_pr_cycle = cycle + PR_POLL_EVERY_N_CYCLES;
+        entry.urgent = false;
+    }
+
+    pub fn ci_dispatched(&mut self, id: &str, cycle: u64) {
+        let entry = self.entry(id);
+        entry.next_ci_cycle = cycle + CI_SETTLED_POLL_EVERY_N_CYCLES;
+        entry.urgent = false;
+    }
+
+    pub fn record_pr(&mut self, id: &str, cycle: u64) {
+        let entry = self.entry(id);
+        entry.next_pr_cycle = cycle + PR_POLL_EVERY_N_CYCLES;
+        entry.urgent = false;
+    }
+
+    /// A CI fetch came back. `pending` drives this project's own cadence, and a
+    /// settled result caches its commit so the next poll can skip the wire.
+    pub fn record_ci(&mut self, id: &str, cycle: u64, pending: bool, sha: Option<String>) {
+        let entry = self.entry(id);
+        entry.next_ci_cycle = cycle
+            + if pending {
+                CI_PENDING_POLL_EVERY_N_CYCLES
+            } else {
+                CI_SETTLED_POLL_EVERY_N_CYCLES
+            };
+        entry.urgent = false;
+        entry.settled_ci_sha = if pending { None } else { sha };
+        entry.ci_revalidate_cycle = cycle + CI_REVALIDATE_EVERY_N_CYCLES;
+    }
+
+    /// The upstream commit was unchanged, so no request went out. Keeps the
+    /// cached commit and revalidation deadline, just re-arms the cadence.
+    pub fn record_ci_unchanged(&mut self, id: &str, cycle: u64) {
+        let entry = self.entry(id);
+        entry.next_ci_cycle = cycle + CI_SETTLED_POLL_EVERY_N_CYCLES;
+        entry.urgent = false;
+    }
+
+    /// GitHub refused because the API rate limit is exhausted. Parks every
+    /// project's `gh` traffic, doubling the wait per consecutive refusal.
+    pub fn note_rate_limited(&mut self, cycle: u64) {
+        self.backoff_cycles = if self.backoff_cycles == 0 {
+            RATE_LIMIT_BACKOFF_MIN_CYCLES
+        } else {
+            (self.backoff_cycles * 2).min(RATE_LIMIT_BACKOFF_MAX_CYCLES)
+        };
+        self.gate_until_cycle = Some(cycle + self.backoff_cycles);
+    }
+
+    /// A request went through — clear the gate and the accumulated backoff.
+    pub fn note_request_succeeded(&mut self) {
+        self.backoff_cycles = 0;
+        self.gate_until_cycle = None;
+    }
+
+    /// Whether `gh` is currently parked by the rate-limit gate.
+    pub fn is_rate_limited(&self, cycle: u64) -> bool {
+        self.gate_until_cycle.is_some_and(|until| cycle < until)
+    }
+
+    /// Length of the current rate-limit backoff, in cycles. For logging.
+    pub fn rate_limit_backoff_cycles(&self) -> u64 {
+        self.backoff_cycles
+    }
+
+    /// Whether this project asked for an off-cadence fetch that hasn't been
+    /// dispatched yet.
+    pub fn is_urgent(&self, id: &str) -> bool {
+        self.projects.get(id).is_some_and(|entry| entry.urgent)
+    }
+
+    fn entry(&mut self, id: &str) -> &mut ProjectSchedule {
+        self.projects.entry(id.to_string()).or_default()
+    }
+}
 
 /// External wake-up request for git / GitHub status polling.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -121,5 +321,122 @@ mod tests {
             })
             .is_none()
         );
+    }
+
+    #[test]
+    fn first_fetch_lands_on_cycle_one_not_at_startup() {
+        let schedule = GithubPollSchedule::default();
+        assert!(!schedule.pr_due("p1", 0, true));
+        assert!(!schedule.ci_due("p1", 0, true));
+        assert!(schedule.pr_due("p1", 1, true));
+        assert!(schedule.ci_due("p1", 1, true));
+    }
+
+    #[test]
+    fn nothing_is_due_between_cadence_ticks() {
+        let schedule = GithubPollSchedule::default();
+        assert!(!schedule.pr_due("p1", 5, false));
+        assert!(!schedule.ci_due("p1", 5, false));
+    }
+
+    #[test]
+    fn forced_project_is_due_off_cadence() {
+        let mut schedule = GithubPollSchedule::default();
+        schedule.force("p1");
+        assert!(schedule.has_urgent());
+        assert!(schedule.pr_due("p1", 3, false));
+        assert!(schedule.ci_due("p1", 3, false));
+        schedule.ci_dispatched("p1", 3);
+        schedule.pr_dispatched("p1", 3);
+        assert!(!schedule.has_urgent());
+    }
+
+    #[test]
+    fn pending_ci_stays_local_to_its_own_project() {
+        let mut schedule = GithubPollSchedule::default();
+        schedule.record_ci("busy", 10, true, None);
+        schedule.record_ci("idle", 10, false, Some("abc".into()));
+
+        // Busy repo is back 3 cycles later, idle one only after 12.
+        assert!(schedule.ci_due("busy", 13, true));
+        assert!(!schedule.ci_due("idle", 13, true));
+        assert!(schedule.ci_due("idle", 22, true));
+    }
+
+    #[test]
+    fn settled_result_skips_the_wire_while_the_commit_holds() {
+        let mut schedule = GithubPollSchedule::default();
+        schedule.record_ci("p1", 10, false, Some("abc".into()));
+        assert_eq!(schedule.ci_skip_sha("p1", 22).as_deref(), Some("abc"));
+
+        // …but is revalidated once the staleness deadline passes.
+        assert_eq!(
+            schedule.ci_skip_sha("p1", 10 + CI_REVALIDATE_EVERY_N_CYCLES),
+            None
+        );
+    }
+
+    #[test]
+    fn pending_result_is_never_cacheable() {
+        let mut schedule = GithubPollSchedule::default();
+        schedule.record_ci("p1", 10, true, Some("abc".into()));
+        assert_eq!(schedule.ci_skip_sha("p1", 12), None);
+    }
+
+    #[test]
+    fn unchanged_result_keeps_the_cached_commit() {
+        let mut schedule = GithubPollSchedule::default();
+        schedule.record_ci("p1", 10, false, Some("abc".into()));
+        schedule.record_ci_unchanged("p1", 22);
+        assert_eq!(schedule.ci_skip_sha("p1", 23).as_deref(), Some("abc"));
+        assert!(schedule.ci_due("p1", 34, true));
+    }
+
+    #[test]
+    fn branch_change_drops_the_cached_commit() {
+        let mut schedule = GithubPollSchedule::default();
+        schedule.record_ci("p1", 10, false, Some("abc".into()));
+        schedule.force("p1");
+        assert_eq!(schedule.ci_skip_sha("p1", 11), None);
+    }
+
+    #[test]
+    fn relevance_only_forces_projects_never_fetched() {
+        let mut schedule = GithubPollSchedule::default();
+        schedule.force_if_unfetched("fresh");
+        assert!(schedule.ci_due("fresh", 0, false));
+
+        schedule.record_ci("known", 10, false, Some("abc".into()));
+        schedule.force_if_unfetched("known");
+        assert!(!schedule.ci_due("known", 11, true));
+    }
+
+    #[test]
+    fn rate_limit_gate_backs_off_and_clears() {
+        let mut schedule = GithubPollSchedule::default();
+        schedule.note_rate_limited(0);
+        assert!(schedule.is_rate_limited(RATE_LIMIT_BACKOFF_MIN_CYCLES - 1));
+        assert!(!schedule.is_rate_limited(RATE_LIMIT_BACKOFF_MIN_CYCLES));
+
+        // Consecutive refusals double the wait, up to the ceiling.
+        schedule.note_rate_limited(100);
+        assert!(schedule.is_rate_limited(100 + RATE_LIMIT_BACKOFF_MIN_CYCLES));
+        for cycle in 0..20 {
+            schedule.note_rate_limited(cycle);
+        }
+        assert!(!schedule.is_rate_limited(19 + RATE_LIMIT_BACKOFF_MAX_CYCLES + 1));
+
+        schedule.note_request_succeeded();
+        assert!(!schedule.is_rate_limited(0));
+    }
+
+    #[test]
+    fn retain_drops_removed_projects() {
+        let mut schedule = GithubPollSchedule::default();
+        schedule.record_ci("gone", 10, false, Some("abc".into()));
+        schedule.record_ci("kept", 10, false, Some("def".into()));
+        schedule.retain(&HashSet::from(["kept".to_string()]));
+        assert_eq!(schedule.ci_skip_sha("gone", 11), None);
+        assert_eq!(schedule.ci_skip_sha("kept", 11).as_deref(), Some("def"));
     }
 }

--- a/crates/okena-daemon-core/src/git_poll.rs
+++ b/crates/okena-daemon-core/src/git_poll.rs
@@ -6,6 +6,12 @@
 //! 30s full status). Explicit actions and detected HEAD changes still trigger an
 //! immediate targeted refresh. Cached statuses for projects not selected in a
 //! cycle remain published, so tiering changes freshness rather than visibility.
+//!
+//! The `gh` PR/CI fan-out is deliberately *narrower* than the local tier: it
+//! covers only projects visible in a window (plus explicitly requested ones),
+//! is scheduled per project by [`GithubPollSchedule`], skips any project whose
+//! upstream commit hasn't moved since its last settled result, and parks itself
+//! when GitHub reports the API rate limit as exhausted.
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -13,12 +19,13 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use okena_core::api::ApiGitStatus;
-use okena_core::git_poll::GitPollTrigger;
+use okena_core::git_poll::{GitPollTrigger, GithubPollSchedule};
 use okena_core::process::{Lane, with_lane};
+use okena_git::repository::{CiFetch, PrFetch};
 use okena_git::{self as git, GitStatus, HeadSnapshot};
 use okena_workspace::state::Workspace;
 use parking_lot::Mutex;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{Semaphore, mpsc, watch};
 
 /// Responsive full-status cadence for visible or remotely subscribed projects.
 const GIT_POLL_INTERVAL: Duration = Duration::from_secs(5);
@@ -28,15 +35,11 @@ const HIDDEN_GIT_POLL_EVERY_N_CYCLES: u64 = 6;
 const HEAD_POLL_INTERVAL: Duration = Duration::from_millis(250);
 /// Hidden projects receive a cheap HEAD fallback scan every 8 ticks (2s).
 const HIDDEN_HEAD_POLL_EVERY_N_TICKS: u64 = 8;
-/// How many git poll cycles between PR URL checks (~60s). Mirrors the GUI
-/// watcher's `PR_POLL_EVERY_N_CYCLES`.
-const PR_POLL_EVERY_N_CYCLES: u64 = 12;
-/// How many git poll cycles between CI check polls when checks are pending
-/// (~15s). Mirrors the GUI watcher's `CI_PENDING_POLL_EVERY_N_CYCLES`.
-const CI_PENDING_POLL_EVERY_N_CYCLES: u64 = 3;
-/// How many git poll cycles between CI check polls when checks are settled
-/// (~60s). Mirrors the GUI watcher's `CI_SETTLED_POLL_EVERY_N_CYCLES`.
-const CI_SETTLED_POLL_EVERY_N_CYCLES: u64 = 12;
+/// How many projects the `gh` fan-out talks to at once. Matches the process
+/// bus's `Lane::Poll` worker count — going wider just queues on the bus, going
+/// narrower (the previous strictly sequential loop) made a full pass outlast
+/// its own cadence and let passes pile up on top of each other.
+const GH_FANOUT_CONCURRENCY: usize = 4;
 
 /// Project the local [`GitStatus`] onto the slimmer wire type pushed to remote
 /// clients. GPUI-free reimplementation of `okena-views-git`'s `to_api`.
@@ -103,14 +106,45 @@ struct GithubPollResult {
     head_generations: HashMap<String, u64>,
     branches: HashMap<String, Option<String>>,
     pr_infos: HashMap<String, Option<git::PrInfo>>,
-    ci_checks: HashMap<String, Option<git::CiCheckSummary>>,
+    ci: HashMap<String, CiFetch>,
+    /// GitHub refused at least one call because the rate limit is exhausted.
+    rate_limited: bool,
+    /// At least one call actually reached GitHub, so the rate-limit backoff can
+    /// be cleared. A pass of nothing but cache hits proves nothing.
+    reached_github: bool,
 }
 
-fn relevant_project_ids(
+/// One project's slot in a `gh` pass.
+struct ProjectPoll {
+    id: String,
+    path: String,
+    want_pr: bool,
+    want_ci: bool,
+    /// Upstream commit whose CI result the poller already holds; the fetch is
+    /// skipped while the branch still points at it.
+    ci_skip_sha: Option<String>,
+    /// PR number from a previous pass, used when this pass isn't re-fetching it.
+    cached_pr_number: Option<u32>,
+}
+
+/// Projects the user can currently see. The `gh` fan-out is scoped to these:
+/// a badge nobody is looking at is not worth GitHub API budget.
+fn visible_project_ids(workspace: &Workspace) -> HashSet<String> {
+    workspace.all_visible_project_ids()
+}
+
+/// Visible projects plus any owning a terminal a remote client is streaming.
+///
+/// This is the *local* status tier only. Clients subscribe to every terminal in
+/// the daemon's state — not just the ones they render — so folding subscriptions
+/// into the `gh` set would put every project that merely owns a terminal on the
+/// responsive GitHub cadence, which is how a machine with a few dozen projects
+/// burns an hourly API budget without displaying a single extra badge.
+fn streaming_project_ids(
     workspace: &Workspace,
     remote_subscribed_terminals: &RwLock<HashMap<u64, HashSet<String>>>,
 ) -> HashSet<String> {
-    let mut relevant = workspace.all_visible_project_ids();
+    let mut relevant = visible_project_ids(workspace);
     if let Ok(subscribed) = remote_subscribed_terminals.read() {
         for terminal_ids in subscribed.values() {
             for terminal_id in terminal_ids {
@@ -187,7 +221,7 @@ pub async fn run_git_head_poll(
 
         let (projects, relevant_ids): (Vec<(String, String)>, HashSet<String>) = {
             let workspace = workspace.lock();
-            let relevant = relevant_project_ids(&workspace, &remote_subscribed_terminals);
+            let relevant = streaming_project_ids(&workspace, &remote_subscribed_terminals);
             let projects = workspace
                 .projects()
                 .iter()
@@ -249,65 +283,137 @@ fn update_head_snapshots<T: PartialEq>(
         .collect()
 }
 
+/// Pick this cycle's `gh` slots.
+///
+/// Two rules, both of which used to be missing: a project earns a slot only if
+/// it is *visible* (or explicitly asked for), and only when its own schedule
+/// says it is due — one repo with running CI no longer drags every other repo
+/// onto the fast cadence.
+fn select_github_polls(
+    projects: &[(String, String)],
+    visible_ids: &HashSet<String>,
+    schedule: &GithubPollSchedule,
+    pr_infos: &HashMap<String, Option<git::PrInfo>>,
+    cycle: u64,
+    cadence_due: bool,
+) -> Vec<ProjectPoll> {
+    projects
+        .iter()
+        .filter(|(id, _)| visible_ids.contains(id) || schedule.is_urgent(id))
+        .filter_map(|(id, path)| {
+            let want_pr = schedule.pr_due(id, cycle, cadence_due);
+            let want_ci = schedule.ci_due(id, cycle, cadence_due);
+            (want_pr || want_ci).then(|| ProjectPoll {
+                id: id.clone(),
+                path: path.clone(),
+                want_pr,
+                want_ci,
+                ci_skip_sha: schedule.ci_skip_sha(id, cycle),
+                cached_pr_number: pr_infos
+                    .get(id)
+                    .and_then(|pr| pr.as_ref())
+                    .map(|pr| pr.number),
+            })
+        })
+        .collect()
+}
+
+/// What one project's `gh` slot produced.
+struct ProjectOutcome {
+    pr: Option<PrFetch>,
+    ci: Option<CiFetch>,
+}
+
+/// Run one project's PR and CI lookups back to back on a bus worker.
+///
+/// Paired rather than run as two separate passes so the CI call can use the PR
+/// number this pass just fetched, and so a project costs one blocking task
+/// instead of two.
+fn poll_one_project(poll: &ProjectPoll) -> ProjectOutcome {
+    with_lane(Lane::Poll, || {
+        let path = Path::new(&poll.path);
+        // Repos with no GitHub remote can never have PRs or checks; skipping
+        // them here keeps the whole `gh` machinery off non-GitHub projects.
+        if !git::repository::has_github_remote(path) {
+            return ProjectOutcome {
+                pr: poll.want_pr.then_some(PrFetch::Fetched(None)),
+                ci: poll.want_ci.then_some(CiFetch::Fetched {
+                    sha: None,
+                    summary: None,
+                }),
+            };
+        }
+
+        let pr = poll.want_pr.then(|| git::repository::fetch_pr_info(path));
+        let pr_number = match &pr {
+            Some(PrFetch::Fetched(info)) => info.as_ref().map(|info| info.number),
+            _ => poll.cached_pr_number,
+        };
+
+        // A rate-limited PR call means the CI call would only be refused too.
+        let ci = if matches!(pr, Some(PrFetch::RateLimited)) {
+            None
+        } else {
+            poll.want_ci.then(|| {
+                git::repository::fetch_ci_checks(path, pr_number, poll.ci_skip_sha.as_deref())
+            })
+        };
+
+        ProjectOutcome { pr, ci }
+    })
+}
+
 async fn poll_github(
-    projects: Vec<(String, String)>,
-    pr_poll_ids: HashSet<String>,
-    ci_poll_ids: HashSet<String>,
-    cached_pr_infos: HashMap<String, Option<git::PrInfo>>,
+    polls: Vec<ProjectPoll>,
     head_generations: HashMap<String, u64>,
     branches: HashMap<String, Option<String>>,
 ) -> GithubPollResult {
     let mut pr_infos = HashMap::new();
-    let mut ci_checks = HashMap::new();
+    let mut ci = HashMap::new();
+    let mut rate_limited = false;
+    let mut reached_github = false;
 
-    for (id, path) in &projects {
-        if !pr_poll_ids.contains(id) {
-            continue;
-        }
-        let task_id = id.clone();
-        let path = path.clone();
-        let fetched = tokio::task::spawn_blocking(move || {
-            with_lane(Lane::Poll, || {
-                if !git::repository::has_github_remote(Path::new(&path)) {
-                    return None;
-                }
-                git::repository::get_pr_info(Path::new(&path))
-            })
-        })
-        .await;
-        match fetched {
-            Ok(pr) => {
-                pr_infos.insert(task_id, pr);
-            }
-            Err(error) => log::warn!("gh PR info task failed for {task_id}: {error}"),
-        }
+    let permits = Arc::new(Semaphore::new(GH_FANOUT_CONCURRENCY));
+    let mut tasks = tokio::task::JoinSet::new();
+    for poll in polls {
+        let permits = permits.clone();
+        tasks.spawn(async move {
+            // Bounded so a large workspace doesn't queue dozens of blocking
+            // tasks that all end up waiting on the same four bus workers.
+            let _permit = permits.acquire_owned().await;
+            let id = poll.id.clone();
+            let outcome = tokio::task::spawn_blocking(move || poll_one_project(&poll)).await;
+            (id, outcome)
+        });
     }
 
-    for (id, path) in &projects {
-        if !ci_poll_ids.contains(id) {
+    while let Some(joined) = tasks.join_next().await {
+        let Ok((id, outcome)) = joined else {
             continue;
-        }
-        let task_id = id.clone();
-        let path = path.clone();
-        let pr_number = pr_infos
-            .get(id)
-            .or_else(|| cached_pr_infos.get(id))
-            .and_then(|pr| pr.as_ref())
-            .map(|pr| pr.number);
-        let fetched = tokio::task::spawn_blocking(move || {
-            with_lane(Lane::Poll, || {
-                if !git::repository::has_github_remote(Path::new(&path)) {
-                    return None;
-                }
-                git::repository::get_ci_checks(Path::new(&path), pr_number)
-            })
-        })
-        .await;
-        match fetched {
-            Ok(checks) => {
-                ci_checks.insert(task_id, checks);
+        };
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                log::warn!("gh poll task failed for {id}: {error}");
+                continue;
             }
-            Err(error) => log::warn!("gh CI checks task failed for {task_id}: {error}"),
+        };
+
+        match outcome.pr {
+            Some(PrFetch::Fetched(info)) => {
+                reached_github = true;
+                pr_infos.insert(id.clone(), info);
+            }
+            Some(PrFetch::RateLimited) => rate_limited = true,
+            None => {}
+        }
+        match outcome.ci {
+            Some(CiFetch::RateLimited) => rate_limited = true,
+            Some(fetch) => {
+                reached_github |= matches!(fetch, CiFetch::Fetched { .. });
+                ci.insert(id, fetch);
+            }
+            None => {}
         }
     }
 
@@ -315,25 +421,43 @@ async fn poll_github(
         head_generations,
         branches,
         pr_infos,
-        ci_checks,
+        ci,
+        rate_limited,
+        reached_github,
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn apply_github_result(
     result: GithubPollResult,
+    cycle: u64,
     current_head_generations: &HashMap<String, u64>,
+    schedule: &mut GithubPollSchedule,
     pr_infos: &mut HashMap<String, Option<git::PrInfo>>,
     ci_checks: &mut HashMap<String, Option<git::CiCheckSummary>>,
     last: &mut HashMap<String, GitStatus>,
     git_status_tx: &watch::Sender<HashMap<String, ApiGitStatus>>,
     state_version: &watch::Sender<u64>,
-) -> bool {
+) {
     let GithubPollResult {
         head_generations,
         branches,
         pr_infos: fetched_pr_infos,
-        ci_checks: fetched_ci_checks,
+        ci: fetched_ci,
+        rate_limited,
+        reached_github,
     } = result;
+
+    if rate_limited {
+        schedule.note_rate_limited(cycle);
+        log::warn!(
+            "GitHub API rate limit hit; PR/CI polling paused for {} cycles",
+            schedule.rate_limit_backoff_cycles()
+        );
+    } else if reached_github {
+        schedule.note_request_succeeded();
+    }
+
     let is_current = |id: &str| {
         let expected_generation = head_generations.get(id).copied().unwrap_or_default();
         let current_generation = current_head_generations
@@ -347,12 +471,25 @@ fn apply_github_result(
 
     for (id, pr_info) in fetched_pr_infos {
         if is_current(&id) {
+            schedule.record_pr(&id, cycle);
             pr_infos.insert(id, pr_info);
         }
     }
-    for (id, checks) in fetched_ci_checks {
-        if is_current(&id) {
-            ci_checks.insert(id, checks);
+    for (id, fetch) in fetched_ci {
+        if !is_current(&id) {
+            continue;
+        }
+        match fetch {
+            CiFetch::Unchanged => schedule.record_ci_unchanged(&id, cycle),
+            CiFetch::Fetched { sha, summary } => {
+                let pending = summary
+                    .as_ref()
+                    .is_some_and(|summary| summary.status.is_pending());
+                schedule.record_ci(&id, cycle, pending, sha);
+                ci_checks.insert(id, summary);
+            }
+            // Refusals never make it this far — they set `rate_limited` instead.
+            CiFetch::RateLimited => {}
         }
     }
 
@@ -362,7 +499,6 @@ fn apply_github_result(
         status.ci_checks = ci_checks.get(id).cloned().flatten();
     }
     publish(last, &enriched, git_status_tx, state_version);
-    has_pending_ci(ci_checks)
 }
 
 /// Run the daemon git-status poll loop until the `watch` channel is closed (all
@@ -397,12 +533,16 @@ pub async fn run_git_poll(
     // project that drops out of the visible set keeps its last-known PR/CI.
     let mut pr_infos: HashMap<String, Option<git::PrInfo>> = HashMap::new();
     let mut ci_checks: HashMap<String, Option<git::CiCheckSummary>> = HashMap::new();
-    // Drives the adaptive CI cadence: faster polling while any check is pending.
-    let mut any_pending_ci = false;
+    // Per-project `gh` cadence, commit-level result caching and the rate-limit
+    // gate. Replaces the old global "is anything pending?" flag, which put every
+    // project on the fast cadence as soon as one repo had CI running.
+    let mut schedule = GithubPollSchedule::default();
+    // A `gh` pass is running. Passes used to be spawned unconditionally, so a
+    // fan-out slower than its own cadence stacked copies of itself.
+    let mut github_in_flight = false;
     let mut cycle: u64 = 0;
     let mut trigger_acc = TriggerAccumulator::default();
-    let mut known_gh_ids: HashSet<String> = HashSet::new();
-    let mut known_relevant_ids: HashSet<String> = HashSet::new();
+    let mut known_streaming_ids: HashSet<String> = HashSet::new();
     let mut trigger_rx_closed = false;
     let mut head_generations: HashMap<String, u64> = HashMap::new();
     let (github_result_tx, mut github_result_rx) = mpsc::unbounded_channel();
@@ -415,75 +555,66 @@ pub async fn run_git_poll(
 
     loop {
         drain_git_poll_triggers(&mut trigger_rx, &mut trigger_acc, &mut trigger_rx_closed);
-        let mut github_cache_changed = false;
         for id in &trigger_acc.head_change_ids {
+            // Bump the generation so in-flight results for the old commit are
+            // discarded. The cached CI summary is deliberately *not* dropped:
+            // checks belong to the last pushed commit, which a local commit
+            // doesn't move — and dropping it both blanked the badge and forced
+            // a refetch on every commit.
             *head_generations.entry(id.clone()).or_default() += 1;
-            github_cache_changed |= ci_checks.remove(id).is_some();
         }
-        github_cache_changed |= clear_github_cache_for_ids(
+        clear_github_cache_for_ids(
             &trigger_acc.invalidate_gh_ids,
             &mut pr_infos,
             &mut ci_checks,
         );
-        if github_cache_changed {
-            any_pending_ci = has_pending_ci(&ci_checks);
-        }
 
         // ── 1. Snapshot relevance and choose this cycle's local work ─────────
-        let (projects, relevant_ids): (Vec<(String, String)>, HashSet<String>) = {
+        let (projects, visible_ids, streaming_ids) = {
             let workspace = workspace.lock();
-            let relevant = relevant_project_ids(&workspace, &remote_subscribed_terminals);
-            let projects = workspace
+            let visible = visible_project_ids(&workspace);
+            let streaming = streaming_project_ids(&workspace, &remote_subscribed_terminals);
+            let projects: Vec<(String, String)> = workspace
                 .projects()
                 .iter()
                 .filter(|project| !project.is_remote)
                 .map(|project| (project.id.clone(), project.path.clone()))
                 .collect();
-            (projects, relevant)
+            (projects, visible, streaming)
         };
         let active_ids: HashSet<String> = projects.iter().map(|(id, _)| id.clone()).collect();
         pr_infos.retain(|id, _| active_ids.contains(id));
         ci_checks.retain(|id, _| active_ids.contains(id));
         head_generations.retain(|id, _| active_ids.contains(id));
-        known_gh_ids.retain(|id| active_ids.contains(id));
-        known_relevant_ids.retain(|id| active_ids.contains(id));
+        known_streaming_ids.retain(|id| active_ids.contains(id));
+        schedule.retain(&active_ids);
 
-        let newly_relevant_ids: HashSet<String> = relevant_ids
-            .difference(&known_relevant_ids)
+        let newly_relevant_ids: HashSet<String> = streaming_ids
+            .difference(&known_streaming_ids)
             .cloned()
             .collect();
-        known_relevant_ids = relevant_ids.clone();
+        known_streaming_ids = streaming_ids.clone();
         let forced_local_ids = trigger_acc.local_status_ids();
         let poll_hidden =
             cycle == 0 || (cadence_due && cycle.is_multiple_of(HIDDEN_GIT_POLL_EVERY_N_CYCLES));
         let status_poll_ids = select_status_poll_ids(
             &active_ids,
-            &relevant_ids,
+            &streaming_ids,
             &forced_local_ids,
             &newly_relevant_ids,
             cadence_due,
             poll_hidden,
         );
 
-        // `gh` stays limited to relevant/explicit projects independently of the
-        // slower hidden local-status fallback.
-        let mut gh_ids = relevant_ids;
-        gh_ids.extend(trigger_acc.force_gh_ids.iter().cloned());
-        gh_ids.extend(trigger_acc.candidate_gh_ids.iter().cloned());
-        if cycle != 0 || !known_gh_ids.is_empty() {
-            trigger_acc.force_gh_ids.extend(missing_github_stats_ids(
-                gh_ids.difference(&known_gh_ids),
-                &pr_infos,
-                &ci_checks,
-            ));
+        // Explicit actions steer the `gh` schedule: a branch switch invalidates
+        // what we hold, while merely showing a project is only worth a fetch
+        // when it has never been fetched at all.
+        for id in &trigger_acc.invalidate_gh_ids {
+            schedule.force(id);
         }
-        trigger_acc.force_gh_ids.extend(missing_github_stats_ids(
-            trigger_acc.candidate_gh_ids.iter(),
-            &pr_infos,
-            &ci_checks,
-        ));
-        gh_ids.extend(trigger_acc.force_gh_ids.iter().cloned());
-        known_gh_ids = gh_ids.clone();
+        for id in &trigger_acc.candidate_gh_ids {
+            schedule.force_if_unfetched(id);
+        }
 
         // ── 2. Refresh selected statuses and merge into the published cache ──
         let mut attempted: HashMap<String, Option<GitStatus>> = HashMap::new();
@@ -519,44 +650,21 @@ pub async fn run_git_poll(
             .iter()
             .filter_map(|(id, status)| status.is_none().then_some(id.clone()))
             .collect();
-        if clear_github_cache_for_ids(&missing_status_ids, &mut pr_infos, &mut ci_checks) {
-            any_pending_ci = has_pending_ci(&ci_checks);
-        }
+        clear_github_cache_for_ids(&missing_status_ids, &mut pr_infos, &mut ci_checks);
         let mut new_statuses = merge_status_results(&last, &active_ids, attempted);
 
         let branch_changes = branch_changed_ids(&last, &new_statuses);
         if !branch_changes.is_empty() {
-            if clear_github_cache_for_ids(&branch_changes, &mut pr_infos, &mut ci_checks) {
-                any_pending_ci = has_pending_ci(&ci_checks);
-            }
+            clear_github_cache_for_ids(&branch_changes, &mut pr_infos, &mut ci_checks);
             for id in &branch_changes {
                 if let Some(status) = new_statuses.get_mut(id) {
                     status.pr_info = None;
                     status.ci_checks = None;
                 }
+                // Cached PR/CI described the branch we just left.
+                schedule.force(id);
             }
-            trigger_acc
-                .force_gh_ids
-                .extend(branch_changes.iter().cloned());
-            gh_ids.extend(branch_changes);
         }
-
-        // Skip the cycle-0 `gh` fan-out unless something explicitly forced it:
-        // startup still gets basic gix status immediately without a `gh` herd.
-        let ci_poll_interval = if any_pending_ci {
-            CI_PENDING_POLL_EVERY_N_CYCLES
-        } else {
-            CI_SETTLED_POLL_EVERY_N_CYCLES
-        };
-        let pr_cadence = cadence_due
-            && (cycle == 1 || (cycle != 0 && cycle.is_multiple_of(PR_POLL_EVERY_N_CYCLES)));
-        let ci_cadence =
-            cadence_due && (cycle == 1 || (cycle != 0 && cycle.is_multiple_of(ci_poll_interval)));
-        let force_gh = !trigger_acc.force_gh_ids.is_empty();
-        let check_prs = force_gh || pr_cadence;
-        let check_ci = force_gh || ci_cadence;
-        let pr_poll_ids = gh_poll_ids(&gh_ids, &trigger_acc.force_gh_ids, force_gh, pr_cadence);
-        let ci_poll_ids = gh_poll_ids(&gh_ids, &trigger_acc.force_gh_ids, force_gh, ci_cadence);
 
         // ── 3. Publish the basic status map on change — BEFORE the slow `gh` ──
         // git status comes from gix (fast, in-process); PR/CI come from `gh`
@@ -566,38 +674,67 @@ pub async fn run_git_poll(
 
         // Stop once every external `watch` receiver is gone (the server is down).
         if git_status_tx.is_closed() {
+            log::trace!("git poll loop exiting: no status receivers left");
             return;
         }
 
         // ── 4. Start `gh` PR/CI fan-out without blocking local git refreshes ─
-        if check_prs || check_ci {
-            let result_tx = github_result_tx.clone();
-            let poll_generations = projects
-                .iter()
-                .map(|(id, _)| {
-                    (
-                        id.clone(),
-                        head_generations.get(id).copied().unwrap_or_default(),
-                    )
-                })
-                .collect();
-            let poll_branches = new_statuses
-                .iter()
-                .map(|(id, status)| (id.clone(), status.branch.clone()))
-                .collect();
-            let cached_pr_infos = pr_infos.clone();
-            tokio::spawn(async move {
-                let result = poll_github(
-                    projects,
-                    pr_poll_ids,
-                    ci_poll_ids,
-                    cached_pr_infos,
-                    poll_generations,
-                    poll_branches,
-                )
-                .await;
-                let _ = result_tx.send(result);
-            });
+        // Only visible projects (plus anything explicitly asked for) and only
+        // while no pass is already running and GitHub isn't refusing us.
+        if !github_in_flight && !schedule.is_rate_limited(cycle) {
+            let polls = select_github_polls(
+                &projects,
+                &visible_ids,
+                &schedule,
+                &pr_infos,
+                cycle,
+                cadence_due,
+            );
+
+            log::trace!(
+                "gh poll cycle={cycle}: {} projects, {} visible, {} due",
+                projects.len(),
+                visible_ids.len(),
+                polls.len()
+            );
+            if !polls.is_empty() {
+                // Push each project's next due cycle forward before the pass
+                // leaves, so the cycles it spans don't queue it again.
+                for poll in &polls {
+                    if poll.want_pr {
+                        schedule.pr_dispatched(&poll.id, cycle);
+                    }
+                    if poll.want_ci {
+                        schedule.ci_dispatched(&poll.id, cycle);
+                    }
+                }
+                let poll_generations = polls
+                    .iter()
+                    .map(|poll| {
+                        (
+                            poll.id.clone(),
+                            head_generations.get(&poll.id).copied().unwrap_or_default(),
+                        )
+                    })
+                    .collect();
+                let poll_branches = polls
+                    .iter()
+                    .map(|poll| {
+                        (
+                            poll.id.clone(),
+                            new_statuses
+                                .get(&poll.id)
+                                .and_then(|status| status.branch.clone()),
+                        )
+                    })
+                    .collect();
+                let result_tx = github_result_tx.clone();
+                github_in_flight = true;
+                tokio::spawn(async move {
+                    let result = poll_github(polls, poll_generations, poll_branches).await;
+                    let _ = result_tx.send(result);
+                });
+            }
         }
 
         trigger_acc.clear();
@@ -622,9 +759,12 @@ pub async fn run_git_poll(
                     }
                 }
                 Some(result) = github_result_rx.recv() => {
-                    any_pending_ci = apply_github_result(
+                    github_in_flight = false;
+                    apply_github_result(
                         result,
+                        cycle,
                         &head_generations,
+                        &mut schedule,
                         &mut pr_infos,
                         &mut ci_checks,
                         &mut last,
@@ -659,24 +799,6 @@ fn drain_git_poll_triggers(
     }
 }
 
-fn missing_github_stats(
-    id: &str,
-    pr_infos: &HashMap<String, Option<git::PrInfo>>,
-    ci_checks: &HashMap<String, Option<git::CiCheckSummary>>,
-) -> bool {
-    !(pr_infos.contains_key(id) && ci_checks.contains_key(id))
-}
-
-fn missing_github_stats_ids<'a>(
-    ids: impl Iterator<Item = &'a String>,
-    pr_infos: &HashMap<String, Option<git::PrInfo>>,
-    ci_checks: &HashMap<String, Option<git::CiCheckSummary>>,
-) -> HashSet<String> {
-    ids.filter(|id| missing_github_stats(id, pr_infos, ci_checks))
-        .cloned()
-        .collect()
-}
-
 fn branch_changed_ids(
     last: &HashMap<String, GitStatus>,
     new_statuses: &HashMap<String, GitStatus>,
@@ -695,32 +817,10 @@ fn clear_github_cache_for_ids(
     ids: &HashSet<String>,
     pr_infos: &mut HashMap<String, Option<git::PrInfo>>,
     ci_checks: &mut HashMap<String, Option<git::CiCheckSummary>>,
-) -> bool {
-    let mut changed = false;
+) {
     for id in ids {
-        changed |= pr_infos.remove(id).is_some();
-        changed |= ci_checks.remove(id).is_some();
-    }
-    changed
-}
-
-fn has_pending_ci(ci_checks: &HashMap<String, Option<git::CiCheckSummary>>) -> bool {
-    ci_checks
-        .values()
-        .any(|c| c.as_ref().map(|s| s.status.is_pending()).unwrap_or(false))
-}
-
-fn gh_poll_ids(
-    gh_ids: &HashSet<String>,
-    forced_gh_ids: &HashSet<String>,
-    force_gh: bool,
-    cadence: bool,
-) -> HashSet<String> {
-    match (force_gh, cadence) {
-        (true, true) => gh_ids.clone(),
-        (true, false) => forced_gh_ids.clone(),
-        (false, true) => gh_ids.clone(),
-        (false, false) => HashSet::new(),
+        pr_infos.remove(id);
+        ci_checks.remove(id);
     }
 }
 
@@ -781,30 +881,6 @@ mod tests {
     }
 
     #[test]
-    fn forced_gh_poll_ids_are_targeted_between_cadence_cycles() {
-        let gh_ids: HashSet<String> = ["visible-a".to_string(), "visible-b".to_string()]
-            .into_iter()
-            .collect();
-        let forced: HashSet<String> = ["switched".to_string()].into_iter().collect();
-
-        assert_eq!(gh_poll_ids(&gh_ids, &forced, true, false), forced);
-    }
-
-    #[test]
-    fn missing_github_stats_requires_both_cache_slots() {
-        let mut prs = HashMap::new();
-        let mut checks = HashMap::new();
-
-        assert!(missing_github_stats("p1", &prs, &checks));
-
-        prs.insert("p1".to_string(), None);
-        assert!(missing_github_stats("p1", &prs, &checks));
-
-        checks.insert("p1".to_string(), None);
-        assert!(!missing_github_stats("p1", &prs, &checks));
-    }
-
-    #[test]
     fn branch_changed_ids_only_reports_existing_branch_changes() {
         let mut last = HashMap::new();
         last.insert(
@@ -854,13 +930,12 @@ mod tests {
         let mut prs = HashMap::from([("p1".to_string(), None), ("p2".to_string(), None)]);
         let mut checks = HashMap::from([("p1".to_string(), None), ("p3".to_string(), None)]);
 
-        let changed = clear_github_cache_for_ids(
+        clear_github_cache_for_ids(
             &HashSet::from(["p1".to_string(), "missing".to_string()]),
             &mut prs,
             &mut checks,
         );
 
-        assert!(changed);
         assert!(!prs.contains_key("p1"));
         assert!(prs.contains_key("p2"));
         assert!(!checks.contains_key("p1"));
@@ -993,59 +1068,227 @@ mod tests {
         assert_eq!(changed, vec!["hidden".to_string()]);
     }
 
-    #[test]
-    fn github_results_apply_only_to_the_captured_head() {
-        let (git_status_tx, _rx) = watch::channel(HashMap::new());
-        let (state_version, _state_rx) = watch::channel(0);
-        let mut last = HashMap::from([(
-            "p1".to_string(),
-            GitStatus {
-                branch: Some("main".to_string()),
-                ..GitStatus::default()
-            },
-        )]);
-        let mut pr_infos = HashMap::new();
-        let mut ci_checks = HashMap::new();
-        let current_generations = HashMap::from([("p1".to_string(), 2)]);
-
-        let result = |generation, branch: &str| GithubPollResult {
+    /// Build an `apply_github_result` fixture: one project, one CI outcome.
+    fn github_result(generation: u64, branch: &str, ci: CiFetch) -> GithubPollResult {
+        GithubPollResult {
             head_generations: HashMap::from([("p1".to_string(), generation)]),
             branches: HashMap::from([("p1".to_string(), Some(branch.to_string()))]),
             pr_infos: HashMap::from([("p1".to_string(), None)]),
-            ci_checks: HashMap::from([("p1".to_string(), None)]),
-        };
+            ci: HashMap::from([("p1".to_string(), ci)]),
+            rate_limited: false,
+            reached_github: true,
+        }
+    }
 
-        apply_github_result(
-            result(1, "main"),
-            &current_generations,
-            &mut pr_infos,
-            &mut ci_checks,
-            &mut last,
-            &git_status_tx,
-            &state_version,
-        );
-        apply_github_result(
-            result(2, "feature"),
-            &current_generations,
-            &mut pr_infos,
-            &mut ci_checks,
-            &mut last,
-            &git_status_tx,
-            &state_version,
-        );
-        assert!(!pr_infos.contains_key("p1"));
-        assert!(!ci_checks.contains_key("p1"));
+    fn fetched(sha: &str) -> CiFetch {
+        CiFetch::Fetched {
+            sha: Some(sha.to_string()),
+            summary: None,
+        }
+    }
 
-        apply_github_result(
-            result(2, "main"),
+    struct ApplyHarness {
+        schedule: GithubPollSchedule,
+        pr_infos: HashMap<String, Option<git::PrInfo>>,
+        ci_checks: HashMap<String, Option<git::CiCheckSummary>>,
+        last: HashMap<String, GitStatus>,
+        git_status_tx: watch::Sender<HashMap<String, ApiGitStatus>>,
+        state_version: watch::Sender<u64>,
+        _rx: watch::Receiver<HashMap<String, ApiGitStatus>>,
+        _state_rx: watch::Receiver<u64>,
+    }
+
+    impl ApplyHarness {
+        fn new() -> Self {
+            let (git_status_tx, _rx) = watch::channel(HashMap::new());
+            let (state_version, _state_rx) = watch::channel(0);
+            Self {
+                schedule: GithubPollSchedule::default(),
+                pr_infos: HashMap::new(),
+                ci_checks: HashMap::new(),
+                last: HashMap::from([(
+                    "p1".to_string(),
+                    GitStatus {
+                        branch: Some("main".to_string()),
+                        ..GitStatus::default()
+                    },
+                )]),
+                git_status_tx,
+                state_version,
+                _rx,
+                _state_rx,
+            }
+        }
+
+        fn apply(
+            &mut self,
+            result: GithubPollResult,
+            cycle: u64,
+            generations: &HashMap<String, u64>,
+        ) {
+            apply_github_result(
+                result,
+                cycle,
+                generations,
+                &mut self.schedule,
+                &mut self.pr_infos,
+                &mut self.ci_checks,
+                &mut self.last,
+                &self.git_status_tx,
+                &self.state_version,
+            );
+        }
+    }
+
+    #[test]
+    fn github_results_apply_only_to_the_captured_head() {
+        let mut harness = ApplyHarness::new();
+        let current_generations = HashMap::from([("p1".to_string(), 2)]);
+
+        harness.apply(
+            github_result(1, "main", fetched("abc")),
+            5,
             &current_generations,
-            &mut pr_infos,
-            &mut ci_checks,
-            &mut last,
-            &git_status_tx,
-            &state_version,
         );
-        assert!(pr_infos.contains_key("p1"));
-        assert!(ci_checks.contains_key("p1"));
+        harness.apply(
+            github_result(2, "feature", fetched("abc")),
+            5,
+            &current_generations,
+        );
+        assert!(!harness.pr_infos.contains_key("p1"));
+        assert!(!harness.ci_checks.contains_key("p1"));
+
+        harness.apply(
+            github_result(2, "main", fetched("abc")),
+            5,
+            &current_generations,
+        );
+        assert!(harness.pr_infos.contains_key("p1"));
+        assert!(harness.ci_checks.contains_key("p1"));
+    }
+
+    #[test]
+    fn settled_result_arms_the_commit_skip_for_the_next_poll() {
+        let mut harness = ApplyHarness::new();
+        let generations = HashMap::from([("p1".to_string(), 0)]);
+
+        harness.apply(github_result(0, "main", fetched("abc")), 5, &generations);
+
+        assert_eq!(
+            harness.schedule.ci_skip_sha("p1", 6).as_deref(),
+            Some("abc")
+        );
+        // Settled → back on the slow cadence, not the pending one.
+        assert!(!harness.schedule.ci_due("p1", 10, true));
+        assert!(harness.schedule.ci_due("p1", 17, true));
+    }
+
+    #[test]
+    fn a_skipped_fetch_keeps_the_cached_summary() {
+        let mut harness = ApplyHarness::new();
+        let generations = HashMap::from([("p1".to_string(), 0)]);
+        harness.ci_checks.insert(
+            "p1".to_string(),
+            Some(git::CiCheckSummary {
+                status: git::CiStatus::Success,
+                passed: 1,
+                failed: 0,
+                pending: 0,
+                total: 1,
+                checks: Vec::new(),
+            }),
+        );
+
+        harness.apply(
+            github_result(0, "main", CiFetch::Unchanged),
+            5,
+            &generations,
+        );
+
+        assert!(
+            harness.ci_checks.get("p1").is_some_and(Option::is_some),
+            "an unchanged commit must not blank the badge"
+        );
+    }
+
+    fn projects() -> Vec<(String, String)> {
+        vec![
+            ("visible".to_string(), "/tmp/visible".to_string()),
+            ("hidden".to_string(), "/tmp/hidden".to_string()),
+        ]
+    }
+
+    #[test]
+    fn hidden_projects_never_earn_a_gh_slot() {
+        let visible = HashSet::from(["visible".to_string()]);
+        let schedule = GithubPollSchedule::default();
+
+        let polls = select_github_polls(&projects(), &visible, &schedule, &HashMap::new(), 1, true);
+
+        assert_eq!(polls.len(), 1);
+        assert_eq!(polls[0].id, "visible");
+    }
+
+    #[test]
+    fn an_explicit_request_reaches_a_hidden_project() {
+        let visible = HashSet::new();
+        let mut schedule = GithubPollSchedule::default();
+        schedule.force("hidden");
+
+        // Off-cadence too: an explicit action shouldn't wait for the next tick.
+        let polls =
+            select_github_polls(&projects(), &visible, &schedule, &HashMap::new(), 4, false);
+
+        assert_eq!(polls.len(), 1);
+        assert_eq!(polls[0].id, "hidden");
+    }
+
+    #[test]
+    fn a_settled_project_carries_its_commit_so_the_fetch_can_be_skipped() {
+        let visible = HashSet::from(["visible".to_string()]);
+        let mut schedule = GithubPollSchedule::default();
+        schedule.record_pr("visible", 1);
+        schedule.record_ci("visible", 1, false, Some("abc".to_string()));
+
+        // Nothing due yet on the settled cadence…
+        assert!(
+            select_github_polls(&projects(), &visible, &schedule, &HashMap::new(), 5, true)
+                .is_empty()
+        );
+
+        // …and when it is, the cached commit rides along.
+        let polls =
+            select_github_polls(&projects(), &visible, &schedule, &HashMap::new(), 13, true);
+        assert_eq!(polls.len(), 1);
+        assert_eq!(polls[0].ci_skip_sha.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn one_busy_repo_does_not_speed_up_the_others() {
+        let visible = HashSet::from(["visible".to_string(), "hidden".to_string()]);
+        let mut schedule = GithubPollSchedule::default();
+        schedule.record_pr("visible", 1);
+        schedule.record_pr("hidden", 1);
+        schedule.record_ci("visible", 1, true, None); // CI running
+        schedule.record_ci("hidden", 1, false, Some("abc".to_string())); // settled
+
+        let polls = select_github_polls(&projects(), &visible, &schedule, &HashMap::new(), 4, true);
+
+        assert_eq!(polls.len(), 1, "only the repo with running CI is due");
+        assert_eq!(polls[0].id, "visible");
+        assert!(polls[0].want_ci && !polls[0].want_pr);
+    }
+
+    #[test]
+    fn rate_limited_pass_parks_further_polling() {
+        let mut harness = ApplyHarness::new();
+        let generations = HashMap::from([("p1".to_string(), 0)]);
+        let mut result = github_result(0, "main", fetched("abc"));
+        result.rate_limited = true;
+        result.reached_github = false;
+
+        harness.apply(result, 5, &generations);
+
+        assert!(harness.schedule.is_rate_limited(6));
     }
 }

--- a/crates/okena-git/CLAUDE.md
+++ b/crates/okena-git/CLAUDE.md
@@ -12,7 +12,7 @@ Git status, diff parsing, and worktree operations for project directories.
 | `repository/worktree.rs` | Worktree ops — `create_worktree`, `create_worktree_with_start_point`, `remove_worktree`, `remove_worktree_fast`, `list_git_worktrees`, stale-dir cleanup. |
 | `repository/branch.rs` | Branch ops — list/classify (`BranchList`), checkout/create/delete/push, `get_default_branch`, rebase, merge, stash, per-file stage/unstage/discard. |
 | `repository/status.rs` | Working-tree status & diff stats — `StatusFetch`, `get_status`, `has_uncommitted_changes`, `get_current_branch`, `get_head_sha`, diff-stats, ahead/behind & unpushed counts. |
-| `repository/ci.rs` | CI/PR integration — `get_pr_info`, `get_ci_checks`, and the pure, unit-tested parsers `parse_ci_checks` / `parse_branch_ci`. |
+| `repository/ci.rs` | CI/PR integration — `fetch_pr_info`, `fetch_ci_checks`, and the pure, unit-tested parsers `parse_ci_checks` / `parse_branch_ci`. Both return `PrFetch`/`CiFetch` so callers can tell "no PR / no checks" from a rate-limit refusal; `fetch_ci_checks` skips the request entirely while the upstream commit still matches a settled cached result. |
 | `repository/paths.rs` | Path utilities — `get_repo_root`, `normalize_path`, `resolve_git_root_and_subdir`, `project_path_in_worktree`, `compute_target_paths`. |
 | `branch_names.rs` | Branch name utilities and validation. |
 

--- a/crates/okena-git/src/repository/ci.rs
+++ b/crates/okena-git/src/repository/ci.rs
@@ -17,6 +17,42 @@ use super::status::get_pushed_sha;
 /// elapses so one stuck repo can never wedge the git-status loop.
 const GH_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// Outcome of a PR lookup. `RateLimited` is kept distinct from "no PR" so the
+/// poller can park its whole `gh` fan-out instead of hammering a closed door.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrFetch {
+    Fetched(Option<crate::PrInfo>),
+    RateLimited,
+}
+
+/// Outcome of a CI lookup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CiFetch {
+    /// The upstream commit still matches the caller's cached result, so nothing
+    /// was requested and the cached summary stays valid.
+    Unchanged,
+    /// A request ran. `sha` is the upstream commit the summary describes, used
+    /// to skip the next fetch while it holds.
+    Fetched {
+        sha: Option<String>,
+        summary: Option<crate::CiCheckSummary>,
+    },
+    RateLimited,
+}
+
+/// Whether a failed `gh` invocation failed because GitHub is rate-limiting us.
+///
+/// `gh` surfaces both the primary hourly limit ("API rate limit exceeded") and
+/// the secondary abuse limit ("exceeded a secondary rate limit") on stderr; a
+/// plain substring match covers the REST and GraphQL wordings alike.
+fn is_rate_limited(output: &std::process::Output) -> bool {
+    if output.status.success() {
+        return false;
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+    stderr.contains("rate limit")
+}
+
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct GhPullRequest {
@@ -108,9 +144,13 @@ pub fn has_github_remote(path: &Path) -> bool {
 /// lives (a fork/upstream split) it reports "no pull requests found" even when
 /// a PR exists. `gh pr list --head` matches by head branch name in the default
 /// repo, which resolves correctly in that setup.
-pub fn get_pr_info(path: &Path) -> Option<crate::PrInfo> {
-    let path_str = path.to_str()?;
-    let branch = super::status::get_current_branch(path)?;
+pub fn fetch_pr_info(path: &Path) -> PrFetch {
+    let Some(path_str) = path.to_str() else {
+        return PrFetch::Fetched(None);
+    };
+    let Some(branch) = super::status::get_current_branch(path) else {
+        return PrFetch::Fetched(None);
+    };
     let current_sha = super::status::get_head_sha(path);
     let pushed_sha = get_pushed_sha(path);
 
@@ -132,15 +172,24 @@ pub fn get_pr_info(path: &Path) -> Option<crate::PrInfo> {
             ])
             .current_dir(path_str),
         GH_TIMEOUT,
-    )
-    .ok()?;
+    );
+    let Ok(output) = output else {
+        return PrFetch::Fetched(None);
+    };
 
+    if is_rate_limited(&output) {
+        return PrFetch::RateLimited;
+    }
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
-        return parse_pr_list_tsv(stdout.trim(), current_sha.as_deref(), pushed_sha.as_deref());
+        return PrFetch::Fetched(parse_pr_list_tsv(
+            stdout.trim(),
+            current_sha.as_deref(),
+            pushed_sha.as_deref(),
+        ));
     }
 
-    None
+    PrFetch::Fetched(None)
 }
 
 /// Parse the single TSV line our `gh pr list --jq ... | @tsv` query emits into a
@@ -326,20 +375,41 @@ pub(crate) fn parse_ci_checks(json_str: &str) -> Option<crate::CiCheckSummary> {
 /// fetching `check-runs` + `status` on the current HEAD commit via `gh api`,
 /// which works for any pushed branch — including default branches without a PR.
 ///
-/// Returns `None` when there are no checks, when `gh` isn't installed /
+/// `unchanged_sha` is the upstream commit a *settled* cached summary describes.
+/// Checks on a given commit only move while something is running, so when the
+/// branch still points at that commit the whole lookup is skipped — no `gh`, no
+/// request. This is what keeps a machine with many projects inside GitHub's
+/// hourly budget: a repo parked on `main` costs one cheap local ref read per
+/// poll instead of two REST calls.
+///
+/// Returns `Fetched(None)` when there are no checks, when `gh` isn't installed /
 /// authenticated, or when the repo has no GitHub remote.
-pub fn get_ci_checks(path: &Path, pr_number: Option<u32>) -> Option<crate::CiCheckSummary> {
+pub fn fetch_ci_checks(
+    path: &Path,
+    pr_number: Option<u32>,
+    unchanged_sha: Option<&str>,
+) -> CiFetch {
+    // Read locally (gix, no network) before deciding to spend a request.
+    let sha = get_pushed_sha(path);
+    if let (Some(sha), Some(cached)) = (sha.as_deref(), unchanged_sha)
+        && sha == cached
+    {
+        return CiFetch::Unchanged;
+    }
+
     match pr_number {
-        Some(number) => get_pr_ci_checks(path, number),
-        None => get_branch_ci_checks(path),
+        Some(number) => get_pr_ci_checks(path, number, sha),
+        None => get_branch_ci_checks(path, sha),
     }
 }
 
-/// Fetch CI checks via `gh pr checks <number>` (PR-scoped — see `get_ci_checks`).
+/// Fetch CI checks via `gh pr checks <number>` (PR-scoped — see `fetch_ci_checks`).
 /// The explicit PR number is passed rather than relying on `gh`'s current-branch
 /// resolution, which (like `gh pr view`) misfires on fork/upstream-split repos.
-fn get_pr_ci_checks(path: &Path, pr_number: u32) -> Option<crate::CiCheckSummary> {
-    let path_str = path.to_str()?;
+fn get_pr_ci_checks(path: &Path, pr_number: u32, sha: Option<String>) -> CiFetch {
+    let Some(path_str) = path.to_str() else {
+        return CiFetch::Fetched { sha, summary: None };
+    };
     let number = pr_number.to_string();
 
     let output = safe_output_with_timeout(
@@ -353,15 +423,23 @@ fn get_pr_ci_checks(path: &Path, pr_number: u32) -> Option<crate::CiCheckSummary
             ])
             .current_dir(path_str),
         GH_TIMEOUT,
-    )
-    .ok()?;
+    );
+    let Ok(output) = output else {
+        return CiFetch::Fetched { sha, summary: None };
+    };
 
+    if is_rate_limited(&output) {
+        return CiFetch::RateLimited;
+    }
     if !output.status.success() {
-        return None;
+        return CiFetch::Fetched { sha, summary: None };
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_ci_checks(stdout.trim())
+    CiFetch::Fetched {
+        summary: parse_ci_checks(stdout.trim()),
+        sha,
+    }
 }
 
 /// Fetch CI checks for the branch's last *pushed* commit via the REST API.
@@ -370,32 +448,49 @@ fn get_pr_ci_checks(path: &Path, pr_number: u32) -> Option<crate::CiCheckSummary
 /// use) into a single `CiCheckSummary`.
 ///
 /// Uses the upstream (pushed) SHA, not the local HEAD: CI runs on what's on the
-/// remote, so an unpushed local commit has no checks. Returns `None` (skipping
-/// the API calls) when the branch has no upstream — nothing has been pushed.
-fn get_branch_ci_checks(path: &Path) -> Option<crate::CiCheckSummary> {
-    let path_str = path.to_str()?;
-    let sha = get_pushed_sha(path)?;
+/// remote, so an unpushed local commit has no checks. Returns no summary
+/// (skipping the API calls) when the branch has no upstream — nothing has been
+/// pushed.
+fn get_branch_ci_checks(path: &Path, sha: Option<String>) -> CiFetch {
+    let (Some(path_str), Some(sha)) = (path.to_str(), sha) else {
+        return CiFetch::Fetched {
+            sha: None,
+            summary: None,
+        };
+    };
 
     // `gh api` substitutes `{owner}` and `{repo}` from the current repo
     // context, so we don't need to resolve the remote ourselves.
     let check_runs_endpoint = format!("repos/{{owner}}/{{repo}}/commits/{}/check-runs", sha);
     let status_endpoint = format!("repos/{{owner}}/{{repo}}/commits/{}/status", sha);
+    let fetched = |summary| CiFetch::Fetched {
+        sha: Some(sha.clone()),
+        summary,
+    };
 
-    let check_runs_out = safe_output_with_timeout(
+    let Ok(check_runs_out) = safe_output_with_timeout(
         command("gh")
             .args(["api", "--paginate", &check_runs_endpoint])
             .current_dir(path_str),
         GH_TIMEOUT,
-    )
-    .ok()?;
+    ) else {
+        return fetched(None);
+    };
+    if is_rate_limited(&check_runs_out) {
+        return CiFetch::RateLimited;
+    }
 
-    let statuses_out = safe_output_with_timeout(
+    let Ok(statuses_out) = safe_output_with_timeout(
         command("gh")
             .args(["api", &status_endpoint])
             .current_dir(path_str),
         GH_TIMEOUT,
-    )
-    .ok()?;
+    ) else {
+        return fetched(None);
+    };
+    if is_rate_limited(&statuses_out) {
+        return CiFetch::RateLimited;
+    }
 
     let check_runs_json = if check_runs_out.status.success() {
         Some(String::from_utf8_lossy(&check_runs_out.stdout).into_owned())
@@ -409,10 +504,13 @@ fn get_branch_ci_checks(path: &Path) -> Option<crate::CiCheckSummary> {
     };
 
     if check_runs_json.is_none() && statuses_json.is_none() {
-        return None;
+        return fetched(None);
     }
 
-    parse_branch_ci(check_runs_json.as_deref(), statuses_json.as_deref())
+    fetched(parse_branch_ci(
+        check_runs_json.as_deref(),
+        statuses_json.as_deref(),
+    ))
 }
 
 /// Parse the REST `check-runs` + `status` JSON payloads into a unified
@@ -862,5 +960,75 @@ mod tests {
     #[test]
     fn parse_branch_ci_invalid_json_returns_none() {
         assert!(super::parse_branch_ci(Some("not json"), Some("also not json")).is_none());
+    }
+
+    fn output(code: i32, stderr: &str) -> std::process::Output {
+        use std::os::unix::process::ExitStatusExt;
+        std::process::Output {
+            status: std::process::ExitStatus::from_raw(code << 8),
+            stdout: Vec::new(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn rate_limit_is_told_apart_from_other_failures() {
+        assert!(super::is_rate_limited(&output(
+            1,
+            "gh: API rate limit exceeded for user ID 1276059."
+        )));
+        assert!(super::is_rate_limited(&output(
+            1,
+            "You have exceeded a secondary rate limit"
+        )));
+        assert!(!super::is_rate_limited(&output(
+            1,
+            "gh: Not Found (HTTP 404)"
+        )));
+        // A successful call is never a rate-limit hit, whatever it printed.
+        assert!(!super::is_rate_limited(&output(0, "rate limit")));
+    }
+
+    #[test]
+    fn unchanged_upstream_commit_skips_the_lookup_entirely() {
+        // A repo whose upstream still points at the cached commit must not
+        // shell out to `gh` at all — this is the skip that keeps the poller
+        // inside GitHub's hourly budget.
+        let (_bare_tmp, bare) = {
+            let tmp = tempfile::tempdir().expect("create temp dir");
+            let path = tmp.path().join("origin.git");
+            std::process::Command::new("git")
+                .args(["init", "--bare", "-b", "main"])
+                .arg(&path)
+                .output()
+                .expect("git init --bare");
+            (tmp, path)
+        };
+        let (_tmp, repo) = super::super::test_support::init_temp_repo();
+        super::super::test_support::git_in(
+            &repo,
+            &["remote", "add", "origin", bare.to_str().expect("path")],
+        );
+        super::super::test_support::git_in(&repo, &["push", "-u", "origin", "main"]);
+
+        let sha = super::get_pushed_sha(&repo).expect("branch has an upstream");
+        assert_eq!(
+            super::fetch_ci_checks(&repo, None, Some(&sha)),
+            super::CiFetch::Unchanged
+        );
+    }
+
+    #[test]
+    fn branch_without_upstream_never_reaches_the_api() {
+        // Nothing is pushed, so there is nothing CI could have run on.
+        let (_tmp, repo) = super::super::test_support::init_temp_repo();
+        assert_eq!(
+            super::fetch_ci_checks(&repo, None, None),
+            super::CiFetch::Fetched {
+                sha: None,
+                summary: None
+            }
+        );
     }
 }

--- a/crates/okena-git/src/repository/mod.rs
+++ b/crates/okena-git/src/repository/mod.rs
@@ -28,7 +28,9 @@ pub use branch::{
     list_branches_classified, merge_branch, push_branch, rebase_onto, resolve_base_ref,
     resolve_review_base, stage_file, stash_changes, stash_pop, unstage_file,
 };
-pub use ci::{get_ci_checks, get_pr_info, has_github_remote, list_pull_requests};
+pub use ci::{
+    CiFetch, PrFetch, fetch_ci_checks, fetch_pr_info, has_github_remote, list_pull_requests,
+};
 pub use paths::{
     compute_target_paths, get_repo_common_dir, get_repo_root, normalize_path,
     project_path_in_worktree, resolve_git_root_and_subdir,

--- a/crates/okena-views-git/src/watcher.rs
+++ b/crates/okena-views-git/src/watcher.rs
@@ -1,8 +1,9 @@
 use gpui::prelude::*;
 use gpui::*;
 use okena_core::api::ApiGitStatus;
-use okena_core::git_poll::GitPollTrigger;
+use okena_core::git_poll::{GitPollTrigger, GithubPollSchedule};
 use okena_core::process::{Lane, with_lane};
+use okena_git::repository::{CiFetch, PrFetch};
 use okena_git::{self as git, GitStatus};
 use okena_workspace::state::Workspace;
 use std::collections::{HashMap, HashSet};
@@ -32,12 +33,6 @@ fn to_api(s: &GitStatus) -> ApiGitStatus {
 const GIT_POLL_INTERVAL: u64 = 5;
 /// Cheap HEAD-only cadence used to wake the full status refresh after commits and checkouts.
 const HEAD_POLL_INTERVAL: Duration = Duration::from_millis(250);
-/// How many git poll cycles between PR URL checks (~60s)
-const PR_POLL_EVERY_N_CYCLES: u64 = 12;
-/// How many git poll cycles between CI check polls when checks are pending (~15s)
-const CI_PENDING_POLL_EVERY_N_CYCLES: u64 = 3;
-/// How many git poll cycles between CI check polls when checks are settled (~60s)
-const CI_SETTLED_POLL_EVERY_N_CYCLES: u64 = 12;
 
 /// Centralized git status poller.
 ///
@@ -54,8 +49,13 @@ pub struct GitStatusWatcher {
     pr_infos: HashMap<String, Option<okena_git::PrInfo>>,
     /// Cached CI check status keyed by project ID
     ci_checks: HashMap<String, Option<okena_git::CiCheckSummary>>,
-    /// Whether any project has pending CI checks (drives adaptive polling)
-    any_pending_ci: bool,
+    /// Per-project `gh` cadence, commit-level result caching and the
+    /// rate-limit gate. See [`GithubPollSchedule`].
+    schedule: GithubPollSchedule,
+    /// Poll cycle counter (one per `GIT_POLL_INTERVAL` tick). Lives on the
+    /// entity so out-of-band refreshes schedule against the same clock as the
+    /// poll loop.
+    cycle: u64,
     /// Invalidates async results captured before a project's HEAD changed.
     head_generations: HashMap<String, u64>,
     /// Watch channel sender for remote WS push
@@ -76,7 +76,8 @@ impl GitStatusWatcher {
             statuses: HashMap::new(),
             pr_infos: HashMap::new(),
             ci_checks: HashMap::new(),
-            any_pending_ci: false,
+            schedule: GithubPollSchedule::default(),
+            cycle: 0,
             head_generations: HashMap::new(),
             remote_tx,
             remote_subscribed_terminals,
@@ -161,20 +162,18 @@ impl GitStatusWatcher {
                     && this
                         .update(cx, |this, cx| {
                             for (id, reference_changed) in changed {
+                                // Bump the generation so results captured before
+                                // this change are discarded. The cached CI stays:
+                                // checks belong to the last *pushed* commit, which
+                                // a local commit doesn't move — dropping it blanked
+                                // the badge and forced a refetch on every commit.
                                 *this.head_generations.entry(id.clone()).or_default() += 1;
-                                this.ci_checks.remove(&id);
                                 if reference_changed {
                                     this.refresh_project(id, cx);
                                 } else {
                                     this.refresh_visible_project(id, cx);
                                 }
                             }
-                            this.any_pending_ci = this.ci_checks.values().any(|checks| {
-                                checks
-                                    .as_ref()
-                                    .map(|s| s.status.is_pending())
-                                    .unwrap_or(false)
-                            });
                         })
                         .is_err()
                 {
@@ -227,6 +226,50 @@ impl GitStatusWatcher {
         !(self.pr_infos.contains_key(project_id) && self.ci_checks.contains_key(project_id))
     }
 
+    /// Fold one project's `gh` outcome into the caches and its schedule.
+    ///
+    /// A refusal parks *all* `gh` traffic rather than being cached as "no PR /
+    /// no checks" — otherwise an exhausted rate limit would both blank every
+    /// badge and keep the poller hammering a closed door.
+    fn apply_github_fetch(&mut self, project_id: &str, pr: Option<PrFetch>, ci: Option<CiFetch>) {
+        let cycle = self.cycle;
+        let mut rate_limited = false;
+        let mut reached_github = false;
+
+        match pr {
+            Some(PrFetch::Fetched(info)) => {
+                reached_github = true;
+                self.schedule.record_pr(project_id, cycle);
+                self.pr_infos.insert(project_id.to_string(), info);
+            }
+            Some(PrFetch::RateLimited) => rate_limited = true,
+            None => {}
+        }
+        match ci {
+            Some(CiFetch::Unchanged) => self.schedule.record_ci_unchanged(project_id, cycle),
+            Some(CiFetch::Fetched { sha, summary }) => {
+                reached_github = true;
+                let pending = summary
+                    .as_ref()
+                    .is_some_and(|summary| summary.status.is_pending());
+                self.schedule.record_ci(project_id, cycle, pending, sha);
+                self.ci_checks.insert(project_id.to_string(), summary);
+            }
+            Some(CiFetch::RateLimited) => rate_limited = true,
+            None => {}
+        }
+
+        if rate_limited {
+            self.schedule.note_rate_limited(cycle);
+            log::warn!(
+                "GitHub API rate limit hit; PR/CI polling paused for {} cycles",
+                self.schedule.rate_limit_backoff_cycles()
+            );
+        } else if reached_github {
+            self.schedule.note_request_succeeded();
+        }
+    }
+
     /// Trigger an immediate git status refresh for a single project, bypassing
     /// the 5-second polling cadence. Used after explicit user actions like
     /// branch checkout so the UI reflects the new state without waiting for the
@@ -258,28 +301,22 @@ impl GitStatusWatcher {
                 self.refresh_visible_project(project_id, cx);
             }
             // No project id (a client's terminal subscription changed): fetch
-            // `gh` for any newly visible/subscribed project not yet cached.
+            // `gh` for any newly visible project not yet cached.
             None => self.refresh_visible_projects_missing_github(cx),
         }
     }
 
-    /// Refresh every currently visible-or-subscribed non-remote project that has
-    /// no cached PR/CI yet. Mirrors the poll loop's `gh_ids` set so a project
-    /// that just entered view (e.g. a remote client subscribed to its terminal)
-    /// gets its badge immediately instead of on the next `gh` cadence cycle.
+    /// Refresh every currently *visible* non-remote project that has no cached
+    /// PR/CI yet, so a project entering view gets its badge immediately instead
+    /// of on the next `gh` cadence cycle. Mirrors the poll loop's `gh_ids` set —
+    /// subscribed-but-hidden projects deliberately excluded, see there.
     fn refresh_visible_projects_missing_github(&mut self, cx: &mut Context<Self>) {
-        let mut gh_ids = self.workspace.read(cx).all_visible_project_ids();
-        if let Ok(remote_terminals) = self.remote_subscribed_terminals.read() {
-            for terminal_ids in remote_terminals.values() {
-                for tid in terminal_ids {
-                    if let Some(p) = self.workspace.read(cx).find_project_for_terminal(tid)
-                        && !p.is_remote
-                    {
-                        gh_ids.insert(p.id.clone());
-                    }
-                }
-            }
+        // A client's subscription set changes often; without the gate this fans
+        // `gh` out over the whole workspace while GitHub is already refusing us.
+        if self.schedule.is_rate_limited(self.cycle) {
+            return;
         }
+        let gh_ids = self.workspace.read(cx).all_visible_project_ids();
         let stale: Vec<String> = gh_ids
             .into_iter()
             .filter(|id| !self.statuses.contains_key(id) || self.missing_github_stats(id))
@@ -307,10 +344,7 @@ impl GitStatusWatcher {
         if invalidate_github {
             self.pr_infos.remove(&project_id);
             self.ci_checks.remove(&project_id);
-            self.any_pending_ci = self
-                .ci_checks
-                .values()
-                .any(|c| c.as_ref().map(|s| s.status.is_pending()).unwrap_or(false));
+            self.schedule.force(&project_id);
             let mut changed = false;
             if let Some(Some(status)) = self.statuses.get_mut(&project_id)
                 && (status.pr_info.is_some() || status.ci_checks.is_some())
@@ -335,6 +369,8 @@ impl GitStatusWatcher {
                 .and_then(|p| p.base.clone())
         };
         let poll_github = invalidate_github || self.missing_github_stats(&project_id);
+        // Skip the wire when the upstream commit still matches a settled result.
+        let ci_skip_sha = self.schedule.ci_skip_sha(&project_id, self.cycle);
         let head_generation = self
             .head_generations
             .get(&project_id)
@@ -383,16 +419,29 @@ impl GitStatusWatcher {
                 return;
             }
 
-            let (fetched_pr_info, fetched_ci_checks) = smol::unblock(move || {
+            let (fetched_pr_info, fetched_ci) = smol::unblock(move || {
                 with_lane(Lane::Poll, || {
                     let path = Path::new(&path);
                     if !git::repository::has_github_remote(path) {
-                        return (None, None);
+                        return (
+                            PrFetch::Fetched(None),
+                            CiFetch::Fetched {
+                                sha: None,
+                                summary: None,
+                            },
+                        );
                     }
-                    let pr_info = git::repository::get_pr_info(path);
-                    let pr_number = pr_info.as_ref().map(|pr| pr.number);
-                    let ci_checks = git::repository::get_ci_checks(path, pr_number);
-                    (pr_info, ci_checks)
+                    let pr_info = git::repository::fetch_pr_info(path);
+                    let pr_number = match &pr_info {
+                        PrFetch::Fetched(info) => info.as_ref().map(|info| info.number),
+                        PrFetch::RateLimited => None,
+                    };
+                    let ci = if matches!(pr_info, PrFetch::RateLimited) {
+                        CiFetch::RateLimited
+                    } else {
+                        git::repository::fetch_ci_checks(path, pr_number, ci_skip_sha.as_deref())
+                    };
+                    (pr_info, ci)
                 })
             })
             .await;
@@ -407,14 +456,7 @@ impl GitStatusWatcher {
                 {
                     return;
                 }
-                this.pr_infos.insert(project_id.clone(), fetched_pr_info);
-                this.ci_checks.insert(project_id.clone(), fetched_ci_checks);
-                this.any_pending_ci = this.ci_checks.values().any(|checks| {
-                    checks
-                        .as_ref()
-                        .map(|s| s.status.is_pending())
-                        .unwrap_or(false)
-                });
+                this.apply_github_fetch(&project_id, Some(fetched_pr_info), Some(fetched_ci));
 
                 let mut changed = false;
                 if let Some(Some(status)) = this.statuses.get_mut(&project_id) {
@@ -456,23 +498,27 @@ impl GitStatusWatcher {
                 // shown ONLY in an extra window is still polled (per PRD rule
                 // 3b-ii, projects added from window N are hidden elsewhere).
                 //
-                // `gh_ids` is the same set; the expensive `gh` PR/CI fan-out is
-                // gated further by cycle cadence below.
+                // `gh_ids` is deliberately *narrower* — visible projects only.
+                // A client subscribes to every terminal in the workspace, not
+                // just the ones it renders, so folding subscriptions into the
+                // `gh` set puts projects nobody is looking at on the GitHub
+                // cadence and burns the hourly API budget for nothing.
                 let (projects, gh_ids): (Vec<(String, String)>, HashSet<String>) =
                     cx.update(|cx| {
                         let ws = workspace.read(cx);
 
-                        let mut gh_ids = ws.all_visible_project_ids();
+                        let gh_ids = ws.all_visible_project_ids();
+                        let mut status_ids = gh_ids.clone();
 
-                        // Add projects with remotely subscribed terminals — they're
-                        // shown on a remote client, so poll their status + PR/CI too.
+                        // Projects with remotely subscribed terminals are shown on
+                        // a remote client, so keep their local git status fresh.
                         if let Ok(remote_terminals) = remote_subscribed_terminals.read() {
                             for terminal_ids in remote_terminals.values() {
                                 for tid in terminal_ids {
                                     if let Some(p) = ws.find_project_for_terminal(tid)
                                         && !p.is_remote
                                     {
-                                        gh_ids.insert(p.id.clone());
+                                        status_ids.insert(p.id.clone());
                                     }
                                 }
                             }
@@ -484,30 +530,16 @@ impl GitStatusWatcher {
                         let projects = ws
                             .projects()
                             .iter()
-                            .filter(|p| !p.is_remote && gh_ids.contains(&p.id))
+                            .filter(|p| !p.is_remote && status_ids.contains(&p.id))
                             .map(|p| (p.id.clone(), p.path.clone()))
                             .collect();
                         (projects, gh_ids)
                     });
 
-                // Skip the cycle-0 `gh` fan-out: at startup the app is already
-                // busy spawning terminals/hooks, and git status (phase 1, gix)
-                // renders immediately regardless. PR/CI kick in on cycle 1 (+5s)
-                // and then follow their normal cadence — so the badges fill in
-                // shortly after launch without a thundering herd of `gh` at the
-                // worst moment.
-                let ci_poll_interval = if this
-                    .update(cx, |this, _| this.any_pending_ci)
-                    .unwrap_or(false)
-                {
-                    CI_PENDING_POLL_EVERY_N_CYCLES
-                } else {
-                    CI_SETTLED_POLL_EVERY_N_CYCLES
-                };
-                let pr_cadence =
-                    cycle == 1 || (cycle != 0 && cycle.is_multiple_of(PR_POLL_EVERY_N_CYCLES));
-                let ci_cadence =
-                    cycle == 1 || (cycle != 0 && cycle.is_multiple_of(ci_poll_interval));
+                // Cycle 0 is startup: the app is already busy spawning terminals
+                // and hooks, and git status (phase 1, gix) renders without `gh`.
+                // The schedule's own default puts the first fetch on cycle 1.
+                let _ = this.update(cx, |this, _| this.cycle = cycle);
 
                 // Snapshot each project's known PR base branch (from the cached
                 // PR info fetched on prior `check_prs` cycles). Passing it into
@@ -574,7 +606,7 @@ impl GitStatusWatcher {
                 // and the poll loop keeps cycling. Inject whatever PR/CI we
                 // already have cached so we don't blank those mid-cycle.
                 let status_generations = poll_generations.clone();
-                let force_gh_ids = match this.update(cx, |this, cx| {
+                match this.update(cx, |this, cx| {
                     new_statuses.retain(|id, _| {
                         this.head_generations.get(id).copied().unwrap_or_default()
                             == status_generations.get(id).copied().unwrap_or_default()
@@ -587,19 +619,15 @@ impl GitStatusWatcher {
                             (prev.branch != status.branch).then(|| id.clone())
                         })
                         .collect();
-                    if !branch_changes.is_empty() {
-                        for id in &branch_changes {
-                            this.pr_infos.remove(id);
-                            this.ci_checks.remove(id);
-                            if let Some(Some(status)) = new_statuses.get_mut(id) {
-                                status.pr_info = None;
-                                status.ci_checks = None;
-                            }
+                    for id in &branch_changes {
+                        this.pr_infos.remove(id);
+                        this.ci_checks.remove(id);
+                        if let Some(Some(status)) = new_statuses.get_mut(id) {
+                            status.pr_info = None;
+                            status.ci_checks = None;
                         }
-                        this.any_pending_ci = this
-                            .ci_checks
-                            .values()
-                            .any(|c| c.as_ref().map(|s| s.status.is_pending()).unwrap_or(false));
+                        // Cached PR/CI described the branch we just left.
+                        this.schedule.force(id);
                     }
                     for (id, status) in new_statuses.iter_mut() {
                         if let Some(s) = status.as_mut() {
@@ -608,100 +636,60 @@ impl GitStatusWatcher {
                         }
                     }
                     this.commit_statuses(&new_statuses, cx);
-                    branch_changes
                 }) {
-                    Ok(ids) => ids,
+                    Ok(()) => {}
                     Err(_) => break,
                 };
-                let check_prs = pr_cadence || !force_gh_ids.is_empty();
-                let check_ci = ci_cadence || !force_gh_ids.is_empty();
 
-                // Phase 2: Fetch PR info in parallel (slower, network calls) — only on PR poll cycles.
-                // Runs after all statuses are updated so git status isn't delayed by PR checks.
-                let mut new_pr_infos: HashMap<String, Option<okena_git::PrInfo>> = if check_prs {
-                    let pr_futures: Vec<_> = projects
-                        .iter()
-                        .filter(|(id, _)| {
-                            gh_ids.contains(id) && (pr_cadence || force_gh_ids.contains(id))
-                        })
-                        .map(|(id, path)| {
-                            let id = id.clone();
-                            let path = path.clone();
-                            async move {
-                                let pr_info = smol::unblock(move || {
-                                    with_lane(Lane::Poll, || {
-                                        // Skip `gh` entirely for non-GitHub repos.
-                                        if !git::repository::has_github_remote(Path::new(&path)) {
-                                            return None;
-                                        }
-                                        git::repository::get_pr_info(Path::new(&path))
-                                    })
-                                })
-                                .await;
-                                (id, pr_info)
-                            }
-                        })
-                        .collect();
-                    futures::future::join_all(pr_futures)
-                        .await
-                        .into_iter()
-                        .collect()
-                } else {
-                    HashMap::new()
-                };
-
-                // Phase 3: Fetch CI check status — adaptive interval based on pending state.
-                // Runs for every project; uses `gh pr checks` when a PR is known,
-                // falls back to branch-level `check-runs`/`status` otherwise.
-                let mut new_ci_checks: HashMap<String, Option<okena_git::CiCheckSummary>> =
-                    if check_ci {
-                        let pr_infos_snapshot: HashMap<String, Option<okena_git::PrInfo>> =
-                            if check_prs {
-                                // Use freshly fetched PR info
-                                new_pr_infos.clone()
-                            } else {
-                                // Use cached PR info
-                                this.update(cx, |this, _| this.pr_infos.clone())
-                                    .unwrap_or_default()
-                            };
-                        let ci_futures: Vec<_> = projects
+                // Phase 2: `gh` PR/CI, per project and only where due. Each
+                // project's PR and CI calls are paired so the CI lookup can use
+                // the PR number this pass just fetched.
+                let polls: Vec<GithubProjectPoll> = this
+                    .update(cx, |this, cx| {
+                        // Retain across *all* projects, not just the polled set:
+                        // a project scrolling out of view should keep its cached
+                        // commit so coming back doesn't cost a fetch.
+                        let known: HashSet<String> = this
+                            .workspace
+                            .read(cx)
+                            .projects()
                             .iter()
-                            .filter(|(id, _)| {
-                                gh_ids.contains(id) && (ci_cadence || force_gh_ids.contains(id))
-                            })
-                            .map(|(id, path)| {
-                                let id = id.clone();
-                                let path = path.clone();
-                                let pr_number = pr_infos_snapshot
-                                    .get(&id)
-                                    .and_then(|p| p.as_ref())
-                                    .map(|p| p.number);
-                                async move {
-                                    let checks = smol::unblock(move || {
-                                        with_lane(Lane::Poll, || {
-                                            // Skip `gh` entirely for non-GitHub repos.
-                                            if !git::repository::has_github_remote(Path::new(&path))
-                                            {
-                                                return None;
-                                            }
-                                            git::repository::get_ci_checks(
-                                                Path::new(&path),
-                                                pr_number,
-                                            )
-                                        })
-                                    })
-                                    .await;
-                                    (id, checks)
-                                }
-                            })
+                            .map(|p| p.id.clone())
                             .collect();
-                        futures::future::join_all(ci_futures)
-                            .await
-                            .into_iter()
+                        this.schedule.retain(&known);
+                        if this.schedule.is_rate_limited(cycle) {
+                            return Vec::new();
+                        }
+                        projects
+                            .iter()
+                            .filter(|(id, _)| gh_ids.contains(id) || this.schedule.is_urgent(id))
+                            .filter_map(|(id, path)| {
+                                let want_pr = this.schedule.pr_due(id, cycle, true);
+                                let want_ci = this.schedule.ci_due(id, cycle, true);
+                                (want_pr || want_ci).then(|| GithubProjectPoll {
+                                    id: id.clone(),
+                                    path: path.clone(),
+                                    want_pr,
+                                    want_ci,
+                                    ci_skip_sha: this.schedule.ci_skip_sha(id, cycle),
+                                    cached_pr_number: this
+                                        .pr_infos
+                                        .get(id)
+                                        .and_then(|pr| pr.as_ref())
+                                        .map(|pr| pr.number),
+                                })
+                            })
                             .collect()
-                    } else {
-                        HashMap::new()
-                    };
+                    })
+                    .unwrap_or_default();
+
+                let fetched: Vec<(String, Option<PrFetch>, Option<CiFetch>)> =
+                    futures::future::join_all(polls.into_iter().map(|poll| async move {
+                        let id = poll.id.clone();
+                        let (pr, ci) = smol::unblock(move || fetch_project_github(&poll)).await;
+                        (id, pr, ci)
+                    }))
+                    .await;
 
                 // Merge freshly-fetched PR/CI into the caches and re-commit the
                 // statuses with that richer data. `commit_statuses` no-ops when
@@ -713,24 +701,15 @@ impl GitStatusWatcher {
                                 == poll_generations.get(id).copied().unwrap_or_default()
                         };
                         new_statuses.retain(|id, _| is_current(id));
-                        new_pr_infos.retain(|id, _| is_current(id));
-                        new_ci_checks.retain(|id, _| is_current(id));
+                        let fresh: Vec<_> = fetched
+                            .into_iter()
+                            .filter(|(id, _, _)| is_current(id))
+                            .collect();
                         // Merge into caches rather than replace: when fullscreen narrows
                         // the visible set to a single project, the un-polled projects
                         // should keep their last-known values until they're polled again.
-                        if check_prs {
-                            for (id, pr) in new_pr_infos {
-                                this.pr_infos.insert(id, pr);
-                            }
-                        }
-
-                        if check_ci {
-                            for (id, checks) in new_ci_checks {
-                                this.ci_checks.insert(id, checks);
-                            }
-                            this.any_pending_ci = this.ci_checks.values().any(|c| {
-                                c.as_ref().map(|s| s.status.is_pending()).unwrap_or(false)
-                            });
+                        for (id, pr, ci) in fresh {
+                            this.apply_github_fetch(&id, pr, ci);
                         }
 
                         // Inject cached PR info + CI checks into statuses
@@ -756,6 +735,52 @@ impl GitStatusWatcher {
         })
         .detach();
     }
+}
+
+/// One project's slot in a `gh` pass.
+struct GithubProjectPoll {
+    id: String,
+    path: String,
+    want_pr: bool,
+    want_ci: bool,
+    /// Upstream commit whose CI result is already cached; while the branch
+    /// still points at it the CI lookup makes no request at all.
+    ci_skip_sha: Option<String>,
+    /// PR number from a previous pass, used when this pass isn't refetching it.
+    cached_pr_number: Option<u32>,
+}
+
+/// Run one project's PR and CI lookups on a bus worker, paired so the CI call
+/// can use the PR number this pass just fetched.
+fn fetch_project_github(poll: &GithubProjectPoll) -> (Option<PrFetch>, Option<CiFetch>) {
+    with_lane(Lane::Poll, || {
+        let path = Path::new(&poll.path);
+        // Skip `gh` entirely for non-GitHub repos.
+        if !git::repository::has_github_remote(path) {
+            return (
+                poll.want_pr.then_some(PrFetch::Fetched(None)),
+                poll.want_ci.then_some(CiFetch::Fetched {
+                    sha: None,
+                    summary: None,
+                }),
+            );
+        }
+
+        let pr = poll.want_pr.then(|| git::repository::fetch_pr_info(path));
+        let pr_number = match &pr {
+            Some(PrFetch::Fetched(info)) => info.as_ref().map(|info| info.number),
+            _ => poll.cached_pr_number,
+        };
+        // A rate-limited PR call means the CI call would only be refused too.
+        let ci = if matches!(pr, Some(PrFetch::RateLimited)) {
+            None
+        } else {
+            poll.want_ci.then(|| {
+                git::repository::fetch_ci_checks(path, pr_number, poll.ci_skip_sha.as_deref())
+            })
+        };
+        (pr, ci)
+    })
 }
 
 fn update_head_snapshots(


### PR DESCRIPTION
## What's wrong

The PR/CI badge poller was consuming several times GitHub's hourly API budget. Measured on a live 94-project workspace with **11 projects visible**, sampling `/proc` for `gh` process spawns:

| window | `gh` spawns | REST req/h | GraphQL req/h |
|---|---|---|---|
| 116s | 190/min | **9,279** | 2,110 |
| 288s | 108/min | **4,614** | 3,089 |
| GitHub's limit | | 5,000 | 5,000 |

The limit was exhausted — a direct replay of one of the poller's own requests returned:

```
HTTP/2.0 403 Forbidden   X-RateLimit-Resource: core
X-RateLimit-Used: 5000   X-RateLimit-Remaining: 0
```

So the badges were not just expensive, they were broken.

## Why

Five things compounded. Each is fixed separately in `e730b57`.

**1. `gh` followed the wrong set of projects.** `relevant_project_ids` = visible ∪ *projects owning a terminal a remote client subscribed to*. Clients subscribe to every terminal in the daemon's state, not just the ones they render, so a project merely owning a terminal joined the responsive GitHub cadence. Measured: **34 repositories polled to render 11 badges.**

**2. One global "is anything pending?" flag.** A single repo with running CI moved all 34 from the 60s cadence to 15s. The flag was also computed over the cache for *all* projects, so a `pending` entry for a repo that had stopped being polled pinned the fast cadence indefinitely.

**3. Nothing was cached against the commit.** Checks on a commit only change while something is running, but every poll re-fetched them anyway. Most of these repos sit on `main` with no PR, which takes the two-request branch fallback (`check-runs` + `status`).

**4. Passes stacked.** `poll_github` awaited each project sequentially — ~250ms per call, ~17s for 34 repos — while being re-spawned unconditionally on every cadence tick, with no in-flight guard. Observed: concurrency up to 3, and **17 cases of the same repo fetched twice within the same second**.

**5. No rate-limit handling.** `grep -rn "rate.limit\|403\|Retry-After"` over `okena-git` and `okena-daemon-core` returned nothing. Once GitHub started refusing, the request rate didn't change, and refusals were cached as "this project has no PR", blanking badges.

Worth noting the floor: even at the intended settled cadence, 34 repos × 2 REST calls per 60s is 4,080 req/h — 82% of the limit. Fixing the cadence bugs alone would not have been enough; the redundant fetches had to go.

## What changed

**`okena-core`** — new `GithubPollSchedule`: per-project due cycles, the upstream commit a settled CI result describes, and a rate-limit gate with a doubling 60s→30min backoff. The cadence constants live here now; they were duplicated across both poll loops with comments claiming they mirrored each other.

**`okena-git`** — `get_pr_info`/`get_ci_checks` become `fetch_pr_info`/`fetch_ci_checks` returning `PrFetch`/`CiFetch`, so callers can tell "no PR" from "refused". `fetch_ci_checks` takes the commit a cached settled result belongs to and returns `Unchanged` without touching the network while the branch still points at it — a repo parked on `main` now costs one local gix ref read instead of two REST calls. Settled results are still revalidated every ~10min so a re-run of an old commit is noticed.

**`okena-daemon-core` + `okena-views-git`** — both loops now scope `gh` to visible projects, schedule per project, run the fan-out 4-wide (matching the process bus's `Lane::Poll` worker count), refuse to start a pass while one is in flight, and park on a refusal.

Also drops the CI cache eviction on every local commit: checks belong to the last *pushed* commit, which a local commit doesn't move — that eviction only blanked the badge and forced a refetch.

## Behaviour changes worth knowing

- A hidden project no longer refreshes its PR/CI badge. It keeps the last value and refreshes when it becomes visible.
- A settled CI result is trusted for up to 10 minutes on an unchanged commit, so a re-run on an already-settled commit can take that long to appear.
- Explicit actions (branch checkout, `GitStatus`) still fetch immediately, off-cadence.

## Verification

`cargo test --workspace` green (67 test binaries), `cargo clippy --workspace --all-targets` clean.

New tests: 11 in `okena-core` covering per-project cadence, commit-skip arming, revalidation, and the backoff; 4 in `okena-daemon-core` covering poll selection (hidden excluded, urgent included, skip-sha carried, one busy repo not speeding up the others) plus the apply path; 4 in `okena-git`, two of which build a real repo with an upstream and assert `fetch_ci_checks` returns `Unchanged` without invoking `gh`.

Not verified end-to-end against the live GitHub API: the daemon's poll loop exits when no client holds a status receiver, so a client-less bench run polls nothing. The behaviour above is covered by unit tests at the seams instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfU7oDTtKEaQ9vG7Y6fquX
