### PR TITLE
feat(files): browse daemon filesystem paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6077,8 +6077,10 @@ dependencies = [
  "okena-terminal",
  "okena-theme",
  "okena-workspace",
+ "percent-encoding",
  "serde_json",
  "smol",
+ "url",
  "uuid",
 ]
 
@@ -6245,6 +6247,7 @@ name = "okena-files"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "dirs 5.0.1",
  "gpui",
  "gpui-component",
  "grep-matcher",
@@ -6393,6 +6396,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "uuid",
 ]

--- a/crates/okena-app-core/Cargo.toml
+++ b/crates/okena-app-core/Cargo.toml
@@ -30,6 +30,8 @@ serde_json = "1.0"
 log = "0.4"
 uuid = { version = "1.10", features = ["v4"] }
 base64 = "0.22"
+url = "2"
+percent-encoding = "2"
 
 # `gpui` here is the *same* optional dependency declared in `[dependencies]`;
 # this entry only layers on the `test-support` feature so the gpui-gated test

--- a/crates/okena-app-core/src/workspace/actions/execute/files.rs
+++ b/crates/okena-app-core/src/workspace/actions/execute/files.rs
@@ -3,6 +3,9 @@
 use super::{
     ActionResult, Workspace, resolve_new_project_file, resolve_project_file, validate_leaf_name,
 };
+use okena_core::api::{PathBreadcrumb, ResolvedPath, ResolvedPathKind};
+use okena_terminal::TerminalsRegistry;
+use std::path::{Path, PathBuf};
 
 pub struct PreparedContentSearch {
     project_path: std::path::PathBuf,
@@ -72,6 +75,369 @@ pub(super) fn read_file(ws: &Workspace, project_id: String, relative_path: Strin
 /// resident multiple is roughly 3-4× the file size).
 const MAX_READ_FILE_BYTES: u64 = 20 * 1024 * 1024;
 
+fn modified_at_millis(metadata: &std::fs::Metadata) -> Option<u64> {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .and_then(|duration| u64::try_from(duration.as_millis()).ok())
+}
+
+fn path_breadcrumbs(path: &Path) -> Vec<PathBreadcrumb> {
+    let mut ancestors: Vec<&Path> = path.ancestors().collect();
+    ancestors.reverse();
+    ancestors
+        .into_iter()
+        .map(|ancestor| PathBreadcrumb {
+            canonical_path: ancestor.to_string_lossy().into_owned(),
+            label: ancestor
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| ancestor.to_string_lossy().into_owned()),
+        })
+        .collect()
+}
+
+fn resolved_path(ws: &Workspace, canonical_path: PathBuf) -> Result<ResolvedPath, String> {
+    let metadata =
+        std::fs::metadata(&canonical_path).map_err(|error| format!("Cannot read path: {error}"))?;
+    let kind = if metadata.is_file() {
+        ResolvedPathKind::File
+    } else if metadata.is_dir() {
+        ResolvedPathKind::Directory
+    } else {
+        return Err("Path is neither a regular file nor a directory".to_string());
+    };
+
+    let mut containing_project = None;
+    for project in &ws.data().projects {
+        let Ok(project_root) = Path::new(&project.path).canonicalize() else {
+            continue;
+        };
+        let Ok(relative_path) = canonical_path.strip_prefix(&project_root) else {
+            continue;
+        };
+        let depth = project_root.components().count();
+        if containing_project
+            .as_ref()
+            .is_none_or(|(current_depth, _, _)| depth > *current_depth)
+        {
+            containing_project = Some((
+                depth,
+                project.id.clone(),
+                relative_path.to_string_lossy().replace('\\', "/"),
+            ));
+        }
+    }
+
+    let name = canonical_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| canonical_path.to_string_lossy().into_owned());
+    let (_, project_id, relative_path) = containing_project
+        .map(|value| (value.0, Some(value.1), Some(value.2)))
+        .unwrap_or((0, None, None));
+    let breadcrumbs = path_breadcrumbs(&canonical_path);
+    Ok(ResolvedPath {
+        canonical_path: canonical_path.to_string_lossy().into_owned(),
+        name,
+        kind,
+        size: metadata.len(),
+        modified_at_millis: modified_at_millis(&metadata),
+        project_id,
+        relative_path,
+        breadcrumbs,
+    })
+}
+
+fn expand_terminal_path(path: &str, cwd: &str) -> Result<PathBuf, String> {
+    if path.starts_with("file://") {
+        let url = url::Url::parse(path).map_err(|error| format!("Invalid file URL: {error}"))?;
+        if let Ok(path) = url.to_file_path() {
+            return Ok(path);
+        }
+        #[cfg(unix)]
+        if url.host_str().is_some() {
+            let decoded = percent_encoding::percent_decode_str(url.path())
+                .decode_utf8()
+                .map_err(|error| format!("File URL path is not valid UTF-8: {error}"))?;
+            return Ok(PathBuf::from(decoded.as_ref()));
+        }
+        return Err("File URL does not contain a local path".to_string());
+    }
+    if path == "~" || path.starts_with("~/") || path.starts_with("~\\") {
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .ok_or_else(|| "Cannot resolve the daemon home directory".to_string())?;
+        return Ok(
+            PathBuf::from(home).join(path.trim_start_matches('~').trim_start_matches(['/', '\\']))
+        );
+    }
+    let path = Path::new(path);
+    Ok(if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        Path::new(cwd).join(path)
+    })
+}
+
+pub(super) fn resolve_project_path_action(
+    ws: &Workspace,
+    project_id: String,
+    relative_path: String,
+) -> ActionResult {
+    let project = match ws.project(&project_id) {
+        Some(project) => project,
+        None => return ActionResult::Err(format!("project not found: {project_id}")),
+    };
+    match resolve_project_file(&project.path, &relative_path)
+        .and_then(|path| resolved_path(ws, path))
+    {
+        Ok(path) => ActionResult::Ok(Some(
+            serde_json::to_value(path).expect("BUG: ResolvedPath must serialize"),
+        )),
+        Err(error) => ActionResult::Err(error),
+    }
+}
+
+fn resolve_terminal_path(
+    ws: &Workspace,
+    terminals: &TerminalsRegistry,
+    terminal_id: &str,
+    path: &str,
+) -> Result<ResolvedPath, String> {
+    let terminal = terminals
+        .lock()
+        .get(terminal_id)
+        .cloned()
+        .ok_or_else(|| format!("terminal not found: {terminal_id}"))?;
+    let expanded = expand_terminal_path(path, &terminal.current_cwd())?;
+    let canonical = expanded
+        .canonicalize()
+        .map_err(|error| format!("Cannot resolve path: {error}"))?;
+    resolved_path(ws, canonical)
+}
+
+fn require_file(path: ResolvedPath) -> Result<ResolvedPath, String> {
+    if path.kind == ResolvedPathKind::File {
+        Ok(path)
+    } else {
+        Err("Path is not a regular file".to_string())
+    }
+}
+
+pub(super) fn resolve_terminal_path_action(
+    ws: &Workspace,
+    terminals: &TerminalsRegistry,
+    terminal_id: String,
+    path: String,
+) -> ActionResult {
+    match resolve_terminal_path(ws, terminals, &terminal_id, &path) {
+        Ok(path) => ActionResult::Ok(Some(
+            serde_json::to_value(path).expect("BUG: ResolvedPath must serialize"),
+        )),
+        Err(error) => ActionResult::Err(error),
+    }
+}
+
+pub(super) fn read_terminal_file(
+    ws: &Workspace,
+    terminals: &TerminalsRegistry,
+    terminal_id: String,
+    path: String,
+) -> ActionResult {
+    let file =
+        match resolve_terminal_path(ws, terminals, &terminal_id, &path).and_then(require_file) {
+            Ok(file) => file,
+            Err(error) => return ActionResult::Err(error),
+        };
+    match std::fs::read_to_string(&file.canonical_path) {
+        Ok(content) => ActionResult::Ok(Some(serde_json::json!({ "content": content }))),
+        Err(error) => ActionResult::Err(format!("Cannot read file: {error}")),
+    }
+}
+
+pub(super) fn read_terminal_file_bytes(
+    ws: &Workspace,
+    terminals: &TerminalsRegistry,
+    terminal_id: String,
+    path: String,
+) -> ActionResult {
+    use base64::Engine as _;
+    let file =
+        match resolve_terminal_path(ws, terminals, &terminal_id, &path).and_then(require_file) {
+            Ok(file) => file,
+            Err(error) => return ActionResult::Err(error),
+        };
+    if file.size > MAX_READ_FILE_BYTES {
+        return ActionResult::Err(format!(
+            "File too large ({:.1} MB). Maximum is {} MB.",
+            file.size as f64 / 1024.0 / 1024.0,
+            MAX_READ_FILE_BYTES / 1024 / 1024
+        ));
+    }
+    match std::fs::read(&file.canonical_path) {
+        Ok(bytes) if bytes.len() as u64 <= MAX_READ_FILE_BYTES => {
+            let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+            ActionResult::Ok(Some(serde_json::json!({ "content_b64": encoded })))
+        }
+        Ok(bytes) => ActionResult::Err(format!(
+            "File too large ({:.1} MB). Maximum is {} MB.",
+            bytes.len() as f64 / 1024.0 / 1024.0,
+            MAX_READ_FILE_BYTES / 1024 / 1024
+        )),
+        Err(error) => ActionResult::Err(format!("Cannot read file: {error}")),
+    }
+}
+
+pub(super) fn terminal_file_size(
+    ws: &Workspace,
+    terminals: &TerminalsRegistry,
+    terminal_id: String,
+    path: String,
+) -> ActionResult {
+    match resolve_terminal_path(ws, terminals, &terminal_id, &path).and_then(require_file) {
+        Ok(file) => ActionResult::Ok(Some(serde_json::json!({
+            "size": file.size,
+            "modified_at_millis": file.modified_at_millis,
+        }))),
+        Err(error) => ActionResult::Err(error),
+    }
+}
+
+pub(super) fn resolve_path_action(ws: &Workspace, path: String) -> ActionResult {
+    let canonical = match Path::new(&path).canonicalize() {
+        Ok(path) => path,
+        Err(error) => return ActionResult::Err(format!("Cannot resolve path: {error}")),
+    };
+    match resolved_path(ws, canonical) {
+        Ok(path) => ActionResult::Ok(Some(
+            serde_json::to_value(path).expect("BUG: ResolvedPath must serialize"),
+        )),
+        Err(error) => ActionResult::Err(error),
+    }
+}
+
+pub(super) fn resolve_path_in_scope_action(
+    ws: &Workspace,
+    root: String,
+    relative_path: String,
+) -> ActionResult {
+    let canonical = match resolve_project_file(&root, &relative_path) {
+        Ok(path) => path,
+        Err(error) => return ActionResult::Err(error),
+    };
+    match resolved_path(ws, canonical) {
+        Ok(path) => ActionResult::Ok(Some(
+            serde_json::to_value(path).expect("BUG: ResolvedPath must serialize"),
+        )),
+        Err(error) => ActionResult::Err(error),
+    }
+}
+
+fn canonical_scope_root(root: &str) -> Result<PathBuf, String> {
+    let root = Path::new(root)
+        .canonicalize()
+        .map_err(|error| format!("Cannot resolve browser root: {error}"))?;
+    if !root.is_dir() {
+        return Err("Browser root is not a directory".to_string());
+    }
+    Ok(root)
+}
+
+fn resolve_path_file(root: &str, relative_path: &str) -> Result<PathBuf, String> {
+    let path = resolve_project_file(root, relative_path)?;
+    if !path.is_file() {
+        return Err("Path is not a regular file".to_string());
+    }
+    Ok(path)
+}
+
+pub(super) fn list_path_files(root: String, show_ignored: bool) -> ActionResult {
+    let root = match canonical_scope_root(&root) {
+        Ok(root) => root,
+        Err(error) => return ActionResult::Err(error),
+    };
+    let files = okena_files::file_scan::scan_files(&root, show_ignored);
+    ActionResult::Ok(Some(
+        serde_json::to_value(files).expect("BUG: FileEntry must serialize"),
+    ))
+}
+
+pub(super) fn list_path_directory(
+    root: String,
+    relative_path: String,
+    show_ignored: bool,
+) -> ActionResult {
+    let root = match canonical_scope_root(&root) {
+        Ok(root) => root,
+        Err(error) => return ActionResult::Err(error),
+    };
+    match okena_files::list_directory::list_directory(&root, &relative_path, show_ignored) {
+        Ok(entries) => ActionResult::Ok(Some(
+            serde_json::to_value(entries).expect("BUG: DirEntry must serialize"),
+        )),
+        Err(error) => ActionResult::Err(error),
+    }
+}
+
+pub(super) fn read_path_file(root: String, relative_path: String) -> ActionResult {
+    let path = match resolve_path_file(&root, &relative_path) {
+        Ok(path) => path,
+        Err(error) => return ActionResult::Err(error),
+    };
+    match std::fs::read_to_string(path) {
+        Ok(content) => ActionResult::Ok(Some(serde_json::json!({ "content": content }))),
+        Err(error) => ActionResult::Err(format!("Cannot read file: {error}")),
+    }
+}
+
+pub(super) fn read_path_file_bytes(root: String, relative_path: String) -> ActionResult {
+    use base64::Engine as _;
+    let path = match resolve_path_file(&root, &relative_path) {
+        Ok(path) => path,
+        Err(error) => return ActionResult::Err(error),
+    };
+    let metadata = match std::fs::metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) => return ActionResult::Err(format!("Cannot read file: {error}")),
+    };
+    if metadata.len() > MAX_READ_FILE_BYTES {
+        return ActionResult::Err(format!(
+            "File too large ({:.1} MB). Maximum is {} MB.",
+            metadata.len() as f64 / 1024.0 / 1024.0,
+            MAX_READ_FILE_BYTES / 1024 / 1024
+        ));
+    }
+    match std::fs::read(path) {
+        Ok(bytes) if bytes.len() as u64 <= MAX_READ_FILE_BYTES => {
+            let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+            ActionResult::Ok(Some(serde_json::json!({ "content_b64": encoded })))
+        }
+        Ok(bytes) => ActionResult::Err(format!(
+            "File too large ({:.1} MB). Maximum is {} MB.",
+            bytes.len() as f64 / 1024.0 / 1024.0,
+            MAX_READ_FILE_BYTES / 1024 / 1024
+        )),
+        Err(error) => ActionResult::Err(format!("Cannot read file: {error}")),
+    }
+}
+
+pub(super) fn path_file_size(root: String, relative_path: String) -> ActionResult {
+    let path = match resolve_path_file(&root, &relative_path) {
+        Ok(path) => path,
+        Err(error) => return ActionResult::Err(error),
+    };
+    match std::fs::metadata(path) {
+        Ok(metadata) => ActionResult::Ok(Some(serde_json::json!({
+            "size": metadata.len(),
+            "modified_at_millis": modified_at_millis(&metadata),
+        }))),
+        Err(error) => ActionResult::Err(format!("Cannot read file: {error}")),
+    }
+}
+
 pub(super) fn read_file_bytes(
     ws: &Workspace,
     project_id: String,
@@ -126,11 +492,7 @@ pub(super) fn file_size(ws: &Workspace, project_id: String, relative_path: Strin
             };
             match std::fs::metadata(&canonical) {
                 Ok(m) => {
-                    let modified_at_millis = m
-                        .modified()
-                        .ok()
-                        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-                        .and_then(|duration| u64::try_from(duration.as_millis()).ok());
+                    let modified_at_millis = modified_at_millis(&m);
                     ActionResult::Ok(Some(serde_json::json!({
                         "size": m.len(),
                         "modified_at_millis": modified_at_millis,
@@ -155,37 +517,57 @@ pub fn prepare_content_search(
     context_lines: usize,
     show_ignored: bool,
 ) -> Result<PreparedContentSearch, String> {
+    let project_path = match ws.project(&project_id) {
+        Some(project) => project.path.clone(),
+        None => return Err(format!("project not found: {project_id}")),
+    };
+    prepare_content_search_for_path(
+        &project_path,
+        query,
+        case_sensitive,
+        mode,
+        max_results,
+        file_glob,
+        context_lines,
+        show_ignored,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prepare_content_search_for_path(
+    root: &str,
+    query: String,
+    case_sensitive: bool,
+    mode: String,
+    max_results: usize,
+    file_glob: Option<String>,
+    context_lines: usize,
+    show_ignored: bool,
+) -> Result<PreparedContentSearch, String> {
     if let Some(ref glob) = file_glob
         && (glob.contains("..") || glob.starts_with('/'))
     {
         return Err("file_glob must not contain '..' or start with '/'".to_string());
     }
-    match ws.project(&project_id) {
-        Some(p) => {
-            let project_path = std::path::Path::new(&p.path)
-                .canonicalize()
-                .map_err(|error| format!("Cannot resolve project path: {error}"))?;
-            let search_mode = match mode.as_str() {
-                "regex" => okena_files::content_search::SearchMode::Regex,
-                "fuzzy" => okena_files::content_search::SearchMode::Fuzzy,
-                _ => okena_files::content_search::SearchMode::Literal,
-            };
-            let config = okena_files::content_search::ContentSearchConfig {
-                case_sensitive,
-                mode: search_mode,
-                max_results,
-                file_glob,
-                context_lines,
-                show_ignored,
-            };
-            Ok(PreparedContentSearch {
-                project_path,
-                query,
-                config,
-            })
-        }
-        None => Err(format!("project not found: {project_id}")),
-    }
+    let project_path = canonical_scope_root(root)?;
+    let search_mode = match mode.as_str() {
+        "regex" => okena_files::content_search::SearchMode::Regex,
+        "fuzzy" => okena_files::content_search::SearchMode::Fuzzy,
+        _ => okena_files::content_search::SearchMode::Literal,
+    };
+    let config = okena_files::content_search::ContentSearchConfig {
+        case_sensitive,
+        mode: search_mode,
+        max_results,
+        file_glob,
+        context_lines,
+        show_ignored,
+    };
+    Ok(PreparedContentSearch {
+        project_path,
+        query,
+        config,
+    })
 }
 
 pub fn execute_prepared_content_search(search: PreparedContentSearch) -> ActionResult {
@@ -228,6 +610,32 @@ pub(super) fn search_content(
     match prepare_content_search(
         ws,
         project_id,
+        query,
+        case_sensitive,
+        mode,
+        max_results,
+        file_glob,
+        context_lines,
+        show_ignored,
+    ) {
+        Ok(search) => execute_prepared_content_search(search),
+        Err(error) => ActionResult::Err(error),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn search_path_content(
+    root: String,
+    query: String,
+    case_sensitive: bool,
+    mode: String,
+    max_results: usize,
+    file_glob: Option<String>,
+    context_lines: usize,
+    show_ignored: bool,
+) -> ActionResult {
+    match prepare_content_search_for_path(
+        &root,
         query,
         case_sensitive,
         mode,
@@ -303,6 +711,57 @@ pub(super) fn delete_file(
     }
 }
 
+pub(super) fn rename_path(root: String, relative_path: String, new_name: String) -> ActionResult {
+    if let Err(error) = validate_leaf_name(&new_name) {
+        return ActionResult::Err(error);
+    }
+    let root_path = match canonical_scope_root(&root) {
+        Ok(root) => root,
+        Err(error) => return ActionResult::Err(error),
+    };
+    let old_path = match resolve_project_file(&root, &relative_path) {
+        Ok(path) => path,
+        Err(error) => return ActionResult::Err(error),
+    };
+    if old_path == root_path {
+        return ActionResult::Err("cannot rename browser root".to_string());
+    }
+    let Some(parent) = old_path.parent() else {
+        return ActionResult::Err("path has no parent".to_string());
+    };
+    let new_path = parent.join(&new_name);
+    if new_path.exists() {
+        return ActionResult::Err(format!("target already exists: {new_name}"));
+    }
+    match std::fs::rename(old_path, new_path) {
+        Ok(()) => ActionResult::Ok(None),
+        Err(error) => ActionResult::Err(format!("Cannot rename: {error}")),
+    }
+}
+
+pub(super) fn delete_path(root: String, relative_path: String) -> ActionResult {
+    let root_path = match canonical_scope_root(&root) {
+        Ok(root) => root,
+        Err(error) => return ActionResult::Err(error),
+    };
+    let target = match resolve_project_file(&root, &relative_path) {
+        Ok(path) => path,
+        Err(error) => return ActionResult::Err(error),
+    };
+    if target == root_path {
+        return ActionResult::Err("cannot delete browser root".to_string());
+    }
+    let result = if target.is_dir() {
+        std::fs::remove_dir_all(target)
+    } else {
+        std::fs::remove_file(target)
+    };
+    match result {
+        Ok(()) => ActionResult::Ok(None),
+        Err(error) => ActionResult::Err(format!("Cannot delete: {error}")),
+    }
+}
+
 pub(super) fn create_file(
     ws: &Workspace,
     project_id: String,
@@ -348,5 +807,60 @@ pub(super) fn create_directory(
     match std::fs::create_dir(&target) {
         Ok(()) => ActionResult::Ok(None),
         Err(e) => ActionResult::Err(format!("Cannot create directory: {}", e)),
+    }
+}
+
+#[cfg(test)]
+mod terminal_path_tests {
+    use super::{expand_terminal_path, path_breadcrumbs};
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn relative_path_uses_terminal_cwd() {
+        assert_eq!(
+            expand_terminal_path("notes/release.md", "/srv/project").unwrap(),
+            PathBuf::from("/srv/project/notes/release.md")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_url_decodes_escaped_path() {
+        assert_eq!(
+            expand_terminal_path("file:///tmp/release%20notes.md", "/ignored").unwrap(),
+            PathBuf::from("/tmp/release notes.md")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_url_host_is_informational_on_the_daemon() {
+        assert_eq!(
+            expand_terminal_path("file://build-server/tmp/release.md", "/ignored").unwrap(),
+            PathBuf::from("/tmp/release.md")
+        );
+    }
+
+    #[test]
+    fn tilde_path_uses_daemon_home() {
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .expect("test process should have a home directory");
+        assert_eq!(
+            expand_terminal_path("~/notes.md", "/ignored").unwrap(),
+            PathBuf::from(home).join("notes.md")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn breadcrumbs_include_root_and_each_ancestor() {
+        let breadcrumbs = path_breadcrumbs(Path::new("/srv/apps/demo"));
+        let labels: Vec<&str> = breadcrumbs
+            .iter()
+            .map(|breadcrumb| breadcrumb.label.as_str())
+            .collect();
+        assert_eq!(labels, vec!["/", "srv", "apps", "demo"]);
+        assert_eq!(breadcrumbs[2].canonical_path, "/srv/apps");
     }
 }

--- a/crates/okena-app-core/src/workspace/actions/execute/mod.rs
+++ b/crates/okena-app-core/src/workspace/actions/execute/mod.rs
@@ -369,6 +369,75 @@ pub fn execute_action(
             project_id,
             relative_path,
         } => files::read_file_bytes(ws, project_id, relative_path),
+        ActionRequest::ResolveProjectPath {
+            project_id,
+            relative_path,
+        } => files::resolve_project_path_action(ws, project_id, relative_path),
+        ActionRequest::ResolveTerminalPath { terminal_id, path } => {
+            files::resolve_terminal_path_action(ws, terminals, terminal_id, path)
+        }
+        ActionRequest::ResolvePath { path } => files::resolve_path_action(ws, path),
+        ActionRequest::ResolvePathInScope {
+            root,
+            relative_path,
+        } => files::resolve_path_in_scope_action(ws, root, relative_path),
+        ActionRequest::ListPathFiles { root, show_ignored } => {
+            files::list_path_files(root, show_ignored)
+        }
+        ActionRequest::ListPathDirectory {
+            root,
+            relative_path,
+            show_ignored,
+        } => files::list_path_directory(root, relative_path, show_ignored),
+        ActionRequest::ReadPathFile {
+            root,
+            relative_path,
+        } => files::read_path_file(root, relative_path),
+        ActionRequest::ReadPathFileBytes {
+            root,
+            relative_path,
+        } => files::read_path_file_bytes(root, relative_path),
+        ActionRequest::PathFileSize {
+            root,
+            relative_path,
+        } => files::path_file_size(root, relative_path),
+        ActionRequest::SearchPathContent {
+            root,
+            query,
+            case_sensitive,
+            mode,
+            max_results,
+            file_glob,
+            context_lines,
+            show_ignored,
+        } => files::search_path_content(
+            root,
+            query,
+            case_sensitive,
+            mode,
+            max_results,
+            file_glob,
+            context_lines,
+            show_ignored,
+        ),
+        ActionRequest::RenamePath {
+            root,
+            relative_path,
+            new_name,
+        } => files::rename_path(root, relative_path, new_name),
+        ActionRequest::DeletePath {
+            root,
+            relative_path,
+        } => files::delete_path(root, relative_path),
+        ActionRequest::ReadTerminalFile { terminal_id, path } => {
+            files::read_terminal_file(ws, terminals, terminal_id, path)
+        }
+        ActionRequest::ReadTerminalFileBytes { terminal_id, path } => {
+            files::read_terminal_file_bytes(ws, terminals, terminal_id, path)
+        }
+        ActionRequest::TerminalFileSize { terminal_id, path } => {
+            files::terminal_file_size(ws, terminals, terminal_id, path)
+        }
         ActionRequest::FileSize {
             project_id,
             relative_path,

--- a/crates/okena-app/src/action_dispatch.rs
+++ b/crates/okena-app/src/action_dispatch.rs
@@ -966,6 +966,109 @@ fn strip_remote_ids(action: ActionRequest, connection_id: &str) -> ActionRequest
             project_id: s(&project_id),
             relative_path,
         },
+        ActionRequest::ResolveProjectPath {
+            project_id,
+            relative_path,
+        } => ActionRequest::ResolveProjectPath {
+            project_id: s(&project_id),
+            relative_path,
+        },
+        ActionRequest::ResolveTerminalPath { terminal_id, path } => {
+            ActionRequest::ResolveTerminalPath {
+                terminal_id: s(&terminal_id),
+                path,
+            }
+        }
+        ActionRequest::ResolvePath { path } => ActionRequest::ResolvePath { path },
+        ActionRequest::ResolvePathInScope {
+            root,
+            relative_path,
+        } => ActionRequest::ResolvePathInScope {
+            root,
+            relative_path,
+        },
+        ActionRequest::ListPathFiles { root, show_ignored } => {
+            ActionRequest::ListPathFiles { root, show_ignored }
+        }
+        ActionRequest::ListPathDirectory {
+            root,
+            relative_path,
+            show_ignored,
+        } => ActionRequest::ListPathDirectory {
+            root,
+            relative_path,
+            show_ignored,
+        },
+        ActionRequest::ReadPathFile {
+            root,
+            relative_path,
+        } => ActionRequest::ReadPathFile {
+            root,
+            relative_path,
+        },
+        ActionRequest::ReadPathFileBytes {
+            root,
+            relative_path,
+        } => ActionRequest::ReadPathFileBytes {
+            root,
+            relative_path,
+        },
+        ActionRequest::PathFileSize {
+            root,
+            relative_path,
+        } => ActionRequest::PathFileSize {
+            root,
+            relative_path,
+        },
+        ActionRequest::SearchPathContent {
+            root,
+            query,
+            case_sensitive,
+            mode,
+            max_results,
+            file_glob,
+            context_lines,
+            show_ignored,
+        } => ActionRequest::SearchPathContent {
+            root,
+            query,
+            case_sensitive,
+            mode,
+            max_results,
+            file_glob,
+            context_lines,
+            show_ignored,
+        },
+        ActionRequest::RenamePath {
+            root,
+            relative_path,
+            new_name,
+        } => ActionRequest::RenamePath {
+            root,
+            relative_path,
+            new_name,
+        },
+        ActionRequest::DeletePath {
+            root,
+            relative_path,
+        } => ActionRequest::DeletePath {
+            root,
+            relative_path,
+        },
+        ActionRequest::ReadTerminalFile { terminal_id, path } => ActionRequest::ReadTerminalFile {
+            terminal_id: s(&terminal_id),
+            path,
+        },
+        ActionRequest::ReadTerminalFileBytes { terminal_id, path } => {
+            ActionRequest::ReadTerminalFileBytes {
+                terminal_id: s(&terminal_id),
+                path,
+            }
+        }
+        ActionRequest::TerminalFileSize { terminal_id, path } => ActionRequest::TerminalFileSize {
+            terminal_id: s(&terminal_id),
+            path,
+        },
         ActionRequest::FileSize {
             project_id,
             relative_path,

--- a/crates/okena-app/src/views/overlay_manager.rs
+++ b/crates/okena-app/src/views/overlay_manager.rs
@@ -284,6 +284,12 @@ pub enum OverlayManagerEvent {
     /// File viewer blame click: open the named commit in the diff viewer.
     OpenCommitFromBlame { project_id: String, hash: String },
 
+    OpenFileExternally {
+        path: String,
+        line: Option<usize>,
+        column: Option<usize>,
+    },
+
     /// Profile manager: switch to a different profile (triggers relaunch)
     SwitchProfile(String),
 }
@@ -1684,7 +1690,11 @@ impl OverlayManager {
         if let Some(viewer) = self.cached_file_viewers.get(&cache_key) {
             viewer.update(cx, |v, cx| {
                 v.update_config(font_size, is_dark, cx);
-                v.set_blame_visible(blame_visible, cx);
+                if v.is_scope(&fs) {
+                    v.set_blame_visible(blame_visible, cx);
+                } else {
+                    v.rebind_scope(fs, blame_provider, blame_visible, None, None, None, cx);
+                }
             });
             self.open_file_viewer_modal(viewer.clone(), cx);
             return;
@@ -1720,8 +1730,20 @@ impl OverlayManager {
         if let Some(viewer) = self.cached_file_viewers.get(&cache_key) {
             viewer.update(cx, |v, cx| {
                 v.update_config(font_size, is_dark, cx);
-                v.set_blame_visible(blame_visible, cx);
-                v.open_file_in_tab(relative_path.clone(), cx);
+                if v.is_scope(&fs) {
+                    v.set_blame_visible(blame_visible, cx);
+                    v.open_file_in_tab(relative_path.clone(), cx);
+                } else {
+                    v.rebind_scope(
+                        fs,
+                        blame_provider,
+                        blame_visible,
+                        Some(relative_path.clone()),
+                        None,
+                        None,
+                        cx,
+                    );
+                }
             });
             self.open_file_viewer_modal(viewer.clone(), cx);
             return;
@@ -1741,6 +1763,91 @@ impl OverlayManager {
 
         self.subscribe_file_viewer(&viewer, cx);
         self.cached_file_viewers.insert(cache_key, viewer.clone());
+        self.open_file_viewer_modal(viewer, cx);
+    }
+
+    pub fn show_file_viewer_at(
+        &mut self,
+        relative_path: String,
+        fs: std::sync::Arc<dyn okena_files::project_fs::ProjectFs>,
+        blame_provider: Option<std::sync::Arc<dyn okena_files::blame::BlameProvider>>,
+        line: Option<usize>,
+        column: Option<usize>,
+        cx: &mut Context<Self>,
+    ) {
+        let settings = crate::settings::settings_entity(cx)
+            .read(cx)
+            .settings
+            .clone();
+        let is_dark = crate::theme::theme(cx).is_dark();
+        let cache_key = fs.project_id();
+        if let Some(viewer) = self.cached_file_viewers.get(&cache_key) {
+            viewer.update(cx, |viewer, cx| {
+                viewer.update_config(settings.file_font_size, is_dark, cx);
+                if viewer.is_scope(&fs) {
+                    viewer.set_blame_visible(settings.blame_visible, cx);
+                    viewer.open_file_in_tab_at(relative_path.clone(), line, column, cx);
+                } else {
+                    viewer.rebind_scope(
+                        fs,
+                        blame_provider,
+                        settings.blame_visible,
+                        Some(relative_path.clone()),
+                        line,
+                        column,
+                        cx,
+                    );
+                }
+            });
+            self.open_file_viewer_modal(viewer.clone(), cx);
+            return;
+        }
+        let viewer = cx.new(|cx| {
+            FileViewer::new_at(
+                relative_path,
+                fs,
+                blame_provider,
+                settings.blame_visible,
+                settings.file_font_size,
+                is_dark,
+                line,
+                column,
+                cx,
+            )
+        });
+        self.subscribe_file_viewer(&viewer, cx);
+        self.cached_file_viewers.insert(cache_key, viewer.clone());
+        self.open_file_viewer_modal(viewer, cx);
+    }
+
+    pub fn show_path_browser(
+        &mut self,
+        relative_path: Option<String>,
+        fs: std::sync::Arc<dyn okena_files::project_fs::ProjectFs>,
+        line: Option<usize>,
+        column: Option<usize>,
+        cx: &mut Context<Self>,
+    ) {
+        let settings = crate::settings::settings_entity(cx)
+            .read(cx)
+            .settings
+            .clone();
+        let is_dark = crate::theme::theme(cx).is_dark();
+        let viewer = cx.new(|cx| match relative_path {
+            Some(relative_path) => FileViewer::new_at(
+                relative_path,
+                fs,
+                None,
+                false,
+                settings.file_font_size,
+                is_dark,
+                line,
+                column,
+                cx,
+            ),
+            None => FileViewer::new_browse(fs, None, false, settings.file_font_size, is_dark, cx),
+        });
+        self.subscribe_file_viewer(&viewer, cx);
         self.open_file_viewer_modal(viewer, cx);
     }
 
@@ -1819,6 +1926,13 @@ impl OverlayManager {
                     FileViewerEvent::SendToTerminal(payload) => {
                         this.request_broker.update(cx, |broker, cx| {
                             broker.push_send_to_terminal(payload.clone(), cx);
+                        });
+                    }
+                    FileViewerEvent::OpenExternally { path, line, column } => {
+                        cx.emit(OverlayManagerEvent::OpenFileExternally {
+                            path: path.clone(),
+                            line: *line,
+                            column: *column,
                         });
                     }
                 }

--- a/crates/okena-app/src/views/window/handlers.rs
+++ b/crates/okena-app/src/views/window/handlers.rs
@@ -185,7 +185,7 @@ impl WindowView {
         }
     }
 
-    /// Build a ProjectFs provider for the given project (served by the local daemon).
+    /// Build a daemon filesystem provider rooted at the project's path.
     fn build_project_fs(
         &self,
         project_id: &str,
@@ -194,15 +194,139 @@ impl WindowView {
         let ws = self.workspace.read(cx);
         let project = ws.project(project_id)?;
         let conn_id = project.connection_id.as_ref()?;
-        let (client, actual_id) = self.remote_params(project_id, conn_id, cx)?;
+        let (client, _) = self.remote_params(project_id, conn_id, cx)?;
         Some(std::sync::Arc::new(
-            okena_files::project_fs::RemoteProjectFs::new(
+            okena_files::project_fs::RemotePathFs::new_unresolved(
                 client,
-                actual_id,
                 project.name.clone(),
                 project.path.clone(),
             ),
         ))
+    }
+
+    fn open_terminal_path(
+        &self,
+        project_id: &str,
+        terminal_id: &str,
+        path: String,
+        line: Option<u32>,
+        column: Option<u32>,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(connection_id) = self
+            .workspace
+            .read(cx)
+            .project(project_id)
+            .and_then(|project| project.connection_id.clone())
+        else {
+            okena_workspace::toast::ToastManager::error(
+                "The file's daemon connection is unavailable",
+                cx,
+            );
+            return;
+        };
+        let Some((client, actual_project_id)) = self.remote_params(project_id, &connection_id, cx)
+        else {
+            okena_workspace::toast::ToastManager::error(
+                "The file's daemon connection is unavailable",
+                cx,
+            );
+            return;
+        };
+        let Some(project_fs) = self.build_project_fs(project_id, cx) else {
+            okena_workspace::toast::ToastManager::error(
+                "Cannot create the project file provider",
+                cx,
+            );
+            return;
+        };
+        let blame = self.build_blame_provider(project_id, cx);
+        let actual_terminal_id = okena_transport::client::strip_prefix(terminal_id, &connection_id);
+        let overlay_manager = self.overlay_manager.clone();
+        let line = line.and_then(|value| usize::try_from(value).ok());
+        let column = column.and_then(|value| usize::try_from(value).ok());
+        cx.spawn(async move |_this, cx| {
+            let request_path = path.clone();
+            let action_client = client.clone();
+            let action_terminal_id = actual_terminal_id.clone();
+            let action_project_id = actual_project_id.clone();
+            let result: Result<
+                (
+                    okena_core::api::ResolvedPath,
+                    Option<okena_core::api::ResolvedPath>,
+                ),
+                String,
+            > = cx
+                .background_executor()
+                .spawn(async move {
+                    let value = action_client
+                        .post_action(ActionRequest::ResolveTerminalPath {
+                            terminal_id: action_terminal_id,
+                            path: request_path,
+                        })?
+                        .ok_or_else(|| "Missing resolved path response".to_string())?;
+                    let path = serde_json::from_value::<okena_core::api::ResolvedPath>(value)
+                        .map_err(|error| format!("Invalid resolved path response: {error}"))?;
+                    if path.kind == okena_core::api::ResolvedPathKind::File
+                        && path.project_id.as_deref() == Some(action_project_id.as_str())
+                        && path.relative_path.is_some()
+                    {
+                        return Ok((path, None));
+                    }
+                    if path.kind == okena_core::api::ResolvedPathKind::Directory {
+                        return Ok((path.clone(), Some(path)));
+                    }
+                    let parent = path
+                        .breadcrumbs
+                        .iter()
+                        .rev()
+                        .nth(1)
+                        .ok_or_else(|| "Resolved file has no parent directory".to_string())?;
+                    let value = action_client
+                        .post_action(ActionRequest::ResolvePath {
+                            path: parent.canonical_path.clone(),
+                        })?
+                        .ok_or_else(|| "Missing parent directory response".to_string())?;
+                    let scope = serde_json::from_value::<okena_core::api::ResolvedPath>(value)
+                        .map_err(|error| format!("Invalid parent directory response: {error}"))?;
+                    Ok((path, Some(scope)))
+                })
+                .await;
+            match result {
+                Ok((path, None)) => {
+                    let relative_path = path.relative_path.unwrap_or_default();
+                    overlay_manager.update(cx, |manager, cx| {
+                        manager.show_file_viewer_at(
+                            relative_path,
+                            project_fs,
+                            blame,
+                            line,
+                            column,
+                            cx,
+                        );
+                    });
+                }
+                Ok((path, Some(scope))) => {
+                    let relative_path =
+                        (path.kind == okena_core::api::ResolvedPathKind::File).then_some(path.name);
+                    let fs = std::sync::Arc::new(okena_files::project_fs::RemotePathFs::new(
+                        client, scope,
+                    ));
+                    overlay_manager.update(cx, |manager, cx| {
+                        manager.show_path_browser(relative_path, fs, line, column, cx);
+                    });
+                }
+                Err(error) => {
+                    cx.update(|cx| {
+                        okena_workspace::toast::ToastManager::error(
+                            format!("Cannot open path: {error}"),
+                            cx,
+                        );
+                    });
+                }
+            }
+        })
+        .detach();
     }
 
     /// Evict cached file viewers for projects that no longer exist.
@@ -783,6 +907,35 @@ impl WindowView {
                     });
                 }
             }
+            OverlayManagerEvent::OpenFileExternally { path, line, column } => {
+                let path = path.clone();
+                let line = line.and_then(|value| u32::try_from(value).ok());
+                let column = column.and_then(|value| u32::try_from(value).ok());
+                let opener = crate::settings::settings_entity(cx)
+                    .read(cx)
+                    .settings
+                    .file_opener
+                    .clone();
+                cx.spawn(async move |_this, cx| {
+                    let result = cx
+                        .background_executor()
+                        .spawn(async move {
+                            okena_views_terminal::layout::terminal_pane::url_detector::UrlDetector::open_file(
+                                &path, line, column, &opener,
+                            )
+                        })
+                        .await;
+                    if let Err(error) = result {
+                        cx.update(|cx| {
+                            crate::workspace::toast::ToastManager::error(
+                                format!("Cannot open file: {error}"),
+                                cx,
+                            );
+                        });
+                    }
+                })
+                .detach();
+            }
             OverlayManagerEvent::SwitchProfile(id) => {
                 self.handle_switch_profile(id.clone(), cx);
             }
@@ -1104,6 +1257,14 @@ impl WindowView {
                                 om.show_file_viewer(relative_path, fs, blame, cx);
                             });
                         }
+                    }
+                    ProjectOverlayKind::TerminalPathViewer {
+                        terminal_id,
+                        path,
+                        line,
+                        column,
+                    } => {
+                        self.open_terminal_path(&project_id, &terminal_id, path, line, column, cx);
                     }
                     ProjectOverlayKind::ColorPicker { position } => {
                         self.overlay_manager.update(cx, |om, cx| {

--- a/crates/okena-core/src/api.rs
+++ b/crates/okena-core/src/api.rs
@@ -566,6 +566,54 @@ pub struct ApiFullscreen {
     pub terminal_id: String,
 }
 
+/// The kind of a path resolved on the daemon filesystem.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolvedPathKind {
+    File,
+    Directory,
+}
+
+/// One daemon-native ancestor used by the file browser breadcrumb.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PathBreadcrumb {
+    pub canonical_path: String,
+    pub label: String,
+}
+
+/// A path resolved on the daemon that owns the filesystem.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedPath {
+    pub canonical_path: String,
+    pub name: String,
+    pub kind: ResolvedPathKind,
+    pub size: u64,
+    pub modified_at_millis: Option<u64>,
+    /// Set when the path is inside a known project on this daemon.
+    pub project_id: Option<String>,
+    pub relative_path: Option<String>,
+    /// Ordered from the filesystem root through this path.
+    pub breadcrumbs: Vec<PathBreadcrumb>,
+}
+
+/// Identifies a daemon-side file for streaming downloads.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "source", rename_all = "snake_case", deny_unknown_fields)]
+pub enum FileDownloadRequest {
+    Project {
+        project_id: String,
+        relative_path: String,
+    },
+    Terminal {
+        terminal_id: String,
+        path: String,
+    },
+    Path {
+        root: String,
+        relative_path: String,
+    },
+}
+
 /// POST /v1/actions request body (tagged enum)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
@@ -860,6 +908,82 @@ pub enum ActionRequest {
     ReadFileBytes {
         project_id: String,
         relative_path: String,
+    },
+    ResolveProjectPath {
+        project_id: String,
+        relative_path: String,
+    },
+    ResolveTerminalPath {
+        terminal_id: String,
+        path: String,
+    },
+    ResolvePath {
+        path: String,
+    },
+    ResolvePathInScope {
+        root: String,
+        relative_path: String,
+    },
+    ListPathFiles {
+        root: String,
+        #[serde(default)]
+        show_ignored: bool,
+    },
+    ListPathDirectory {
+        root: String,
+        #[serde(default)]
+        relative_path: String,
+        #[serde(default)]
+        show_ignored: bool,
+    },
+    ReadPathFile {
+        root: String,
+        relative_path: String,
+    },
+    ReadPathFileBytes {
+        root: String,
+        relative_path: String,
+    },
+    PathFileSize {
+        root: String,
+        relative_path: String,
+    },
+    SearchPathContent {
+        root: String,
+        query: String,
+        #[serde(default)]
+        case_sensitive: bool,
+        #[serde(default = "default_search_mode")]
+        mode: String,
+        #[serde(default = "default_max_results")]
+        max_results: usize,
+        #[serde(default)]
+        file_glob: Option<String>,
+        #[serde(default)]
+        context_lines: usize,
+        #[serde(default)]
+        show_ignored: bool,
+    },
+    RenamePath {
+        root: String,
+        relative_path: String,
+        new_name: String,
+    },
+    DeletePath {
+        root: String,
+        relative_path: String,
+    },
+    ReadTerminalFile {
+        terminal_id: String,
+        path: String,
+    },
+    ReadTerminalFileBytes {
+        terminal_id: String,
+        path: String,
+    },
+    TerminalFileSize {
+        terminal_id: String,
+        path: String,
     },
     FileSize {
         project_id: String,
@@ -1574,6 +1698,27 @@ mod tests {
             },
             ActionRequest::ReloadServices {
                 project_id: "p1".into(),
+            },
+            ActionRequest::ResolveTerminalPath {
+                terminal_id: "t1".into(),
+                path: "../notes".into(),
+            },
+            ActionRequest::ResolvePath {
+                path: "/srv/apps".into(),
+            },
+            ActionRequest::ListPathDirectory {
+                root: "/srv/apps".into(),
+                relative_path: "demo".into(),
+                show_ignored: false,
+            },
+            ActionRequest::ReadPathFile {
+                root: "/srv/apps".into(),
+                relative_path: "demo/README.md".into(),
+            },
+            ActionRequest::RenamePath {
+                root: "/srv/apps".into(),
+                relative_path: "demo/old.txt".into(),
+                new_name: "new.txt".into(),
             },
             ActionRequest::RenameFile {
                 project_id: "p1".into(),

--- a/crates/okena-files/Cargo.toml
+++ b/crates/okena-files/Cargo.toml
@@ -52,6 +52,8 @@ base64 = "0.22"
 usvg = { version = "0.45", default-features = false, optional = true }
 ttf-parser = { version = "0.25", optional = true }
 image = { version = "0.25", default-features = false, optional = true }
+dirs = "5"
+tempfile = "3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/okena-files/src/file_viewer/context_menu.rs
+++ b/crates/okena-files/src/file_viewer/context_menu.rs
@@ -326,6 +326,7 @@ impl FileViewer {
             let updated = old.replacen(&old_rel, &new_rel, 1);
             self.expanded_folders.insert(updated);
         }
+        self.invalidate_visible_tree_rows();
     }
 
     // ========================================================================

--- a/crates/okena-files/src/file_viewer/mod.rs
+++ b/crates/okena-files/src/file_viewer/mod.rs
@@ -14,6 +14,7 @@ mod tree;
 
 use crate::blame::{BlameError, BlameLine, BlameProvider};
 use crate::code_view::ScrollbarDrag;
+use crate::file_tree::FileTreeRow;
 use crate::list_directory::DirEntry;
 use crate::selection::SelectionState;
 use crate::syntax::{HighlightedLine, load_syntax_set};
@@ -21,6 +22,7 @@ use context_menu::{DeleteConfirmState, FileRenameState, FileTreeContextMenu, Tab
 use gpui::*;
 use okena_markdown::{MarkdownDocument, MarkdownSelection};
 use okena_ui::resizable_sidebar::ResizableSidebarState;
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -238,6 +240,9 @@ pub(super) struct FileViewerTab {
     /// not on the tab) so the preview pane can render sample text in the
     /// font.
     pub font_data: Option<Arc<FontData>>,
+    /// One-based source position requested by the link that opened this tab.
+    pub target_line: Option<usize>,
+    pub target_column: Option<usize>,
 }
 
 /// Decoded image payload. Raster formats let GPUI's asset cache handle the
@@ -394,6 +399,8 @@ impl FileViewerTab {
             image_view: ImageViewState::default(),
             is_font: false,
             font_data: None,
+            target_line: None,
+            target_column: None,
         }
     }
 
@@ -436,6 +443,8 @@ impl FileViewerTab {
             image_view: ImageViewState::default(),
             is_font,
             font_data: None,
+            target_line: None,
+            target_column: None,
         }
     }
 
@@ -544,8 +553,12 @@ pub struct FileViewer {
     pub(super) tree_error_message: Option<String>,
     /// Which folder paths are currently expanded
     expanded_folders: HashSet<String>,
-    /// Scroll handle for the file tree sidebar
-    tree_scroll_handle: ScrollHandle,
+    /// Cached flattened rows for the currently visible file tree.
+    pub(super) visible_tree_rows: RefCell<Option<Arc<Vec<FileTreeRow<String>>>>>,
+    /// Scroll handle for the virtualized file tree sidebar.
+    tree_scroll_handle: UniformListScrollHandle,
+    /// Active drag gesture for the file tree scrollbar.
+    tree_scrollbar_drag: Option<ScrollbarDrag>,
     /// Whether the sidebar is visible
     sidebar_visible: bool,
     /// Width and active resize gesture for the file tree sidebar.
@@ -593,6 +606,12 @@ pub struct FileViewer {
     /// applies its result if the tab's recorded generation still matches,
     /// so a slow earlier load can't overwrite a faster later one.
     next_load_generation: u64,
+    /// Canonical daemon scope and its breadcrumb ancestry.
+    pub(super) scope: Option<okena_core::api::ResolvedPath>,
+    pub(super) scope_navigation_in_flight: bool,
+    scope_generation: u64,
+    pub(super) transfer_in_progress: bool,
+    pub(super) transfer_status: Option<String>,
 }
 
 impl FileViewer {
@@ -602,6 +621,74 @@ impl FileViewer {
         relative_path: &str,
     ) -> PathBuf {
         PathBuf::from(fs.project_id()).join(relative_path)
+    }
+
+    pub fn is_scope(&self, fs: &std::sync::Arc<dyn crate::project_fs::ProjectFs>) -> bool {
+        self.project_fs.scope_path() == fs.scope_path()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn rebind_scope(
+        &mut self,
+        project_fs: std::sync::Arc<dyn crate::project_fs::ProjectFs>,
+        blame_provider: Option<std::sync::Arc<dyn BlameProvider>>,
+        blame_visible: bool,
+        relative_path: Option<String>,
+        line: Option<usize>,
+        column: Option<usize>,
+        cx: &mut Context<Self>,
+    ) {
+        for tab in &mut self.tabs {
+            if let Some(decoded) = tab.image_data.take() {
+                release_image_assets(decoded, cx);
+            }
+        }
+        self.project_fs = project_fs;
+        self.scope = None;
+        self.scope_generation = self.scope_generation.wrapping_add(1);
+        self.scope_navigation_in_flight = false;
+        self.loaded_dirs.clear();
+        self.loading_dirs.clear();
+        self.tree_error_message = None;
+        self.expanded_folders = relative_path
+            .as_deref()
+            .map(Self::compute_expanded_for_relative)
+            .unwrap_or_default();
+        self.invalidate_visible_tree_rows();
+        self.tree_scroll_handle
+            .scroll_to_item(0, ScrollStrategy::Top);
+        self.tree_scrollbar_drag = None;
+        self.tabs = vec![match &relative_path {
+            Some(relative_path) => {
+                let mut tab = FileViewerTab::new_loading(
+                    relative_path.clone(),
+                    Self::tree_path(&self.project_fs, relative_path),
+                );
+                tab.target_line = line;
+                tab.target_column = column;
+                if line.is_some() {
+                    tab.display_mode = DisplayMode::Source;
+                }
+                tab
+            }
+            None => FileViewerTab::new_empty(),
+        }];
+        self.active_tab = 0;
+        self.history = NavigationHistory::new();
+        self.loading = true;
+        self.freshness_check_in_flight = false;
+        self.sidebar_visible = true;
+        self.blame_provider = blame_provider;
+        self.blame_visible = blame_visible;
+        self.fetch_scope_info(cx);
+        self.fetch_initial_dirs(cx);
+        if let Some(relative_path) = relative_path {
+            self.spawn_tab_load(relative_path, cx);
+            if self.blame_visible {
+                self.spawn_blame_load_for_active(cx);
+            }
+        }
+        cx.notify();
     }
 
     /// Create a new file viewer with `relative_path` (project-relative) opened
@@ -615,12 +702,43 @@ impl FileViewer {
         is_dark: bool,
         cx: &mut Context<Self>,
     ) -> Self {
+        Self::new_at(
+            relative_path,
+            project_fs,
+            blame_provider,
+            blame_visible,
+            font_size,
+            is_dark,
+            None,
+            None,
+            cx,
+        )
+    }
+
+    /// Create a project file viewer and focus an optional one-based position.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_at(
+        relative_path: String,
+        project_fs: std::sync::Arc<dyn crate::project_fs::ProjectFs>,
+        blame_provider: Option<std::sync::Arc<dyn BlameProvider>>,
+        blame_visible: bool,
+        font_size: f32,
+        is_dark: bool,
+        line: Option<usize>,
+        column: Option<usize>,
+        cx: &mut Context<Self>,
+    ) -> Self {
         let focus_handle = cx.focus_handle();
         let expanded_folders = Self::compute_expanded_for_relative(&relative_path);
         let syntax_set = load_syntax_set();
 
         let file_path = Self::tree_path(&project_fs, &relative_path);
-        let tab = FileViewerTab::new_loading(relative_path.clone(), file_path.clone());
+        let mut tab = FileViewerTab::new_loading(relative_path.clone(), file_path.clone());
+        tab.target_line = line;
+        tab.target_column = column;
+        if line.is_some() {
+            tab.display_mode = DisplayMode::Source;
+        }
 
         let mut viewer = Self {
             focus_handle,
@@ -634,7 +752,9 @@ impl FileViewer {
             loading_dirs: HashSet::new(),
             tree_error_message: None,
             expanded_folders,
-            tree_scroll_handle: ScrollHandle::new(),
+            visible_tree_rows: RefCell::new(None),
+            tree_scroll_handle: UniformListScrollHandle::new(),
+            tree_scrollbar_drag: None,
             sidebar_visible: true,
             sidebar_resize: ResizableSidebarState::default(),
             tabs: vec![tab],
@@ -655,10 +775,16 @@ impl FileViewer {
             blame_visible,
             selection_context_menu: None,
             next_load_generation: 0,
+            scope: None,
+            scope_navigation_in_flight: false,
+            scope_generation: 0,
+            transfer_in_progress: false,
+            transfer_status: None,
         };
 
         // Kick off the root directory listing and any expanded ancestors so
         // the tree fills in around the opened file.
+        viewer.fetch_scope_info(cx);
         viewer.fetch_initial_dirs(cx);
         viewer.spawn_tab_load(relative_path, cx);
         if viewer.blame_visible {
@@ -692,7 +818,9 @@ impl FileViewer {
             loading_dirs: HashSet::new(),
             tree_error_message: None,
             expanded_folders: HashSet::new(),
-            tree_scroll_handle: ScrollHandle::new(),
+            visible_tree_rows: RefCell::new(None),
+            tree_scroll_handle: UniformListScrollHandle::new(),
+            tree_scrollbar_drag: None,
             sidebar_visible: true,
             sidebar_resize: ResizableSidebarState::default(),
             tabs: vec![FileViewerTab::new_empty()],
@@ -713,7 +841,13 @@ impl FileViewer {
             blame_visible,
             selection_context_menu: None,
             next_load_generation: 0,
+            scope: None,
+            scope_navigation_in_flight: false,
+            scope_generation: 0,
+            transfer_in_progress: false,
+            transfer_status: None,
         };
+        viewer.fetch_scope_info(cx);
         viewer.fetch_initial_dirs(cx);
         viewer
     }
@@ -735,6 +869,96 @@ impl FileViewer {
     /// Request to detach the viewer into a separate OS window.
     pub(super) fn request_detach(&self, cx: &mut Context<Self>) {
         cx.emit(FileViewerEvent::Detach);
+    }
+
+    pub(super) fn request_source_action(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        use crate::project_fs::FileSourceAction;
+        let tab = self.active_tab();
+        match self.project_fs.source_action() {
+            FileSourceAction::OpenExternally => {
+                let Some(path) = self.project_fs.absolute_path(&tab.relative_path) else {
+                    self.transfer_status = Some("The daemon did not provide a local path".into());
+                    cx.notify();
+                    return;
+                };
+                cx.emit(FileViewerEvent::OpenExternally {
+                    path,
+                    line: tab.target_line,
+                    column: tab.target_column,
+                });
+            }
+            FileSourceAction::Download => {
+                if self.transfer_in_progress {
+                    return;
+                }
+                let initial_dir = dirs::download_dir()
+                    .or_else(|| std::env::current_dir().ok())
+                    .unwrap_or_else(std::env::temp_dir);
+                let filename = tab.filename();
+                let relative_path = tab.relative_path.clone();
+                let provider = self.project_fs.clone();
+                let receiver = cx.prompt_for_new_path(&initial_dir, Some(&filename));
+                self.transfer_status = None;
+                cx.spawn_in(window, async move |entity: WeakEntity<Self>, cx| {
+                    let destination = match receiver.await {
+                        Ok(Ok(Some(destination))) => destination,
+                        Ok(Ok(None)) => return,
+                        Ok(Err(error)) => {
+                            let _ = entity.update(cx, |this, cx| {
+                                this.transfer_status =
+                                    Some(format!("Cannot open save dialog: {error}"));
+                                cx.notify();
+                            });
+                            return;
+                        }
+                        Err(error) => {
+                            let _ = entity.update(cx, |this, cx| {
+                                this.transfer_status =
+                                    Some(format!("Save dialog closed unexpectedly: {error}"));
+                                cx.notify();
+                            });
+                            return;
+                        }
+                    };
+                    let _ = entity.update(cx, |this, cx| {
+                        this.transfer_in_progress = true;
+                        this.transfer_status = Some("Downloading…".to_string());
+                        cx.notify();
+                    });
+                    let saved_path = destination.clone();
+                    let result = cx
+                        .background_executor()
+                        .spawn(async move {
+                            use std::io::Write as _;
+                            let parent = destination.parent().ok_or_else(|| {
+                                "Selected path has no parent directory".to_string()
+                            })?;
+                            let mut temporary =
+                                tempfile::NamedTempFile::new_in(parent).map_err(|error| {
+                                    format!("Cannot create temporary file: {error}")
+                                })?;
+                            provider.download_file(&relative_path, temporary.as_file_mut())?;
+                            temporary.as_file_mut().flush().map_err(|error| {
+                                format!("Cannot flush downloaded file: {error}")
+                            })?;
+                            temporary.persist(&destination).map_err(|error| {
+                                format!("Cannot save downloaded file: {}", error.error)
+                            })?;
+                            Ok::<(), String>(())
+                        })
+                        .await;
+                    let _ = entity.update(cx, |this, cx| {
+                        this.transfer_in_progress = false;
+                        this.transfer_status = Some(match result {
+                            Ok(()) => format!("Saved to {}", saved_path.display()),
+                            Err(error) => error,
+                        });
+                        cx.notify();
+                    });
+                })
+                .detach();
+            }
+        }
     }
 
     /// Update configuration (font size and dark mode) from the host app.
@@ -770,6 +994,7 @@ impl FileViewer {
         self.loaded_dirs.clear();
         self.loading_dirs.clear();
         self.tree_error_message = None;
+        self.invalidate_visible_tree_rows();
         for path in to_refetch {
             self.fetch_directory(path, cx);
         }
@@ -794,6 +1019,7 @@ impl FileViewer {
             self.loaded_dirs.remove(path);
             self.loading_dirs.remove(path);
         }
+        self.invalidate_visible_tree_rows();
         // Always re-fetch the target dir even if it wasn't loaded before — the
         // caller asked us to refresh it.
         self.fetch_directory(relative_path.to_string(), cx);
@@ -802,6 +1028,129 @@ impl FileViewer {
                 self.fetch_directory(path, cx);
             }
         }
+    }
+
+    fn fetch_scope_info(&mut self, cx: &mut Context<Self>) {
+        let fs = self.project_fs.clone();
+        let path = fs.scope_path();
+        let generation = self.scope_generation;
+        cx.spawn(async move |entity: WeakEntity<Self>, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move { fs.resolve_path(&path) })
+                .await;
+            let _ = entity.update(cx, |this, cx| {
+                if this.scope_generation != generation {
+                    return;
+                }
+                match result {
+                    Ok(scope) if scope.kind == okena_core::api::ResolvedPathKind::Directory => {
+                        this.scope = Some(scope);
+                    }
+                    Ok(_) => {
+                        this.tree_error_message =
+                            Some("Browser scope is not a directory".to_string());
+                    }
+                    Err(error) => this.tree_error_message = Some(error),
+                }
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    pub(super) fn navigate_up(&mut self, cx: &mut Context<Self>) {
+        let Some(parent) = self
+            .scope
+            .as_ref()
+            .and_then(|scope| scope.breadcrumbs.iter().rev().nth(1))
+        else {
+            return;
+        };
+        self.navigate_to_scope(parent.canonical_path.clone(), cx);
+    }
+
+    pub(super) fn navigate_to_scope(&mut self, path: String, cx: &mut Context<Self>) {
+        if self.scope_navigation_in_flight
+            || self
+                .scope
+                .as_ref()
+                .is_some_and(|scope| scope.canonical_path == path)
+        {
+            return;
+        }
+        let old_fs = self.project_fs.clone();
+        let old_scope_path = self
+            .scope
+            .as_ref()
+            .map(|scope| scope.canonical_path.clone())
+            .unwrap_or_else(|| old_fs.scope_path());
+        let absolute_tabs: Vec<Option<String>> = self
+            .tabs
+            .iter()
+            .map(|tab| {
+                (!tab.is_empty()).then(|| {
+                    crate::project_fs::join_daemon_path(&old_scope_path, &tab.relative_path)
+                })
+            })
+            .collect();
+        self.scope_navigation_in_flight = true;
+        self.transfer_status = None;
+        cx.notify();
+
+        cx.spawn(async move |entity: WeakEntity<Self>, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move {
+                    let scope = old_fs.resolve_path(&path)?;
+                    if scope.kind != okena_core::api::ResolvedPathKind::Directory {
+                        return Err("Browser scope is not a directory".to_string());
+                    }
+                    let fs = old_fs.scoped_to(scope.clone());
+                    Ok((scope, fs))
+                })
+                .await;
+            let _ = entity.update(cx, |this, cx| {
+                this.scope_navigation_in_flight = false;
+                match result {
+                    Ok((scope, fs)) => {
+                        for (tab, absolute_path) in this.tabs.iter_mut().zip(absolute_tabs) {
+                            let Some(absolute_path) = absolute_path else {
+                                continue;
+                            };
+                            let Some(relative_path) = fs.relative_path(&absolute_path) else {
+                                continue;
+                            };
+                            tab.relative_path = relative_path.clone();
+                            tab.file_path = Self::tree_path(&fs, &relative_path);
+                        }
+                        this.project_fs = fs;
+                        this.scope = Some(scope);
+                        this.scope_generation = this.scope_generation.wrapping_add(1);
+                        this.loaded_dirs.clear();
+                        this.loading_dirs.clear();
+                        this.expanded_folders.clear();
+                        this.tree_error_message = None;
+                        this.invalidate_visible_tree_rows();
+                        this.tree_scroll_handle
+                            .scroll_to_item(0, ScrollStrategy::Top);
+                        this.tree_scrollbar_drag = None;
+                        this.loading = true;
+                        this.freshness_check_in_flight = false;
+                        this.sidebar_visible = true;
+                        this.history = NavigationHistory::new();
+                        this.blame_provider = None;
+                        for tab in &mut this.tabs {
+                            tab.blame = BlameLoadState::NotLoaded;
+                        }
+                        this.fetch_initial_dirs(cx);
+                    }
+                    Err(error) => this.tree_error_message = Some(error),
+                }
+                cx.notify();
+            });
+        })
+        .detach();
     }
 
     /// Fetch the initial directory listings: the project root plus any
@@ -823,15 +1172,20 @@ impl FileViewer {
         {
             return;
         }
+        self.invalidate_visible_tree_rows();
         let fs = self.project_fs.clone();
         let show_ignored = self.show_ignored;
         let path_for_task = relative_path.clone();
+        let generation = self.scope_generation;
         cx.spawn(async move |entity: WeakEntity<Self>, cx| {
             let result: Result<Vec<DirEntry>, String> = cx
                 .background_executor()
                 .spawn(async move { fs.list_directory(&path_for_task, show_ignored) })
                 .await;
             let _ = entity.update(cx, |this, cx| {
+                if this.scope_generation != generation {
+                    return;
+                }
                 this.loading_dirs.remove(&relative_path);
                 match result {
                     Ok(entries) => {
@@ -867,6 +1221,7 @@ impl FileViewer {
                 if relative_path.is_empty() {
                     this.loading = false;
                 }
+                this.invalidate_visible_tree_rows();
                 cx.notify();
             });
         })
@@ -891,6 +1246,7 @@ impl FileViewer {
         let old_mtime = tab.modified_at;
         let fs = self.project_fs.clone();
         let path_for_request = relative_path.clone();
+        let generation = self.scope_generation;
 
         self.freshness_check_in_flight = true;
         cx.spawn(async move |entity: WeakEntity<Self>, cx| {
@@ -899,6 +1255,9 @@ impl FileViewer {
                 .spawn(async move { fs.file_metadata(&path_for_request) })
                 .await;
             let _ = entity.update(cx, |this, cx| {
+                if this.scope_generation != generation {
+                    return;
+                }
                 this.freshness_check_in_flight = false;
                 match result {
                     Ok(metadata) if metadata.modified_at_millis != old_mtime => {
@@ -1177,6 +1536,25 @@ impl FileViewer {
         cx.notify();
     }
 
+    pub fn open_file_in_tab_at(
+        &mut self,
+        relative_path: String,
+        line: Option<usize>,
+        column: Option<usize>,
+        cx: &mut Context<Self>,
+    ) {
+        self.open_file_in_tab(relative_path, cx);
+        let tab = self.active_tab_mut();
+        tab.target_line = line;
+        tab.target_column = column;
+        if let Some(line) = line {
+            tab.display_mode = DisplayMode::Source;
+            tab.source_scroll_handle
+                .scroll_to_item(line.saturating_sub(1), ScrollStrategy::Center);
+        }
+        cx.notify();
+    }
+
     /// Insert `new_tab` directly after the active tab and return
     /// `(new_active_index, evicted_tab)`. When already at `MAX_TABS`, the
     /// oldest tab is evicted first to make room — never the active tab,
@@ -1213,6 +1591,7 @@ impl FileViewer {
             self.fetch_directory(path.clone(), cx);
         }
         self.expanded_folders.extend(expanded);
+        self.invalidate_visible_tree_rows();
     }
 
     /// Close a tab by index.
@@ -1417,6 +1796,7 @@ impl FileViewer {
                 .await;
             let _ = entity.update(cx, |this, cx| {
                 let mut old_image: Option<DecodedImage> = None;
+                let mut target_line: Option<usize> = None;
                 if let Some(tab) = this
                     .tabs
                     .iter_mut()
@@ -1453,8 +1833,14 @@ impl FileViewer {
                         &this.syntax_set,
                         this.is_dark,
                     );
+                    target_line = tab.target_line;
                     tab.blame = BlameLoadState::NotLoaded;
                     cx.notify();
+                }
+                if let Some(line) = target_line {
+                    this.active_tab()
+                        .source_scroll_handle
+                        .scroll_to_item(line.saturating_sub(1), ScrollStrategy::Center);
                 }
                 if let Some(decoded) = old_image {
                     release_image_assets(decoded, cx);
@@ -1498,6 +1884,12 @@ pub enum FileViewerEvent {
     /// User clicked "Send to terminal" on a selection. Carries the structured
     /// payload; the host formats it (relative to terminal CWD) before pasting.
     SendToTerminal(okena_core::send_payload::SendPayload),
+    /// Open the daemon-side path with a same-host external application.
+    OpenExternally {
+        path: String,
+        line: Option<usize>,
+        column: Option<usize>,
+    },
 }
 
 /// Release the GPU-side cache entries backing a `DecodedImage` before the

--- a/crates/okena-files/src/file_viewer/render.rs
+++ b/crates/okena-files/src/file_viewer/render.rs
@@ -44,7 +44,7 @@ fn loading_row(depth: usize, t: &ThemeColors, cx: &App) -> Div {
     div()
         .flex()
         .items_center()
-        .h(px(22.0))
+        .h(px(26.0))
         .pl(px(indent + 8.0 + 18.0))
         .pr(px(12.0))
         .text_size(ui_text(12.0, cx))
@@ -71,6 +71,15 @@ impl FileViewer {
 
         let mut bg_ranges = selection_bg_ranges(&tab.selection, line_number, line.plain_text.len());
         bg_ranges.extend(self.search_bg_ranges_for_line(line_number, t));
+        if tab.target_line == Some(line_number + 1)
+            && let Some(column) = tab.target_column
+        {
+            let char_index = column.saturating_sub(1);
+            if let Some((start, character)) = line.plain_text.char_indices().nth(char_index) {
+                let end = start + character.len_utf8();
+                bg_ranges.push((start..end, rgba(t.selection_bg, 0.8).into()));
+            }
+        }
 
         let plain_text = line.plain_text.clone();
         let line_len = line.plain_text.len();
@@ -83,6 +92,9 @@ impl FileViewer {
             .w_full()
             .flex()
             .h(px(line_height))
+            .when(tab.target_line == Some(line_number + 1), |d| {
+                d.bg(rgba(t.bg_selection, 0.55))
+            })
             .text_size(ui_text(font_size, cx))
             .font_family("monospace")
             .on_mouse_down(MouseButton::Left, {
@@ -196,7 +208,7 @@ impl FileViewer {
     pub(super) fn render_sidebar(
         &self,
         t: &ThemeColors,
-        tree_elements: Vec<AnyElement>,
+        tree_rows: Arc<Vec<FileTreeRow<String>>>,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let active_count = self.show_ignored as u8;
@@ -242,12 +254,19 @@ impl FileViewer {
                 )
             });
 
-        let tree = div()
-            .id("file-viewer-tree")
+        let row_count = tree_rows.len();
+        let rows_for_render = tree_rows;
+        let view = cx.entity().clone();
+        let tree_theme = Arc::new(*t);
+        let tree_scrollbar_geometry = get_scrollbar_geometry(&self.tree_scroll_handle);
+        let tree_scrollbar_is_dragging = self.tree_scrollbar_drag.is_some();
+        let tree_is_measured = self.tree_scroll_handle.0.borrow().last_item_size.is_some();
+        if row_count > 0 && !tree_is_measured {
+            cx.notify();
+        }
+        let tree = v_flex()
             .flex_1()
-            .overflow_y_scroll()
-            .track_scroll(&self.tree_scroll_handle)
-            .py(px(6.0))
+            .min_h_0()
             .when_some(self.tree_error_message.clone(), |d, error| {
                 d.child(
                     div()
@@ -258,7 +277,37 @@ impl FileViewer {
                         .child(error),
                 )
             })
-            .children(tree_elements);
+            .child(
+                div()
+                    .relative()
+                    .flex_1()
+                    .min_h_0()
+                    .child(
+                        uniform_list("file-viewer-tree", row_count, move |range, _window, cx| {
+                            view.update(cx, |this, cx| {
+                                this.render_file_tree_range(
+                                    &rows_for_render[range],
+                                    &tree_theme,
+                                    cx,
+                                )
+                            })
+                        })
+                        .size_full()
+                        .track_scroll(&self.tree_scroll_handle),
+                    )
+                    .when_some(
+                        tree_scrollbar_geometry,
+                        |d, (_, _, thumb_y, thumb_height)| {
+                            d.child(self.render_tree_scrollbar(
+                                t,
+                                thumb_y,
+                                thumb_height,
+                                tree_scrollbar_is_dragging,
+                                cx,
+                            ))
+                        },
+                    ),
+            );
 
         let entity = cx.entity().downgrade();
         let entity_for_end = entity.clone();
@@ -283,13 +332,14 @@ impl FileViewer {
         )
     }
 
-    /// Render the canonical visible file-tree rows.
-    pub(super) fn render_file_tree(
+    /// Render only the file-tree rows requested by the virtualized list.
+    fn render_file_tree_range(
         &self,
+        rows: &[FileTreeRow<String>],
         t: &ThemeColors,
         cx: &mut Context<Self>,
     ) -> Vec<AnyElement> {
-        let mut elements: Vec<AnyElement> = Vec::new();
+        let mut elements: Vec<AnyElement> = Vec::with_capacity(rows.len());
         let active_relative = self.active_tab().relative_path.clone();
         let open_relatives: std::collections::HashSet<String> = self
             .tabs
@@ -298,25 +348,25 @@ impl FileViewer {
             .map(|t| t.relative_path.clone())
             .collect();
 
-        for row in self.file_tree_rows(false) {
+        for row in rows {
             match row {
                 FileTreeRow::Folder {
                     path, name, depth, ..
                 } => {
-                    self.render_folder_row(&mut elements, &name, &path, depth, t, cx);
+                    self.render_folder_row(&mut elements, name, path, *depth, t, cx);
                 }
                 FileTreeRow::File {
                     item: file_relative,
                     depth,
                 } => {
-                    let filename = file_relative.rsplit('/').next().unwrap_or(&file_relative);
-                    let is_active = active_relative == file_relative;
-                    let is_open = open_relatives.contains(&file_relative);
+                    let filename = file_relative.rsplit('/').next().unwrap_or(file_relative);
+                    let is_active = active_relative == file_relative.as_str();
+                    let is_open = open_relatives.contains(file_relative);
                     self.render_file_row(
                         &mut elements,
                         filename,
-                        &file_relative,
-                        depth,
+                        file_relative,
+                        *depth,
                         is_active,
                         is_open,
                         t,
@@ -324,7 +374,7 @@ impl FileViewer {
                     );
                 }
                 FileTreeRow::Loading { depth } => {
-                    elements.push(loading_row(depth, t, cx).into_any_element());
+                    elements.push(loading_row(*depth, t, cx).into_any_element());
                 }
             }
         }
@@ -545,6 +595,58 @@ impl FileViewer {
             )
     }
 
+    fn render_tree_scrollbar(
+        &self,
+        t: &ThemeColors,
+        thumb_y: f32,
+        thumb_height: f32,
+        is_dragging: bool,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        div()
+            .id("file-tree-scrollbar-track")
+            .absolute()
+            .top_0()
+            .bottom_0()
+            .right_0()
+            .w(px(12.0))
+            .cursor(CursorStyle::Arrow)
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, event: &MouseDownEvent, _window, cx| {
+                    let y = f32::from(event.position.y);
+                    if get_scrollbar_geometry(&this.tree_scroll_handle).is_some() {
+                        this.start_tree_scrollbar_drag(y, cx);
+                    }
+                }),
+            )
+            .on_mouse_move(cx.listener(|this, event: &MouseMoveEvent, _window, cx| {
+                if this.tree_scrollbar_drag.is_some() {
+                    let y = f32::from(event.position.y);
+                    this.update_tree_scrollbar_drag(y, cx);
+                }
+            }))
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, _, _window, cx| this.end_tree_scrollbar_drag(cx)),
+            )
+            .child(
+                div()
+                    .absolute()
+                    .top(px(thumb_y))
+                    .right(px(3.0))
+                    .w(px(6.0))
+                    .h(px(thumb_height))
+                    .rounded(px(3.0))
+                    .bg(rgb(if is_dragging {
+                        t.scrollbar_hover
+                    } else {
+                        t.scrollbar
+                    }))
+                    .hover(|s| s.bg(rgb(t.scrollbar_hover))),
+            )
+    }
+
     /// Render the tab bar (styled like terminal tabs).
     fn render_tab_bar(&self, t: &ThemeColors, cx: &mut Context<Self>) -> impl IntoElement {
         let mut tab_elements: Vec<AnyElement> = Vec::new();
@@ -712,6 +814,99 @@ impl FileViewer {
                             }))
                             .opacity(if can_forward { 1.0 } else { 0.4 }),
                     ),
+            )
+    }
+
+    fn render_scope_navigation(&self, t: &ThemeColors, cx: &mut Context<Self>) -> Div {
+        let can_go_up = self
+            .scope
+            .as_ref()
+            .is_some_and(|scope| scope.breadcrumbs.len() > 1)
+            && !self.scope_navigation_in_flight;
+        let mut breadcrumbs = Vec::new();
+        if let Some(scope) = &self.scope {
+            let last = scope.breadcrumbs.len().saturating_sub(1);
+            for (index, breadcrumb) in scope.breadcrumbs.iter().enumerate() {
+                if index > 0 {
+                    breadcrumbs.push(
+                        svg()
+                            .path("icons/chevron-right.svg")
+                            .size(px(10.0))
+                            .text_color(rgb(t.text_muted))
+                            .into_any_element(),
+                    );
+                }
+                let path = breadcrumb.canonical_path.clone();
+                let is_current = index == last;
+                breadcrumbs.push(
+                    div()
+                        .id(ElementId::Name(format!("scope-breadcrumb-{index}").into()))
+                        .px(px(3.0))
+                        .py(px(1.0))
+                        .rounded(px(3.0))
+                        .text_size(ui_text_sm(cx))
+                        .text_color(rgb(if is_current {
+                            t.text_secondary
+                        } else {
+                            t.text_muted
+                        }))
+                        .when(!is_current, |d| {
+                            d.cursor_pointer()
+                                .hover(|style| style.bg(rgb(t.bg_hover)))
+                                .on_click(cx.listener(move |this, _, _window, cx| {
+                                    this.navigate_to_scope(path.clone(), cx);
+                                }))
+                        })
+                        .child(breadcrumb.label.clone())
+                        .into_any_element(),
+                );
+            }
+        }
+
+        h_flex()
+            .min_w_0()
+            .gap(px(4.0))
+            .child(
+                div()
+                    .id("scope-up")
+                    .flex_shrink_0()
+                    .cursor(if can_go_up {
+                        CursorStyle::PointingHand
+                    } else {
+                        CursorStyle::Arrow
+                    })
+                    .w(px(22.0))
+                    .h(px(22.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded(px(4.0))
+                    .when(can_go_up, |d| d.hover(|style| style.bg(rgb(t.bg_hover))))
+                    .on_click(cx.listener(|this, _, _window, cx| this.navigate_up(cx)))
+                    .tooltip(|window, cx| {
+                        gpui_component::tooltip::Tooltip::new("Parent directory").build(window, cx)
+                    })
+                    .child(
+                        svg()
+                            .path("icons/chevron-up.svg")
+                            .size(px(13.0))
+                            .text_color(rgb(t.text_muted))
+                            .opacity(if can_go_up { 1.0 } else { 0.4 }),
+                    ),
+            )
+            .child(
+                h_flex()
+                    .min_w_0()
+                    .overflow_hidden()
+                    .gap(px(1.0))
+                    .child(
+                        div()
+                            .flex_shrink_0()
+                            .text_size(ui_text_sm(cx))
+                            .text_color(rgb(t.text_muted))
+                            .child(format!("{}:", self.project_fs.owner_label())),
+                    )
+                    .children(breadcrumbs),
             )
     }
 
@@ -1140,6 +1335,7 @@ impl Render for FileViewer {
         let t = theme(cx);
         let focus_handle = self.focus_handle.clone();
         let tab = self.active_tab();
+        let has_file = !tab.is_empty();
         let tab_loading = tab.loading;
         let has_error = tab.error_message.is_some();
         let error_message = tab.error_message.clone();
@@ -1166,17 +1362,26 @@ impl Render for FileViewer {
         let sidebar_visible = self.sidebar_visible;
         let show_tabs = self.tabs.len() > 1;
 
-        let filename = tab
-            .file_path
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| "File".to_string());
-
-        let relative_path = if !tab.relative_path.is_empty() {
-            tab.relative_path.clone()
+        let filename = if has_file {
+            tab.file_path
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_else(|| "File".to_string())
         } else {
-            tab.file_path.to_string_lossy().to_string()
+            self.project_fs.project_name()
         };
+        let source_action = self.project_fs.source_action();
+        let source_action_label = match source_action {
+            crate::project_fs::FileSourceAction::OpenExternally => "Open externally",
+            crate::project_fs::FileSourceAction::Download => {
+                if self.transfer_in_progress {
+                    "Downloading…"
+                } else {
+                    "Download"
+                }
+            }
+        };
+        let transfer_status = self.transfer_status.clone();
 
         // Measure actual monospace character width from font metrics
         let font = Font {
@@ -1201,11 +1406,12 @@ impl Render for FileViewer {
         let scrollbar_geometry = get_scrollbar_geometry(&tab.source_scroll_handle);
         let is_dragging_scrollbar = tab.scrollbar_drag.is_some();
 
-        // Pre-render tree elements for sidebar
-        let tree_elements = if sidebar_visible {
-            self.render_file_tree(&t, cx)
+        // Flatten the tree only when its structure changes. The sidebar list
+        // renders just the visible range from these cached rows.
+        let tree_rows = if sidebar_visible {
+            self.visible_file_tree_rows()
         } else {
-            Vec::new()
+            Arc::new(Vec::new())
         };
 
         // Markdown preview uses a virtualized list (built below) so only the
@@ -1392,12 +1598,19 @@ impl Render for FileViewer {
                     let y = f32::from(event.position.y);
                     this.update_scrollbar_drag(y, cx);
                 }
+                if this.tree_scrollbar_drag.is_some() {
+                    let y = f32::from(event.position.y);
+                    this.update_tree_scrollbar_drag(y, cx);
+                }
             }))
             .on_mouse_up(
                 MouseButton::Left,
                 cx.listener(|this, _, _window, cx| {
                     if this.active_tab().scrollbar_drag.is_some() {
                         this.end_scrollbar_drag(cx);
+                    }
+                    if this.tree_scrollbar_drag.is_some() {
+                        this.end_tree_scrollbar_drag(cx);
                     }
                 }),
             )
@@ -1458,32 +1671,22 @@ impl Render for FileViewer {
                                             .overflow_hidden()
                                             .child(filename),
                                     )
-                                    .child(
-                                        div()
-                                            .text_size(ui_text_sm(cx))
-                                            .text_color(rgb(t.text_muted))
-                                            .text_ellipsis()
-                                            .overflow_hidden()
-                                            .min_w_0()
-                                            .child(relative_path),
-                                    )
+                                    .child(self.render_scope_navigation(&t, cx))
                                     .into_any_element()
                             } else {
                                 v_flex()
                                     .gap(px(2.0))
+                                    .min_w_0()
                                     .child(
                                         div()
                                             .text_size(ui_text_xl(cx))
                                             .font_weight(FontWeight::MEDIUM)
                                             .text_color(rgb(t.text_primary))
+                                            .text_ellipsis()
+                                            .overflow_hidden()
                                             .child(filename),
                                     )
-                                    .child(
-                                        div()
-                                            .text_size(ui_text_ms(cx))
-                                            .text_color(rgb(t.text_muted))
-                                            .child(relative_path),
-                                    )
+                                    .child(self.render_scope_navigation(&t, cx))
                                     .into_any_element()
                             }),
                     )
@@ -1492,6 +1695,40 @@ impl Render for FileViewer {
                     .child(
                         h_flex()
                             .gap(px(12.0))
+                            .when_some(transfer_status, |d, status| {
+                                d.child(
+                                    div()
+                                        .max_w(px(260.0))
+                                        .min_w_0()
+                                        .text_ellipsis()
+                                        .overflow_hidden()
+                                        .text_size(ui_text_sm(cx))
+                                        .text_color(rgb(t.text_muted))
+                                        .child(status),
+                                )
+                            })
+                            .when(has_file, |d| d.child(
+                                div()
+                                    .id("file-source-action")
+                                    .cursor_pointer()
+                                    .h(px(28.0))
+                                    .px(px(10.0))
+                                    .flex()
+                                    .items_center()
+                                    .rounded(px(4.0))
+                                    .bg(rgb(t.bg_secondary))
+                                    .hover(|s| s.bg(rgb(t.bg_hover)))
+                                    .when(self.transfer_in_progress, |d| d.opacity(0.6))
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.request_source_action(window, cx);
+                                    }))
+                                    .child(
+                                        div()
+                                            .text_size(ui_text_sm(cx))
+                                            .text_color(rgb(t.text_secondary))
+                                            .child(source_action_label),
+                                    ),
+                            ))
                             .when(self.blame_provider.is_some() && !is_image && !is_font, |d| {
                                 let on = self.blame_visible;
                                 d.child(
@@ -1604,7 +1841,7 @@ impl Render for FileViewer {
                     .flex_1()
                     .min_h_0()
                     .when(sidebar_visible, |d| {
-                        d.child(self.render_sidebar(&t, tree_elements, cx))
+                        d.child(self.render_sidebar(&t, tree_rows, cx))
                     })
                     .child(
                         v_flex()
@@ -2090,10 +2327,7 @@ impl Render for FileViewer {
                                                 cx,
                                             ))
                                             .child(self.render_hint(
-                                                "Alt+\u{2190}/\u{2192}",
-                                                "back/fwd",
-                                                &t,
-                                                cx,
+                                                "Alt+\u{2190}/\u{2192}", "back/fwd", &t, cx,
                                             ))
                                             .child(self.render_hint("Esc", "close", &t, cx)),
                                     )

--- a/crates/okena-files/src/file_viewer/selection.rs
+++ b/crates/okena-files/src/file_viewer/selection.rs
@@ -149,6 +149,7 @@ impl FileViewer {
             self.expanded_folders.insert(folder_path.to_string());
             self.fetch_directory(folder_path.to_string(), cx);
         }
+        self.invalidate_visible_tree_rows();
         cx.notify();
     }
 
@@ -213,6 +214,25 @@ impl FileViewer {
 
     pub(super) fn end_scrollbar_drag(&mut self, cx: &mut Context<Self>) {
         self.active_tab_mut().scrollbar_drag = None;
+        cx.notify();
+    }
+
+    pub(super) fn start_tree_scrollbar_drag(&mut self, y: f32, cx: &mut Context<Self>) {
+        let mut drag = start_scrollbar_drag(&self.tree_scroll_handle);
+        drag.start_y = y;
+        self.tree_scrollbar_drag = Some(drag);
+        cx.notify();
+    }
+
+    pub(super) fn update_tree_scrollbar_drag(&mut self, y: f32, cx: &mut Context<Self>) {
+        if let Some(drag) = self.tree_scrollbar_drag {
+            update_scrollbar_drag(&self.tree_scroll_handle, drag, y);
+            cx.notify();
+        }
+    }
+
+    pub(super) fn end_tree_scrollbar_drag(&mut self, cx: &mut Context<Self>) {
+        self.tree_scrollbar_drag = None;
         cx.notify();
     }
 

--- a/crates/okena-files/src/file_viewer/tree.rs
+++ b/crates/okena-files/src/file_viewer/tree.rs
@@ -5,6 +5,7 @@ use crate::file_tree::{FileTreeNavigationDirection, FileTreeRow, adjacent_file_t
 use crate::list_directory::DirEntry;
 use gpui::Context;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 fn collect_file_tree_rows(
     parent_path: &str,
@@ -55,7 +56,7 @@ fn collect_file_tree_rows(
 }
 
 impl FileViewer {
-    pub(super) fn file_tree_rows(&self, include_collapsed: bool) -> Vec<FileTreeRow<String>> {
+    fn collect_file_tree_rows(&self, include_collapsed: bool) -> Vec<FileTreeRow<String>> {
         let mut rows = Vec::new();
         collect_file_tree_rows(
             "",
@@ -69,17 +70,39 @@ impl FileViewer {
         rows
     }
 
+    pub(super) fn invalidate_visible_tree_rows(&mut self) {
+        *self.visible_tree_rows.get_mut() = None;
+        self.tree_scroll_handle.0.borrow_mut().last_item_size = None;
+    }
+
+    pub(super) fn visible_file_tree_rows(&self) -> Arc<Vec<FileTreeRow<String>>> {
+        if let Some(rows) = self.visible_tree_rows.borrow().as_ref() {
+            return rows.clone();
+        }
+
+        let rows = Arc::new(self.collect_file_tree_rows(false));
+        *self.visible_tree_rows.borrow_mut() = Some(rows.clone());
+        rows
+    }
+
     fn navigate_file_tree(
         &mut self,
         direction: FileTreeNavigationDirection,
         cx: &mut Context<Self>,
     ) {
-        let visible = self.file_tree_rows(false);
-        let all = self.file_tree_rows(true);
+        let visible = self.visible_file_tree_rows();
+        let all = self.collect_file_tree_rows(true);
         let active_path = &self.active_tab().relative_path;
         let selected = (!active_path.is_empty()).then_some(active_path);
 
         if let Some(path) = adjacent_file_tree_item(&visible, &all, selected, direction) {
+            if let Some(index) = visible
+                .iter()
+                .position(|row| matches!(row, FileTreeRow::File { item, .. } if item == &path))
+            {
+                self.tree_scroll_handle
+                    .scroll_to_item(index, gpui::ScrollStrategy::Nearest);
+            }
             self.navigate_to_file_no_history(path, cx);
         }
     }

--- a/crates/okena-files/src/project_fs.rs
+++ b/crates/okena-files/src/project_fs.rs
@@ -1,8 +1,9 @@
-//! ProjectFs trait and the remote-server (HTTP) implementation.
+//! Filesystem scope trait and daemon-backed implementations.
 
 use crate::content_search::{ContentSearchConfig, FileSearchResult, SearchMode};
 use crate::file_scan::FileEntry;
 use crate::list_directory::DirEntry;
+use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -11,13 +12,19 @@ pub struct ProjectFileMetadata {
     pub modified_at_millis: Option<u64>,
 }
 
-/// Provides file system operations from either local disk or a remote server.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FileSourceAction {
+    OpenExternally,
+    Download,
+}
+
+/// Provides browser operations inside a movable daemon filesystem scope.
 pub trait ProjectFs: Send + Sync + 'static {
-    /// List files in the project (for file search dialog).
+    /// List files in the current scope (for file search dialog).
     fn list_files(&self, show_ignored: bool) -> Result<Vec<FileEntry>, String>;
 
-    /// List immediate children of a project-relative directory (for the lazy
-    /// file viewer tree). `relative_path = ""` lists the project root.
+    /// List immediate children of a scope-relative directory (for the lazy
+    /// file viewer tree). `relative_path = ""` lists the scope root.
     fn list_directory(
         &self,
         relative_path: &str,
@@ -48,39 +55,123 @@ pub trait ProjectFs: Send + Sync + 'static {
         on_result: &mut (dyn FnMut(FileSearchResult) + Send),
     ) -> Result<(), String>;
 
-    /// Project display name (directory name).
+    /// Scope display name (directory name).
     fn project_name(&self) -> String;
 
-    /// Unique project identifier (used for caching).
+    /// Unique scope identifier (used for caching and client-side paths).
     fn project_id(&self) -> String;
 
-    /// Daemon-side absolute path for a project-relative path, for display/copy
+    /// Daemon-side absolute path for a scope-relative path, for display/copy
     /// (e.g. the "Copy Absolute Path" context-menu action). The path lives on
     /// the daemon's filesystem. Returns `None` when the daemon root is unknown.
     fn absolute_path(&self, relative_path: &str) -> Option<String>;
+
+    /// Origin shown in the viewer header, including the daemon that owns it.
+    fn source_label(&self, relative_path: &str) -> String;
+
+    /// Action that can move the viewed file out of the integrated viewer.
+    fn source_action(&self) -> FileSourceAction;
+
+    /// Stream the complete file into a local writer.
+    fn download_file(
+        &self,
+        relative_path: &str,
+        writer: &mut dyn std::io::Write,
+    ) -> Result<(), String>;
+
+    /// Absolute daemon path that anchors relative operations in this browser.
+    fn scope_path(&self) -> String;
+
+    /// Resolve an absolute daemon path for navigation and breadcrumbs.
+    fn resolve_path(&self, path: &str) -> Result<okena_core::api::ResolvedPath, String>;
+
+    /// Create an equivalent provider rooted at a resolved directory.
+    fn scoped_to(&self, scope: okena_core::api::ResolvedPath) -> Arc<dyn ProjectFs>;
+
+    /// Convert a daemon absolute path into this scope's relative identifier.
+    fn relative_path(&self, absolute_path: &str) -> Option<String>;
+
+    /// Daemon identity shown before the filesystem breadcrumb.
+    fn owner_label(&self) -> String;
 }
 
-/// Remote file system provider — fetches data via HTTP from a remote server.
-pub struct RemoteProjectFs {
+fn owner_label(client: &okena_transport::remote_action::RemoteActionClient) -> String {
+    if client.is_local_daemon() {
+        "local".to_string()
+    } else {
+        client.connection_name().to_string()
+    }
+}
+
+pub(crate) fn join_daemon_path(root: &str, relative_path: &str) -> String {
+    if relative_path.is_empty() {
+        return root.to_string();
+    }
+    let separator = if root.contains('\\') && !root.contains('/') {
+        '\\'
+    } else {
+        '/'
+    };
+    let relative_path = relative_path.replace(['/', '\\'], &separator.to_string());
+    format!(
+        "{}{}{}",
+        root.trim_end_matches(['/', '\\']),
+        separator,
+        relative_path
+    )
+}
+
+fn relative_daemon_path(root: &str, absolute_path: &str) -> Option<String> {
+    let normalize = |value: &str| value.replace('\\', "/");
+    let root = normalize(root);
+    let absolute = normalize(absolute_path);
+    let root = if root == "/" {
+        root
+    } else {
+        root.trim_end_matches('/').to_string()
+    };
+    if absolute == root {
+        return Some(String::new());
+    }
+    absolute
+        .strip_prefix(&root)
+        .and_then(|suffix| suffix.strip_prefix('/'))
+        .map(str::to_string)
+}
+
+/// Filesystem provider rooted at an arbitrary daemon directory.
+#[derive(Clone)]
+pub struct RemotePathFs {
     client: okena_transport::remote_action::RemoteActionClient,
-    project_id: String,
-    project_name: String,
-    root: String,
+    scope: okena_core::api::ResolvedPath,
 }
 
-impl RemoteProjectFs {
+impl RemotePathFs {
     pub fn new(
         client: okena_transport::remote_action::RemoteActionClient,
-        project_id: String,
-        project_name: String,
+        scope: okena_core::api::ResolvedPath,
+    ) -> Self {
+        Self { client, scope }
+    }
+
+    pub fn new_unresolved(
+        client: okena_transport::remote_action::RemoteActionClient,
+        name: String,
         root: String,
     ) -> Self {
-        Self {
+        Self::new(
             client,
-            project_id,
-            project_name,
-            root,
-        }
+            okena_core::api::ResolvedPath {
+                canonical_path: root,
+                name,
+                kind: okena_core::api::ResolvedPathKind::Directory,
+                size: 0,
+                modified_at_millis: None,
+                project_id: None,
+                relative_path: None,
+                breadcrumbs: Vec::new(),
+            },
+        )
     }
 
     fn post_action(
@@ -91,14 +182,13 @@ impl RemoteProjectFs {
     }
 }
 
-impl ProjectFs for RemoteProjectFs {
+impl ProjectFs for RemotePathFs {
     fn list_files(&self, show_ignored: bool) -> Result<Vec<FileEntry>, String> {
-        let action = okena_core::api::ActionRequest::ListFiles {
-            project_id: self.project_id.clone(),
-            show_ignored,
-        };
         let value = self
-            .post_action(action)?
+            .post_action(okena_core::api::ActionRequest::ListPathFiles {
+                root: self.scope.canonical_path.clone(),
+                show_ignored,
+            })?
             .ok_or_else(|| "Missing file list response".to_string())?;
         serde_json::from_value(value)
             .map_err(|error| format!("Invalid file list response: {error}"))
@@ -109,85 +199,81 @@ impl ProjectFs for RemoteProjectFs {
         relative_path: &str,
         show_ignored: bool,
     ) -> Result<Vec<DirEntry>, String> {
-        let action = okena_core::api::ActionRequest::ListDirectory {
-            project_id: self.project_id.clone(),
-            relative_path: relative_path.to_string(),
-            show_ignored,
-        };
-        match self.post_action(action)? {
-            Some(value) => serde_json::from_value(value)
-                .map_err(|e| format!("Failed to deserialize directory list: {}", e)),
-            None => Err("Empty response".to_string()),
-        }
+        let value = self
+            .post_action(okena_core::api::ActionRequest::ListPathDirectory {
+                root: self.scope.canonical_path.clone(),
+                relative_path: relative_path.to_string(),
+                show_ignored,
+            })?
+            .ok_or_else(|| "Missing directory list response".to_string())?;
+        serde_json::from_value(value)
+            .map_err(|error| format!("Invalid directory list response: {error}"))
     }
 
     fn read_file(&self, relative_path: &str) -> Result<String, String> {
-        let action = okena_core::api::ActionRequest::ReadFile {
-            project_id: self.project_id.clone(),
-            relative_path: relative_path.to_string(),
-        };
-        match self.post_action(action)? {
-            Some(value) => value
-                .get("content")
-                .and_then(|v| v.as_str())
-                .map(String::from)
-                .ok_or_else(|| "Missing content in response".to_string()),
-            None => Err("Empty response".to_string()),
-        }
+        let value = self
+            .post_action(okena_core::api::ActionRequest::ReadPathFile {
+                root: self.scope.canonical_path.clone(),
+                relative_path: relative_path.to_string(),
+            })?
+            .ok_or_else(|| "Missing file response".to_string())?;
+        value
+            .get("content")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+            .ok_or_else(|| "Missing content in response".to_string())
     }
 
     fn read_file_bytes(&self, relative_path: &str) -> Result<Vec<u8>, String> {
         use base64::Engine as _;
-        let action = okena_core::api::ActionRequest::ReadFileBytes {
-            project_id: self.project_id.clone(),
-            relative_path: relative_path.to_string(),
-        };
-        match self.post_action(action)? {
-            Some(value) => {
-                let encoded = value
-                    .get("content_b64")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| "Missing content_b64 in response".to_string())?;
-                base64::engine::general_purpose::STANDARD
-                    .decode(encoded)
-                    .map_err(|e| format!("Invalid base64 in response: {}", e))
-            }
-            None => Err("Empty response".to_string()),
-        }
+        let value = self
+            .post_action(okena_core::api::ActionRequest::ReadPathFileBytes {
+                root: self.scope.canonical_path.clone(),
+                relative_path: relative_path.to_string(),
+            })?
+            .ok_or_else(|| "Missing file response".to_string())?;
+        let encoded = value
+            .get("content_b64")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| "Missing content_b64 in response".to_string())?;
+        base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .map_err(|error| format!("Invalid base64 in response: {error}"))
     }
 
     fn file_metadata(&self, relative_path: &str) -> Result<ProjectFileMetadata, String> {
-        let action = okena_core::api::ActionRequest::FileSize {
-            project_id: self.project_id.clone(),
-            relative_path: relative_path.to_string(),
-        };
-        match self.post_action(action)? {
-            Some(value) => Ok(ProjectFileMetadata {
-                size: value
-                    .get("size")
-                    .and_then(|v| v.as_u64())
-                    .ok_or_else(|| "Missing size in response".to_string())?,
-                modified_at_millis: value.get("modified_at_millis").and_then(|v| v.as_u64()),
-            }),
-            None => Err("Empty response".to_string()),
-        }
+        let value = self
+            .post_action(okena_core::api::ActionRequest::PathFileSize {
+                root: self.scope.canonical_path.clone(),
+                relative_path: relative_path.to_string(),
+            })?
+            .ok_or_else(|| "Missing file metadata response".to_string())?;
+        Ok(ProjectFileMetadata {
+            size: value
+                .get("size")
+                .and_then(serde_json::Value::as_u64)
+                .ok_or_else(|| "Missing size in response".to_string())?,
+            modified_at_millis: value
+                .get("modified_at_millis")
+                .and_then(serde_json::Value::as_u64),
+        })
     }
 
     fn rename_file(&self, relative_path: &str, new_name: &str) -> Result<(), String> {
-        let action = okena_core::api::ActionRequest::RenameFile {
-            project_id: self.project_id.clone(),
+        self.post_action(okena_core::api::ActionRequest::RenamePath {
+            root: self.scope.canonical_path.clone(),
             relative_path: relative_path.to_string(),
             new_name: new_name.to_string(),
-        };
-        self.post_action(action).map(|_| ())
+        })
+        .map(|_| ())
     }
 
     fn delete_file(&self, relative_path: &str) -> Result<(), String> {
-        let action = okena_core::api::ActionRequest::DeleteFile {
-            project_id: self.project_id.clone(),
+        self.post_action(okena_core::api::ActionRequest::DeletePath {
+            root: self.scope.canonical_path.clone(),
             relative_path: relative_path.to_string(),
-        };
-        self.post_action(action).map(|_| ())
+        })
+        .map(|_| ())
     }
 
     fn search_content(
@@ -202,8 +288,8 @@ impl ProjectFs for RemoteProjectFs {
             SearchMode::Regex => "regex",
             SearchMode::Fuzzy => "fuzzy",
         };
-        let action = okena_core::api::ActionRequest::SearchContent {
-            project_id: self.project_id.clone(),
+        let action = okena_core::api::ActionRequest::SearchPathContent {
+            root: self.scope.canonical_path.clone(),
             query: query.to_string(),
             case_sensitive: config.case_sensitive,
             mode: mode.to_string(),
@@ -228,18 +314,103 @@ impl ProjectFs for RemoteProjectFs {
     }
 
     fn project_name(&self) -> String {
-        self.project_name.clone()
+        self.scope.name.clone()
     }
 
     fn project_id(&self) -> String {
-        self.project_id.clone()
+        format!(
+            "path:{}:{}",
+            owner_label(&self.client),
+            self.scope.canonical_path
+        )
     }
 
     fn absolute_path(&self, relative_path: &str) -> Option<String> {
-        if self.root.is_empty() {
-            return None;
+        Some(join_daemon_path(&self.scope.canonical_path, relative_path))
+    }
+
+    fn source_label(&self, relative_path: &str) -> String {
+        let path = self
+            .absolute_path(relative_path)
+            .unwrap_or_else(|| relative_path.to_string());
+        format!("{}:{path}", owner_label(&self.client))
+    }
+
+    fn source_action(&self) -> FileSourceAction {
+        if self.client.is_local_daemon() {
+            FileSourceAction::OpenExternally
+        } else {
+            FileSourceAction::Download
         }
-        let base = self.root.trim_end_matches(['/', '\\']);
-        Some(format!("{}/{}", base, relative_path))
+    }
+
+    fn download_file(
+        &self,
+        relative_path: &str,
+        writer: &mut dyn std::io::Write,
+    ) -> Result<(), String> {
+        self.client.download_file(
+            &okena_core::api::FileDownloadRequest::Path {
+                root: self.scope.canonical_path.clone(),
+                relative_path: relative_path.to_string(),
+            },
+            writer,
+        )
+    }
+
+    fn scope_path(&self) -> String {
+        self.scope.canonical_path.clone()
+    }
+
+    fn resolve_path(&self, path: &str) -> Result<okena_core::api::ResolvedPath, String> {
+        let value = self
+            .post_action(okena_core::api::ActionRequest::ResolvePath {
+                path: path.to_string(),
+            })?
+            .ok_or_else(|| "Missing resolved path response".to_string())?;
+        serde_json::from_value(value)
+            .map_err(|error| format!("Invalid resolved path response: {error}"))
+    }
+
+    fn scoped_to(&self, scope: okena_core::api::ResolvedPath) -> Arc<dyn ProjectFs> {
+        Arc::new(Self::new(self.client.clone(), scope))
+    }
+
+    fn relative_path(&self, absolute_path: &str) -> Option<String> {
+        relative_daemon_path(&self.scope.canonical_path, absolute_path)
+    }
+
+    fn owner_label(&self) -> String {
+        owner_label(&self.client)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{join_daemon_path, relative_daemon_path};
+
+    #[test]
+    fn daemon_paths_round_trip_with_unix_separators() {
+        let absolute = join_daemon_path("/srv/apps", "demo/src/main.rs");
+        assert_eq!(absolute, "/srv/apps/demo/src/main.rs");
+        assert_eq!(
+            relative_daemon_path("/srv/apps", &absolute).as_deref(),
+            Some("demo/src/main.rs")
+        );
+    }
+
+    #[test]
+    fn daemon_paths_round_trip_with_windows_separators() {
+        let absolute = join_daemon_path(r"C:\Users\dev", "demo/src/main.rs");
+        assert_eq!(absolute, r"C:\Users\dev\demo\src\main.rs");
+        assert_eq!(
+            relative_daemon_path(r"C:\Users\dev", &absolute).as_deref(),
+            Some("demo/src/main.rs")
+        );
+    }
+
+    #[test]
+    fn relative_path_rejects_sibling_prefixes() {
+        assert_eq!(relative_daemon_path("/srv/app", "/srv/application/x"), None);
     }
 }

--- a/crates/okena-remote-server/Cargo.toml
+++ b/crates/okena-remote-server/Cargo.toml
@@ -20,6 +20,7 @@ okena-ext-updater = { path = "../okena-ext-updater", default-features = false }
 
 # Async runtime + channels
 tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros", "time", "fs"] }
+tokio-util = { version = "0.7", features = ["io"] }
 async-channel = "2.3"
 futures = "0.3"
 parking_lot = "0.12"

--- a/crates/okena-remote-server/src/routes/download.rs
+++ b/crates/okena-remote-server/src/routes/download.rs
@@ -1,0 +1,123 @@
+use crate::bridge::{BridgeMessage, CommandResult, RemoteCommand};
+use crate::routes::AppState;
+use axum::Json;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::header::{CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::{HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use okena_core::api::{ActionRequest, FileDownloadRequest, ResolvedPath, ResolvedPathKind};
+use tokio_util::io::ReaderStream;
+
+async fn resolve_file(
+    state: &AppState,
+    request: FileDownloadRequest,
+) -> Result<ResolvedPath, Response> {
+    let action = match request {
+        FileDownloadRequest::Project {
+            project_id,
+            relative_path,
+        } => ActionRequest::ResolveProjectPath {
+            project_id,
+            relative_path,
+        },
+        FileDownloadRequest::Terminal { terminal_id, path } => {
+            ActionRequest::ResolveTerminalPath { terminal_id, path }
+        }
+        FileDownloadRequest::Path {
+            root,
+            relative_path,
+        } => ActionRequest::ResolvePathInScope {
+            root,
+            relative_path,
+        },
+    };
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    state
+        .bridge_tx
+        .send(BridgeMessage {
+            command: RemoteCommand::Action(action),
+            reply: Some(reply_tx),
+        })
+        .await
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "bridge unavailable").into_response())?;
+    match reply_rx.await {
+        Ok(CommandResult::Ok(Some(value))) => serde_json::from_value(value).map_err(|error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("invalid file response: {error}"),
+            )
+                .into_response()
+        }),
+        Ok(CommandResult::Err(error)) => Err((StatusCode::BAD_REQUEST, error).into_response()),
+        Ok(_) => Err((StatusCode::INTERNAL_SERVER_ERROR, "missing file response").into_response()),
+        Err(_) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "command processing failed",
+        )
+            .into_response()),
+    }
+}
+
+fn safe_download_name(name: &str) -> String {
+    let safe: String = name
+        .chars()
+        .map(|character| match character {
+            '"' | '\r' | '\n' | '/' | '\\' => '_',
+            _ => character,
+        })
+        .collect();
+    if safe.is_empty() {
+        "download".to_string()
+    } else {
+        safe
+    }
+}
+
+pub async fn post_download(
+    State(state): State<AppState>,
+    Json(request): Json<FileDownloadRequest>,
+) -> Response {
+    let file = match resolve_file(&state, request).await {
+        Ok(file) => file,
+        Err(response) => return response,
+    };
+    if file.kind != ResolvedPathKind::File {
+        return (StatusCode::BAD_REQUEST, "path is not a regular file").into_response();
+    }
+    let source = match tokio::fs::File::open(&file.canonical_path).await {
+        Ok(source) => source,
+        Err(error) => {
+            return (StatusCode::NOT_FOUND, format!("cannot open file: {error}")).into_response();
+        }
+    };
+    let disposition = format!(
+        "attachment; filename=\"{}\"",
+        safe_download_name(&file.name)
+    );
+    let mut response = Response::new(Body::from_stream(ReaderStream::new(source)));
+    response.headers_mut().insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("application/octet-stream"),
+    );
+    if let Ok(length) = HeaderValue::from_str(&file.size.to_string()) {
+        response.headers_mut().insert(CONTENT_LENGTH, length);
+    }
+    if let Ok(disposition) = HeaderValue::from_str(&disposition) {
+        response
+            .headers_mut()
+            .insert(CONTENT_DISPOSITION, disposition);
+    }
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::safe_download_name;
+
+    #[test]
+    fn download_name_cannot_inject_headers_or_paths() {
+        assert_eq!(safe_download_name("../a\r\n.txt"), ".._a__.txt");
+        assert_eq!(safe_download_name(""), "download");
+    }
+}

--- a/crates/okena-remote-server/src/routes/mod.rs
+++ b/crates/okena-remote-server/src/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod actions;
 pub mod auth_reload;
+pub mod download;
 pub mod health;
 pub mod pair;
 pub mod paste_image;
@@ -159,6 +160,10 @@ pub fn build_router(
     let protected = Router::new()
         .route("/v1/state", axum::routing::get(state::get_state))
         .route("/v1/actions", axum::routing::post(actions::post_actions))
+        .route(
+            "/v1/files/download",
+            axum::routing::post(download::post_download),
+        )
         .route(
             "/v1/terminals/{terminal_id}/paste-image",
             axum::routing::post(paste_image::post_paste_image)

--- a/crates/okena-transport/src/remote_action.rs
+++ b/crates/okena-transport/src/remote_action.rs
@@ -1,7 +1,7 @@
 //! Shared async and blocking clients for actions sent to an Okena daemon.
 
 use crate::RemoteConnectionConfig;
-use okena_core::api::ActionRequest;
+use okena_core::api::{ActionRequest, FileDownloadRequest};
 #[cfg(feature = "blocking-http")]
 use std::sync::{Arc, OnceLock};
 
@@ -26,6 +26,7 @@ const SEARCH_TIMEOUT_SECS: u64 = 90;
 const LONG_MUTATION_TIMEOUT_SECS: u64 = 11 * 60;
 
 const ACTIONS_PATH: &str = "/v1/actions";
+const DOWNLOAD_PATH: &str = "/v1/files/download";
 
 /// Hard ceiling on response body size accepted by the remote bridge. Cuts
 /// off arbitrarily large or runaway responses before they're buffered into
@@ -44,8 +45,12 @@ enum ActionClientKind {
 
 fn client_kind_for(action: &ActionRequest) -> ActionClientKind {
     match action {
-        ActionRequest::ReadFileBytes { .. } => ActionClientKind::Bytes,
-        ActionRequest::SearchContent { .. } => ActionClientKind::Search,
+        ActionRequest::ReadFileBytes { .. }
+        | ActionRequest::ReadTerminalFileBytes { .. }
+        | ActionRequest::ReadPathFileBytes { .. } => ActionClientKind::Bytes,
+        ActionRequest::SearchContent { .. } | ActionRequest::SearchPathContent { .. } => {
+            ActionClientKind::Search
+        }
         ActionRequest::RemoveWorktreeProject { .. }
         | ActionRequest::RenameProjectDirectory { .. } => ActionClientKind::LongMutation,
         _ => ActionClientKind::Fast,
@@ -79,6 +84,7 @@ struct RemoteActionClientInner {
     bytes: OnceLock<Result<ClientAndUrl, String>>,
     search: OnceLock<Result<ClientAndUrl, String>>,
     long_mutation: OnceLock<Result<ClientAndUrl, String>>,
+    download: OnceLock<Result<ClientAndUrl, String>>,
     #[cfg(feature = "cancellable-http")]
     async_search: OnceLock<Result<AsyncClientAndUrl, String>>,
 }
@@ -103,6 +109,7 @@ impl RemoteActionClient {
                 bytes: OnceLock::new(),
                 search: OnceLock::new(),
                 long_mutation: OnceLock::new(),
+                download: OnceLock::new(),
                 #[cfg(feature = "cancellable-http")]
                 async_search: OnceLock::new(),
             }),
@@ -126,6 +133,53 @@ impl RemoteActionClient {
             Err(error) => return Err(error.clone()),
         };
         post_action_inner(client, url, &self.inner.token, action)
+    }
+
+    pub fn connection_id(&self) -> &str {
+        &self.inner.config.id
+    }
+
+    pub fn connection_name(&self) -> &str {
+        &self.inner.config.name
+    }
+
+    pub fn is_local_daemon(&self) -> bool {
+        self.inner.config.id == crate::LOCAL_DAEMON_CONNECTION_ID
+    }
+
+    /// Stream a daemon-side file directly into a local writer.
+    pub fn download_file(
+        &self,
+        request: &FileDownloadRequest,
+        writer: &mut dyn std::io::Write,
+    ) -> Result<(), String> {
+        let client_and_url = self.inner.download.get_or_init(|| {
+            crate::remote_http::blocking_client_and_url(
+                &self.inner.config,
+                DOWNLOAD_PATH,
+                std::time::Duration::from_secs(30 * 60),
+            )
+        });
+        let (client, url) = match client_and_url {
+            Ok(client_and_url) => client_and_url,
+            Err(error) => return Err(error.clone()),
+        };
+        let mut response = client
+            .post(url)
+            .bearer_auth(&self.inner.token)
+            .json(request)
+            .send()
+            .map_err(|error| format!("Download request failed: {error}"))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let message = response
+                .text()
+                .unwrap_or_else(|_| "download failed".to_string());
+            return Err(format!("Download failed ({status}): {message}"));
+        }
+        std::io::copy(&mut response, writer)
+            .map(|_| ())
+            .map_err(|error| format!("Cannot save downloaded file: {error}"))
     }
 
     /// Post a content search while observing the request-local cancellation flag.
@@ -471,6 +525,20 @@ mod tests {
             client_kind_for(&ActionRequest::ReadFileBytes {
                 project_id: "project".to_string(),
                 relative_path: "image.png".to_string(),
+            }),
+            ActionClientKind::Bytes
+        );
+        assert_eq!(
+            client_kind_for(&ActionRequest::ReadTerminalFileBytes {
+                terminal_id: "terminal-1".into(),
+                path: "/tmp/image.png".into(),
+            }),
+            ActionClientKind::Bytes
+        );
+        assert_eq!(
+            client_kind_for(&ActionRequest::ReadPathFileBytes {
+                root: "/tmp".into(),
+                relative_path: "image.png".into(),
             }),
             ActionClientKind::Bytes
         );

--- a/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
@@ -5,7 +5,6 @@ use crate::elements::terminal_element::{
     deregister_resize_viewer as deregister_shared_resize_viewer, next_resize_viewer_id,
 };
 use crate::layout::navigation::register_pane_bounds;
-use crate::terminal_view_settings;
 use gpui::*;
 use okena_files::theme::theme;
 use okena_terminal::terminal::Terminal;
@@ -353,24 +352,37 @@ impl TerminalContent {
         }
     }
 
-    /// Best-effort project-relative path for opening a clicked terminal path in
-    /// the file viewer. Strips any trailing :line:col, then makes it relative to
-    /// the project root (the daemon-side project path). Returns None for absolute
-    /// paths outside the project or `~`-prefixed paths we can't resolve.
-    fn project_relative_path(&self, raw: &str, cx: &App) -> Option<String> {
-        let clean = super::url_detector::strip_line_col_suffix(raw);
-        let project_path = self
-            .workspace
-            .read(cx)
-            .project(&self.project_id)?
-            .path
-            .clone();
-        let cwd = self
+    fn request_file_viewer(
+        &self,
+        path: &str,
+        line: Option<u32>,
+        column: Option<u32>,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(terminal_id) = self
             .terminal
             .as_ref()
-            .map(|terminal| terminal.current_cwd())
-            .unwrap_or_else(|| project_path.clone());
-        remote_project_relative_path(clean, &project_path, &cwd)
+            .map(|terminal| terminal.terminal_id.clone())
+        else {
+            return;
+        };
+        let path = terminal_file_request_path(path, line);
+        self.request_broker.update(cx, |broker, cx| {
+            broker.push_overlay_request(
+                okena_workspace::requests::OverlayRequest::Project(
+                    okena_workspace::requests::ProjectOverlay {
+                        project_id: self.project_id.clone(),
+                        kind: okena_workspace::requests::ProjectOverlayKind::TerminalPathViewer {
+                            terminal_id,
+                            path,
+                            line,
+                            column,
+                        },
+                    },
+                ),
+                cx,
+            );
+        });
     }
 
     fn handle_mouse_down(
@@ -392,38 +404,25 @@ impl TerminalContent {
                 .as_ref()
                 .and_then(|t| t.hyperlink_at(col, row))
             {
-                UrlDetector::open_url(&uri);
+                if uri.starts_with("file://") {
+                    self.request_file_viewer(&uri, None, None, cx);
+                } else {
+                    UrlDetector::open_url(&uri);
+                }
                 self.mouse_down_cell = None;
                 return;
             }
             if let Some(url_match) = self.url_detector.find_at(col, row) {
                 match &url_match.kind {
                     LinkKind::Url => {
-                        UrlDetector::open_url(&url_match.url);
+                        if url_match.url.starts_with("file://") {
+                            self.request_file_viewer(&url_match.url, None, None, cx);
+                        } else {
+                            UrlDetector::open_url(&url_match.url);
+                        }
                     }
                     LinkKind::FilePath { line, col } => {
-                        if self
-                            .workspace
-                            .read(cx)
-                            .is_local_daemon_project(&self.project_id)
-                        {
-                            let file_opener = terminal_view_settings(cx).file_opener.clone();
-                            UrlDetector::open_file(&url_match.url, *line, *col, &file_opener);
-                        } else if let Some(relative_path) =
-                            self.project_relative_path(&url_match.url, cx)
-                        {
-                            self.request_broker.update(cx, |broker, cx| {
-                                broker.push_overlay_request(
-                                    okena_workspace::requests::OverlayRequest::Project(
-                                        okena_workspace::requests::ProjectOverlay {
-                                            project_id: self.project_id.clone(),
-                                            kind: okena_workspace::requests::ProjectOverlayKind::FileViewer { relative_path },
-                                        },
-                                    ),
-                                    cx,
-                                );
-                            });
-                        }
+                        self.request_file_viewer(&url_match.url, *line, *col, cx);
                     }
                 }
                 self.mouse_down_cell = None;
@@ -908,63 +907,13 @@ impl Drop for TerminalContent {
 
 impl EventEmitter<TerminalContentEvent> for TerminalContent {}
 
-fn remote_project_relative_path(raw: &str, project_path: &str, cwd: &str) -> Option<String> {
-    if raw.starts_with('~') {
-        return None;
-    }
-
-    let raw = raw.replace('\\', "/");
-    let project_path = project_path.replace('\\', "/");
-    let cwd = cwd.replace('\\', "/");
-    let raw_is_absolute = is_absolute_path(&raw);
-    let candidate = if raw_is_absolute {
-        raw
-    } else if cwd.is_empty() {
-        format!("{project_path}/{raw}")
+fn terminal_file_request_path(path: &str, line: Option<u32>) -> String {
+    if line.is_some() {
+        super::url_detector::strip_line_col_suffix(path)
     } else {
-        format!("{cwd}/{raw}")
-    };
-
-    let project_parts = normalize_path_parts(&project_path)?;
-    let candidate_parts = normalize_path_parts(&candidate)?;
-    let windows_path =
-        project_path.as_bytes().get(1) == Some(&b':') || project_path.starts_with("//");
-    if candidate_parts.len() <= project_parts.len()
-        || !candidate_parts
-            .iter()
-            .zip(&project_parts)
-            .all(|(candidate, project)| {
-                if windows_path {
-                    candidate.eq_ignore_ascii_case(project)
-                } else {
-                    candidate == project
-                }
-            })
-    {
-        return None;
+        path
     }
-
-    Some(candidate_parts[project_parts.len()..].join("/"))
-}
-
-fn is_absolute_path(path: &str) -> bool {
-    path.starts_with('/')
-        || path.starts_with("//")
-        || (path.as_bytes().get(1) == Some(&b':') && path.as_bytes().get(2) == Some(&b'/'))
-}
-
-fn normalize_path_parts(path: &str) -> Option<Vec<&str>> {
-    let mut parts = Vec::new();
-    for part in path.split('/') {
-        match part {
-            "" | "." => {}
-            ".." => {
-                parts.pop()?;
-            }
-            _ => parts.push(part),
-        }
-    }
-    Some(parts)
+    .to_string()
 }
 
 /// Lines to scroll for drag-selection auto-scroll, given the pointer's `y` and
@@ -990,7 +939,7 @@ fn autoscroll_lines(y: f32, top: f32, bottom: f32, cell_height: f32) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{autoscroll_lines, remote_project_relative_path};
+    use super::{autoscroll_lines, terminal_file_request_path};
 
     const CELL: f32 = 16.0;
     const TOP: f32 = 100.0;
@@ -1031,46 +980,18 @@ mod tests {
     }
 
     #[test]
-    fn remote_absolute_path_is_made_project_relative() {
+    fn detected_source_position_is_removed_from_request_path() {
         assert_eq!(
-            remote_project_relative_path(
-                "/srv/project/src/main.rs",
-                "/srv/project",
-                "/srv/project"
-            ),
-            Some("src/main.rs".to_string())
+            terminal_file_request_path("src/main.rs:42:7", Some(42)),
+            "src/main.rs"
         );
     }
 
     #[test]
-    fn remote_relative_path_uses_terminal_cwd() {
+    fn file_uri_without_detected_position_keeps_numeric_filename() {
         assert_eq!(
-            remote_project_relative_path("../shared.rs", "/srv/project", "/srv/project/src/bin"),
-            Some("src/shared.rs".to_string())
-        );
-    }
-
-    #[test]
-    fn remote_windows_paths_are_normalized_without_client_path_rules() {
-        assert_eq!(
-            remote_project_relative_path(
-                r"C:\work\project\src\main.rs",
-                r"c:\work\project",
-                r"C:\work\project"
-            ),
-            Some("src/main.rs".to_string())
-        );
-    }
-
-    #[test]
-    fn remote_path_outside_project_is_rejected() {
-        assert_eq!(
-            remote_project_relative_path("/etc/passwd", "/srv/project", "/srv/project"),
-            None
-        );
-        assert_eq!(
-            remote_project_relative_path("../../../etc/passwd", "/srv/project", "/srv/project"),
-            None
+            terminal_file_request_path("file:///tmp/release:42", None),
+            "file:///tmp/release:42"
         );
     }
 }

--- a/crates/okena-views-terminal/src/layout/terminal_pane/url_detector.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/url_detector.rs
@@ -237,7 +237,12 @@ impl UrlDetector {
     /// `file_line` and `file_col` are the parsed line/col numbers.
     /// `opener` is the editor command (e.g. "code", "cursor", "zed", "subl", "vim").
     /// If empty, falls back to the system default opener.
-    pub fn open_file(path: &str, file_line: Option<u32>, file_col: Option<u32>, opener: &str) {
+    pub fn open_file(
+        path: &str,
+        file_line: Option<u32>,
+        file_col: Option<u32>,
+        opener: &str,
+    ) -> Result<(), String> {
         // Strip any :line:col suffix from the path for the actual file path
         let clean_path = strip_line_col_suffix(path);
 
@@ -264,26 +269,40 @@ impl UrlDetector {
         );
 
         if opener.is_empty() {
-            // Use system default
-            #[cfg(target_os = "linux")]
-            {
-                let _ = okena_core::process::spawn_and_reap(
-                    okena_core::process::command("xdg-open").arg(clean_path),
-                );
+            let output = {
+                #[cfg(target_os = "linux")]
+                {
+                    okena_core::process::safe_output_with_timeout(
+                        okena_core::process::command("xdg-open").arg(clean_path),
+                        std::time::Duration::from_secs(15),
+                    )
+                }
+                #[cfg(target_os = "macos")]
+                {
+                    okena_core::process::safe_output_with_timeout(
+                        okena_core::process::command("open").arg(clean_path),
+                        std::time::Duration::from_secs(15),
+                    )
+                }
+                #[cfg(target_os = "windows")]
+                {
+                    okena_core::process::safe_output_with_timeout(
+                        okena_core::process::command("cmd").args(["/C", "start", "", clean_path]),
+                        std::time::Duration::from_secs(15),
+                    )
+                }
+            };
+            let output =
+                output.map_err(|error| format!("Cannot start the system file opener: {error}"))?;
+            if output.status.success() {
+                return Ok(());
             }
-            #[cfg(target_os = "macos")]
-            {
-                let _ = okena_core::process::spawn_and_reap(
-                    okena_core::process::command("open").arg(clean_path),
-                );
-            }
-            #[cfg(target_os = "windows")]
-            {
-                let _ = okena_core::process::spawn_and_reap(
-                    okena_core::process::command("cmd").args(["/C", "start", "", clean_path]),
-                );
-            }
-            return;
+            let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(if message.is_empty() {
+                format!("System file opener exited with {}", output.status)
+            } else {
+                message
+            });
         }
 
         // Build editor-specific arguments
@@ -299,9 +318,10 @@ impl UrlDetector {
                     }
                 }
                 args.push(loc);
-                let _ = okena_core::process::spawn_and_reap(
+                okena_core::process::spawn_and_reap(
                     okena_core::process::command(opener).args(&args),
-                );
+                )
+                .map_err(|error| format!("Cannot start {opener}: {error}"))?;
             }
             "zed" => {
                 // Zed: file:line
@@ -312,9 +332,8 @@ impl UrlDetector {
                         loc.push_str(&format!(":{}", col));
                     }
                 }
-                let _ = okena_core::process::spawn_and_reap(
-                    okena_core::process::command("zed").arg(&loc),
-                );
+                okena_core::process::spawn_and_reap(okena_core::process::command("zed").arg(&loc))
+                    .map_err(|error| format!("Cannot start zed: {error}"))?;
             }
             "subl" | "sublime" => {
                 // Sublime Text: file:line:col
@@ -325,9 +344,8 @@ impl UrlDetector {
                         loc.push_str(&format!(":{}", col));
                     }
                 }
-                let _ = okena_core::process::spawn_and_reap(
-                    okena_core::process::command("subl").arg(&loc),
-                );
+                okena_core::process::spawn_and_reap(okena_core::process::command("subl").arg(&loc))
+                    .map_err(|error| format!("Cannot start subl: {error}"))?;
             }
             "vim" | "nvim" => {
                 // vim/nvim: +line file
@@ -336,9 +354,10 @@ impl UrlDetector {
                     args.push(format!("+{}", line));
                 }
                 args.push(clean_path.to_string());
-                let _ = okena_core::process::spawn_and_reap(
+                okena_core::process::spawn_and_reap(
                     okena_core::process::command(opener).args(&args),
-                );
+                )
+                .map_err(|error| format!("Cannot start {opener}: {error}"))?;
             }
             _ => {
                 // Generic: try editor file:line:col pattern
@@ -349,11 +368,11 @@ impl UrlDetector {
                         loc.push_str(&format!(":{}", col));
                     }
                 }
-                let _ = okena_core::process::spawn_and_reap(
-                    okena_core::process::command(opener).arg(&loc),
-                );
+                okena_core::process::spawn_and_reap(okena_core::process::command(opener).arg(&loc))
+                    .map_err(|error| format!("Cannot start {opener}: {error}"))?;
             }
         }
+        Ok(())
     }
 }
 

--- a/crates/okena-workspace/src/requests.rs
+++ b/crates/okena-workspace/src/requests.rs
@@ -71,6 +71,13 @@ pub enum ProjectOverlayKind {
     FileViewer {
         relative_path: String,
     },
+    /// Resolve a terminal-emitted path on the daemon that owns the terminal.
+    TerminalPathViewer {
+        terminal_id: String,
+        path: String,
+        line: Option<u32>,
+        column: Option<u32>,
+    },
     ColorPicker {
         position: gpui::Point<gpui::Pixels>,
     },


### PR DESCRIPTION
## Summary

- generalize the integrated project file viewer into a daemon filesystem browser
- let project viewers navigate above the project root with **Up** and clickable breadcrumbs
- open terminal-reported files and directories through the same browser for local and remote daemons
- resolve absolute, relative, home-relative, and `file://` paths on the daemon that owns the terminal
- keep **Open externally** for local files and provide streamed **Download** for remote files
- preserve terminal-provided line and column highlighting when opening files
- keep very wide directories responsive with cached, virtualized tree rows and a draggable scrollbar

## Why

The project viewer previously treated the project root as a hard filesystem boundary. Terminal paths outside that boundary could not use the existing browser, and directory links failed because the terminal path flow expected a file.

Filesystem scope now belongs to the daemon. The same browser can start at a project, a terminal-reported directory, or a file's parent directory, then move upward to the daemon filesystem root. This also keeps local and remote behavior on the same client/daemon channel.

## Implementation

- add daemon path resolution metadata with canonical path, entry kind, parent, and breadcrumbs
- add scope-relative list, read, search, rename, delete, size, and download actions
- replace project-specific remote filesystem access with a reusable path-scoped provider
- rebind cached project viewers to their project root when reopened after navigating elsewhere
- fence asynchronous scope and directory responses so stale navigation results cannot overwrite the current view
- canonicalize scope-relative targets on the daemon and reject paths that escape the selected scope
- flatten file-tree rows only when tree state changes and render only the visible range with GPUI's uniform list
- add a theme-aware scrollbar with drag handling and refreshed geometry after tree changes
- preserve keyboard navigation by scrolling the virtualized tree to the selected file

## Validation

- GitHub Actions Linux check: compilation, Clippy, daemon/client split gates, and tests passed
- GitHub Actions Windows check passed
- GitHub Actions mobile typecheck and lint passed
- `cargo test -p okena-files` (69 tests)
- `cargo clippy -p okena-files --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Manual GPUI smoke testing of the new directory navigation, very wide directory rendering, and tree scrollbar was not performed.
