### PR TITLE
fix(terminal): protect running apps from click-to-cursor

### DIFF
--- a/crates/okena-views-terminal/src/layout/terminal_pane/mod.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/mod.rs
@@ -320,7 +320,7 @@ impl<D: ActionDispatch + Send + Sync> TerminalPane<D> {
     fn create_terminal_for_existing_pty(&mut self, terminal_id: String, cx: &mut Context<Self>) {
         let existing = self.terminals.lock().get(&terminal_id).cloned();
         if let Some(terminal) = existing {
-            if let Some(pid) = self.backend.get_shell_pid(&terminal_id) {
+            if let Some(pid) = self.backend.get_foreground_shell_pid(&terminal_id) {
                 terminal.set_shell_pid(pid);
             }
             self.terminal = Some(terminal.clone());


### PR DESCRIPTION
## What changed

Use the resolved foreground shell PID when a terminal view reuses an existing cached terminal.

## Why

Click-to-cursor sends arrow-key escape sequences after a clean click. It is disabled while the shell has a running child process, but the cached-terminal path refreshed the guard with the session attach PID instead of the real shell PID.

With `dtach`, the attach process can have no children. The guard then incorrectly allowed click-to-cursor while Codex was running. Codex could interpret the leading Escape as a cancellation and leave `[C` in its input.

The new-terminal path already used `get_foreground_shell_pid`; this change makes the cached-terminal path consistent.

## Impact

Clicking to focus a reused terminal no longer sends cursor movement input into running terminal applications. Click-to-cursor remains available at an idle shell prompt.

## Validation

- `cargo test -p okena-views-terminal --lib` (29 passed)
- `cargo fmt --all -- --check`
- `git diff --check`