### PR TITLE
fix(layout): refit project sizes to the viewport on equalize

### DIFF
--- a/crates/okena-app/src/views/window/render.rs
+++ b/crates/okena-app/src/views/window/render.rs
@@ -875,10 +875,9 @@ impl Render for WindowView {
                 let fm = this.focus_manager.read(cx).clone();
                 let window_id = this.window_id;
                 this.workspace.update(cx, |ws, cx| {
-                    // Clear custom column widths in THIS window → equal distribution.
-                    if let Some(window_state) = ws.data.window_mut(window_id) {
-                        window_state.project_widths.clear();
-                    }
+                    // Clear custom column sizes in THIS window → equal distribution
+                    // across the current viewport (weights *and* pixel scale).
+                    ws.data.clear_project_sizes(window_id);
                     // Equalize pane sizes in the focused terminal's parent split
                     ws.equalize_focused_split(&fm, cx);
                 });

--- a/crates/okena-state/src/windows.rs
+++ b/crates/okena-state/src/windows.rs
@@ -70,6 +70,20 @@ impl WorkspaceData {
         }
     }
 
+    /// Drop the targeted window's custom project sizes.
+    ///
+    /// Clears the weights *and* the pixel scale together: a weight map without
+    /// its scale renders at the old pixels-per-unit, so the equal weights an
+    /// empty map falls back to (`100 / n` each) would sum to whatever
+    /// `100 * scale` happens to be instead of the viewport. Same invariant
+    /// `scrub_orphan_window_state` keeps — no scale without weights.
+    pub fn clear_project_sizes(&mut self, id: WindowId) {
+        if let Some(w) = self.window_mut(id) {
+            w.project_widths.clear();
+            w.project_width_scale = None;
+        }
+    }
+
     /// Set the pixel scale used by the targeted window's project-size weights.
     pub fn set_project_width_scale(&mut self, id: WindowId, scale: f32) {
         if scale.is_finite()

--- a/crates/okena-state/src/workspace_data.rs
+++ b/crates/okena-state/src/workspace_data.rs
@@ -1021,6 +1021,34 @@ mod tests {
     }
 
     #[test]
+    fn clear_project_sizes_drops_weights_and_scale_of_one_window() {
+        // Equalize clears the window's sizes. Leaving the scale behind would
+        // render the fallback weights (100 / n each) at the old pixels-per-unit,
+        // so the grid would sum to 100 * scale instead of the viewport — the
+        // stacked-rows overflow this test pins shut.
+        let mut data = make_workspace();
+        let extra = WindowState::default();
+        let extra_id = extra.id;
+        data.extra_windows.push(extra);
+
+        for id in [WindowId::Main, WindowId::Extra(extra_id)] {
+            data.set_project_width(id, "p1", 23.5);
+            data.set_project_width_scale(id, 35.4);
+        }
+
+        data.clear_project_sizes(WindowId::Extra(extra_id));
+
+        assert!(data.extra_windows[0].project_widths.is_empty());
+        assert_eq!(data.extra_windows[0].project_width_scale, None);
+        // Scoped to the targeted window.
+        assert_eq!(
+            data.main_window.project_widths.get("p1").copied(),
+            Some(23.5)
+        );
+        assert_eq!(data.main_window.project_width_scale, Some(35.4));
+    }
+
+    #[test]
     fn set_project_width_writes_to_targeted_extra() {
         // Mint two extras, set width on one via WindowId::Extra(uuid). The
         // targeted extra's project_widths gains the entry; the sibling extra

--- a/crates/okena-views-terminal/src/layout/split_pane.rs
+++ b/crates/okena-views-terminal/src/layout/split_pane.rs
@@ -498,6 +498,27 @@ mod tests {
     }
 
     #[test]
+    fn equal_weights_refit_the_viewport_only_once_the_stale_scale_is_dropped() {
+        // Dragged weights stop summing to 100, so the persisted scale is
+        // pixels-per-unit for *that* sum. Equalize falls back to `100 / n`
+        // weights: keeping the scale renders `100 * scale` (an overflowing
+        // grid — worst in stacked rows, where it overflows the height),
+        // dropping it refits them to the viewport.
+        let viewport = 3_016.0;
+        let equal = [100.0 / 3.0; 3];
+
+        let stale: f32 = project_pixel_widths(&equal, viewport, 0.0, Some(35.4))
+            .iter()
+            .sum();
+        assert!(stale > viewport + 500.0, "{stale} should overflow");
+
+        let refitted: f32 = project_pixel_widths(&equal, viewport, 0.0, None)
+            .iter()
+            .sum();
+        assert!((refitted - viewport).abs() < 0.01, "{refitted}");
+    }
+
+    #[test]
     fn fitting_resize_transfers_space_until_neighbor_reaches_minimum() {
         let (left, right) =
             resize_project_pair_px(500.0, 500.0, 300.0, 400.0, 1_000.0, 1_000.0, false);

--- a/crates/okena-workspace/src/state.rs
+++ b/crates/okena-workspace/src/state.rs
@@ -1430,7 +1430,9 @@ impl Workspace {
     /// cannot undo the local choice.
     ///
     /// Weights in `project_widths` are axis-agnostic, so relative grid
-    /// sizing is preserved across the flip. Persisted via `notify_data`.
+    /// sizing is preserved across the flip. The pixel scale is not — it is
+    /// pixels per weight unit along the *current* axis, so it is dropped and
+    /// recomputed from the new axis' viewport. Persisted via `notify_data`.
     pub fn toggle_project_layout_mode(&mut self, window_id: WindowId, cx: &mut impl WorkspaceCx) {
         if self.data.window(window_id).is_none() {
             return;
@@ -1438,6 +1440,7 @@ impl Workspace {
 
         if let Some(w) = self.data.window_mut(window_id) {
             w.project_layout = w.project_layout.toggled();
+            w.project_width_scale = None;
         }
         self.notify_data(cx);
     }
@@ -4509,6 +4512,27 @@ mod gpui_tests {
                 ProjectLayoutMode::Columns
             );
             assert_eq!(ws.data_version(), 2);
+        });
+    }
+
+    #[gpui::test]
+    fn toggle_project_layout_mode_keeps_weights_but_drops_scale(cx: &mut gpui::TestAppContext) {
+        // Weights are axis-agnostic and survive the flip; the pixel scale is
+        // pixels per unit along the old axis, so carrying it over would size
+        // stacked rows by the grid's *width*.
+        let data = make_workspace_data(vec![make_project("p1")], vec!["p1"]);
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            let mut widths = HashMap::new();
+            widths.insert("p1".to_string(), 23.5);
+            ws.update_project_widths_with_scale(WindowId::Main, widths, 35.4, cx);
+            ws.toggle_project_layout_mode(WindowId::Main, cx);
+        });
+
+        workspace.read_with(cx, |ws: &Workspace, _cx| {
+            assert_eq!(ws.get_project_width(WindowId::Main, "p1", 1), 23.5);
+            assert_eq!(ws.get_project_width_scale(WindowId::Main), None);
         });
     }
 


### PR DESCRIPTION
## Problem

Equalize Layout cleared a window's `project_widths` but kept `project_width_scale` — the pixels-per-weight-unit persisted on the first project-divider drag.

Dragged weights stop summing to 100: an overflowing drag grows the strip without shrinking the neighbour, shift-drag moves only the leading edge, and the `min_column_width` clamp rewrites small weights. The empty map then falls back to `100 / n` per project, which sums to exactly 100 — rendered at the stale scale the grid lands on `100 * scale` instead of the viewport.

Real numbers from a window in the stacked-rows layout: weights `23.56 + 36.83 + 24.78 = 85.17` at `scale = 35.41` fit a 3016 px grid; after equalize the three rows want `100 * 35.41 = 3541 px`. The ~525 px surplus has nowhere to go, so the last project is pushed out of view. In the columns layout the same surplus only lengthens the horizontal scroll strip, which is why this reads as "equalize is broken in the pivoted view".

The scale is also per-axis, but flipping the grid orientation kept it, so a width-derived scale sized stacked rows by the grid's *width*.

## Fix

- `WorkspaceData::clear_project_sizes()` clears weights **and** scale together — the same no-scale-without-weights invariant `scrub_orphan_window_state` already keeps. The `EqualizeLayout` handler calls it instead of clearing the map by hand.
- `toggle_project_layout_mode()` drops the scale on the flip. Weights are axis-agnostic and still carry over; the scale is recomputed from the new axis' viewport.

## Tests

- `clear_project_sizes_drops_weights_and_scale_of_one_window` — both fields go, scoped to the targeted window.
- `toggle_project_layout_mode_keeps_weights_but_drops_scale`
- `equal_weights_refit_the_viewport_only_once_the_stale_scale_is_dropped` — pins the arithmetic above: equal weights overflow with the stale scale, fit exactly without it.

`cargo test -p okena-state -p okena-views-terminal -p okena-workspace` green (97 / 35 / 373); `cargo check -p okena-app` clean. Verified in the app by the reporter.

## Not covered

In the rows layout `min_column_width` (default 400 px) is applied as a minimum row *height*. It does not bite on a tall window, but 3+ rows in a shorter one still overflow after this fix. Left alone — it needs a product call (own `min_row_height` setting vs. applying the min on the columns axis only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRA6PPZ7M7DTcNYMdYgMme