### PR TITLE
fix(layout): give a hidden project's space back to the grid

### DIFF
--- a/crates/okena-state/src/windows.rs
+++ b/crates/okena-state/src/windows.rs
@@ -50,9 +50,12 @@ impl WorkspaceData {
     /// targets the matching extra by id; if no such extra exists (e.g. the
     /// caller raced a close), the call is a silent no-op rather than an error.
     /// This matches the `window_mut` lookup contract.
+    /// Changing the filter changes which projects the grid renders, so the
+    /// pixel scale is dropped — see `toggle_hidden`.
     pub fn set_folder_filter(&mut self, id: WindowId, filter: Option<String>) {
         if let Some(w) = self.window_mut(id) {
             w.folder_filter = filter;
+            w.project_width_scale = None;
         }
     }
 
@@ -86,11 +89,18 @@ impl WorkspaceData {
     /// is inserted (project becomes hidden). If present, it is removed (project
     /// becomes visible). Unknown extra ids are a silent no-op, matching the
     /// `window_mut` lookup contract.
+    ///
+    /// Drops `project_width_scale`: it is pixels per weight unit captured
+    /// while dragging over the *previous* visible set, so keeping it would
+    /// leave the surviving projects at their old pixel sizes and a gap where
+    /// the hidden one was. The weights stay, so relative sizing survives —
+    /// they just refit to the viewport, as they did before the scale existed.
     pub fn toggle_hidden(&mut self, id: WindowId, project_id: &str) {
-        if let Some(w) = self.window_mut(id)
-            && !w.hidden_project_ids.remove(project_id)
-        {
-            w.hidden_project_ids.insert(project_id.to_string());
+        if let Some(w) = self.window_mut(id) {
+            if !w.hidden_project_ids.remove(project_id) {
+                w.hidden_project_ids.insert(project_id.to_string());
+            }
+            w.project_width_scale = None;
         }
     }
 

--- a/crates/okena-state/src/workspace_data.rs
+++ b/crates/okena-state/src/workspace_data.rs
@@ -926,6 +926,44 @@ mod tests {
     }
 
     #[test]
+    fn changing_the_visible_set_drops_the_scale_but_keeps_the_weights() {
+        // Both legs of the toggle, and the folder filter, change which
+        // projects the grid renders. The scale was captured over the previous
+        // set, so keeping it would leave the survivors at their old pixels
+        // and an empty strip where the hidden project used to be. Weights stay
+        // — relative sizing survives the refit.
+        fn sized() -> WorkspaceData {
+            let mut data = make_workspace();
+            data.set_project_width(WindowId::Main, "p2", 12.5);
+            data.set_project_width_scale(WindowId::Main, 33.5);
+            data
+        }
+        fn assert_refits(data: &WorkspaceData) {
+            assert_eq!(data.main_window.project_width_scale, None);
+            assert_eq!(
+                data.main_window.project_widths.get("p2").copied(),
+                Some(12.5)
+            );
+        }
+
+        let mut hiding = sized();
+        hiding.toggle_hidden(WindowId::Main, "p1");
+        assert_refits(&hiding);
+
+        let mut unhiding = sized();
+        unhiding
+            .main_window
+            .hidden_project_ids
+            .insert("p1".to_string());
+        unhiding.toggle_hidden(WindowId::Main, "p1");
+        assert_refits(&unhiding);
+
+        let mut filtering = sized();
+        filtering.set_folder_filter(WindowId::Main, Some("f1".to_string()));
+        assert_refits(&filtering);
+    }
+
+    #[test]
     fn toggle_hidden_writes_to_targeted_extra() {
         // Mint two extras, toggle on one via WindowId::Extra(uuid). The
         // targeted extra's hidden set gains the project; the sibling extra


### PR DESCRIPTION
## Problem

Hiding a project leaves an empty band where its column was, instead of the remaining projects growing into the space.

`c881367f` replaced width normalization with a persisted pixel scale:

```rust
-    fn normalize_widths(raw_widths: &[f32]) -> Vec<f32> {
-        let total: f32 = raw_widths.iter().sum();
-        ...  raw_widths.iter().map(|w| w / total * 100.0)
```

Normalization ran over the **visible** projects' weights, so the grid always filled the viewport and hiding a project handed its space to the rest. With the scale, each visible project renders at `weight * scale` — absolute pixels — so hiding one just shortens the strip.

Reported on a window with 8 dragged weights (sum 108.66) at `scale = 33.54`: with two projects visible the columns render 516 px and 613 px and the rest of the viewport stays blank.

The scale is what preserves a dragged scroll strip across re-renders, so it can't simply go — but it is captured over the visible set at drag time, and it has no meaning once that set changes.

## Fix

Drop `project_width_scale` whenever the visible set changes, in the data layer where every path funnels:

- `WorkspaceData::toggle_hidden` — both legs, covering the sidebar Hide/Show action, the project switcher (`toggle_project_overview_visibility`) and worktree visibility.
- `WorkspaceData::set_folder_filter` — a filter change swaps the rendered set just as a hide does.

Weights are untouched, so relative sizing survives; they refit to the viewport the way they did before `c881367f`. A drag keeps its overflow for as long as the visible set holds still.

Deliberately **not** hooked: `hide_project_in_all_windows` runs for every non-overview remote project at boot, so dropping the scale there would silently refit a user's dragged layout on every start.

## Tests

`changing_the_visible_set_drops_the_scale_but_keeps_the_weights` — hide, unhide and folder-filter each clear the scale and keep the weight map.

`cargo test -p okena-state -p okena-workspace` green (98 / 373).

## Relation to #179

Independent — different bug, different commit of origin, no code dependency. #179 fixes Equalize Layout keeping a stale scale; this one fixes the scale outliving the visible set it was measured on. Either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRA6PPZ7M7DTcNYMdYgMme