### PR TITLE
feat(terminal): annotate a selection and send it back to the terminal

### DIFF
--- a/crates/okena-app-core/src/settings.rs
+++ b/crates/okena-app-core/src/settings.rs
@@ -161,6 +161,11 @@ impl SettingsState {
         terminal_drag_selects_in_mouse_mode,
         bool
     );
+    setting_setter!(
+        set_terminal_double_click_selects_in_mouse_mode,
+        terminal_double_click_selects_in_mouse_mode,
+        bool
+    );
     setting_setter!(set_blame_visible, blame_visible, bool);
 
     /// Master switch for native desktop notifications (opt-in).

--- a/crates/okena-app-core/src/settings.rs
+++ b/crates/okena-app-core/src/settings.rs
@@ -151,6 +151,16 @@ impl SettingsState {
         terminal_ctrl_c_copies_selection,
         bool
     );
+    setting_setter!(
+        set_terminal_right_click_opens_menu,
+        terminal_right_click_opens_menu,
+        bool
+    );
+    setting_setter!(
+        set_terminal_drag_selects_in_mouse_mode,
+        terminal_drag_selects_in_mouse_mode,
+        bool
+    );
     setting_setter!(set_blame_visible, blame_visible, bool);
 
     /// Master switch for native desktop notifications (opt-in).

--- a/crates/okena-app/src/keybindings/config.rs
+++ b/crates/okena-app/src/keybindings/config.rs
@@ -213,6 +213,13 @@ impl KeybindingConfig {
             ],
         );
         bindings.insert(
+            "AnnotateSelection".to_string(),
+            vec![
+                KeybindingEntry::new("cmd-shift-a", Some("TerminalPane")),
+                KeybindingEntry::new("ctrl-shift-a", Some("TerminalPane")),
+            ],
+        );
+        bindings.insert(
             "ScrollUp".to_string(),
             vec![KeybindingEntry::new("shift-pageup", Some("TerminalPane"))],
         );

--- a/crates/okena-app/src/keybindings/descriptions.rs
+++ b/crates/okena-app/src/keybindings/descriptions.rs
@@ -170,6 +170,15 @@ pub fn get_action_descriptions() -> HashMap<&'static str, ActionDescription> {
         },
     );
     map.insert(
+        "AnnotateSelection",
+        ActionDescription {
+            name: "AnnotateSelection",
+            description: "Annotate the selection and send it to this terminal",
+            category: "Terminal",
+            factory: || Box::new(okena_views_terminal::actions::AnnotateSelection),
+        },
+    );
+    map.insert(
         "Paste",
         ActionDescription {
             name: "Paste",

--- a/crates/okena-app/src/keybindings/mod.rs
+++ b/crates/okena-app/src/keybindings/mod.rs
@@ -194,6 +194,11 @@ pub fn reload_keybindings(cx: &mut App) {
         ),
         KeyBinding::new(
             "escape",
+            okena_views_terminal::actions::Cancel,
+            Some("SendComposer"),
+        ),
+        KeyBinding::new(
+            "escape",
             okena_views_remote::Cancel,
             Some("RemoteConnectDialog"),
         ),
@@ -308,11 +313,16 @@ pub fn register_keybindings(cx: &mut App) {
             Some("RenameDirectoryDialog"),
         ),
         KeyBinding::new("escape", okena_views_sidebar::Cancel, Some("HookLog")),
-        // okena-views-terminal crate Cancel for shell selector
+        // okena-views-terminal crate Cancel for shell selector + send composer
         KeyBinding::new(
             "escape",
             okena_views_terminal::actions::Cancel,
             Some("ShellSelectorOverlay"),
+        ),
+        KeyBinding::new(
+            "escape",
+            okena_views_terminal::actions::Cancel,
+            Some("SendComposer"),
         ),
         // okena-views-remote crate Cancel actions
         KeyBinding::new(

--- a/crates/okena-app/src/keybindings/mod.rs
+++ b/crates/okena-app/src/keybindings/mod.rs
@@ -399,6 +399,11 @@ fn create_keybinding(action: &str, keystroke: &str, context: Option<&str>) -> Op
         "ClearFocus" => Some(KeyBinding::new(keystroke, ClearFocus, context)),
         "FocusActiveProject" => Some(KeyBinding::new(keystroke, FocusActiveProject, context)),
         "Copy" => Some(KeyBinding::new(keystroke, Copy, context)),
+        "AnnotateSelection" => Some(KeyBinding::new(
+            keystroke,
+            okena_views_terminal::actions::AnnotateSelection,
+            context,
+        )),
         "Paste" => Some(KeyBinding::new(keystroke, Paste, context)),
         "ScrollUp" => Some(KeyBinding::new(keystroke, ScrollUp, context)),
         "ScrollDown" => Some(KeyBinding::new(keystroke, ScrollDown, context)),

--- a/crates/okena-app/src/views/overlay_manager.rs
+++ b/crates/okena-app/src/views/overlay_manager.rs
@@ -31,6 +31,7 @@ use crate::views::overlays::remote_pair_dialog::{RemotePairDialog, RemotePairDia
 use crate::views::overlays::rename_directory_dialog::{
     RenameDirectoryDialog, RenameDirectoryDialogEvent,
 };
+use crate::views::overlays::send_composer::{SendComposer, SendComposerEvent};
 use crate::views::overlays::session_manager::{SessionManager, SessionManagerEvent};
 use crate::views::overlays::settings_panel::{SettingsPanel, SettingsPanelEvent};
 use crate::views::overlays::tab_context_menu::{TabContextMenu, TabContextMenuEvent};
@@ -244,6 +245,12 @@ pub enum OverlayManagerEvent {
 
     /// Terminal context menu: copy
     TerminalCopy { terminal_id: String },
+    /// Terminal context menu: annotate the selection and send it back.
+    /// The host owns the terminals, so only it can snapshot the selected text.
+    TerminalAnnotate {
+        terminal_id: String,
+        position: gpui::Point<gpui::Pixels>,
+    },
     /// Terminal context menu: paste
     TerminalPaste { terminal_id: String },
     /// Terminal context menu: clear
@@ -336,6 +343,7 @@ pub struct OverlayManager {
     remote_context_menu: OverlaySlot<RemoteContextMenu>,
     terminal_context_menu: OverlaySlot<TerminalContextMenu>,
     tab_context_menu: OverlaySlot<TabContextMenu>,
+    send_composer: OverlaySlot<SendComposer>,
 
     // Positioned popovers (like context menus, rendered at WindowView level)
     worktree_list: OverlaySlot<WorktreeListPopover>,
@@ -367,6 +375,7 @@ impl OverlayManager {
             remote_context_menu: OverlaySlot::new(),
             terminal_context_menu: OverlaySlot::new(),
             tab_context_menu: OverlaySlot::new(),
+            send_composer: OverlaySlot::new(),
             worktree_list: OverlaySlot::new(),
             color_picker: OverlaySlot::new(),
         }
@@ -420,6 +429,7 @@ impl OverlayManager {
     ///
     /// Automatically clears terminal focus so keyboard input goes to the modal.
     fn open_modal<T: Render + 'static>(&mut self, entity: Entity<T>, cx: &mut Context<Self>) {
+        self.hide_send_composer(cx);
         self.close_modal(cx);
         self.active_modal = Some(entity.into());
         self.modal_type_id = Some(std::any::TypeId::of::<T>());
@@ -504,7 +514,7 @@ impl OverlayManager {
     // ========================================================================
 
     /// Close all context menu slots (mutual exclusion).
-    fn close_all_context_menus(&mut self) {
+    fn close_all_context_menus(&mut self, cx: &mut Context<Self>) {
         self.context_menu.close();
         self.folder_context_menu.close();
         self.remote_context_menu.close();
@@ -512,6 +522,9 @@ impl OverlayManager {
         self.tab_context_menu.close();
         self.worktree_list.close();
         self.color_picker.close();
+        // Not a plain slot close: the composer holds the modal focus context
+        // and has to hand it back.
+        self.hide_send_composer(cx);
     }
 
     /// Check if context menu is open.
@@ -532,6 +545,11 @@ impl OverlayManager {
     /// Check if tab context menu is open.
     pub fn has_tab_context_menu(&self) -> bool {
         self.tab_context_menu.is_open()
+    }
+
+    /// Check if the send composer is open.
+    pub fn has_send_composer(&self) -> bool {
+        self.send_composer.is_open()
     }
 
     // ========================================================================
@@ -922,7 +940,7 @@ impl OverlayManager {
     /// Show context menu for a project.
     pub fn show_context_menu(&mut self, request: ContextMenuRequest, cx: &mut Context<Self>) {
         self.close_modal(cx);
-        self.close_all_context_menus();
+        self.close_all_context_menus(cx);
 
         let workspace = self.workspace.clone();
         let window_id = self.window_id;
@@ -1082,7 +1100,7 @@ impl OverlayManager {
         cx: &mut Context<Self>,
     ) {
         self.close_modal(cx);
-        self.close_all_context_menus();
+        self.close_all_context_menus(cx);
 
         let workspace = self.workspace.clone();
         let window_id = self.window_id;
@@ -1161,7 +1179,7 @@ impl OverlayManager {
         cx: &mut Context<Self>,
     ) {
         self.close_modal(cx);
-        self.close_all_context_menus();
+        self.close_all_context_menus(cx);
 
         let conn_name = connection_name.clone();
         let menu = cx.new(|cx| {
@@ -1244,7 +1262,7 @@ impl OverlayManager {
         cx: &mut Context<Self>,
     ) {
         self.close_modal(cx);
-        self.close_all_context_menus();
+        self.close_all_context_menus(cx);
 
         let menu = cx.new(|cx| {
             TerminalContextMenu::new(
@@ -1268,6 +1286,16 @@ impl OverlayManager {
                     this.hide_terminal_context_menu(cx);
                     cx.emit(OverlayManagerEvent::TerminalCopy {
                         terminal_id: terminal_id.clone(),
+                    });
+                }
+                TerminalContextMenuEvent::AnnotateSelection {
+                    terminal_id,
+                    position,
+                } => {
+                    this.hide_terminal_context_menu(cx);
+                    cx.emit(OverlayManagerEvent::TerminalAnnotate {
+                        terminal_id: terminal_id.clone(),
+                        position: *position,
                     });
                 }
                 TerminalContextMenuEvent::Paste { terminal_id } => {
@@ -1338,6 +1366,83 @@ impl OverlayManager {
     }
 
     // ========================================================================
+    // Send composer (positioned popup)
+    // ========================================================================
+
+    /// Open the annotate-and-send composer over `quoted`, a snapshot of the
+    /// terminal's selection taken by the caller (only it can reach the PTY).
+    pub fn show_send_composer(
+        &mut self,
+        terminal_id: String,
+        quoted: String,
+        position: gpui::Point<gpui::Pixels>,
+        cx: &mut Context<Self>,
+    ) {
+        self.close_all_context_menus(cx);
+
+        // Enter modal focus context, or the terminal pane grabs focus back on
+        // its next render (see terminal_pane::render) — which for a streaming
+        // agent is the next frame, mid-sentence.
+        let workspace = self.workspace.clone();
+        self.focus_manager.update(cx, |fm, cx| {
+            workspace.update(cx, |ws, cx| ws.clear_focused_terminal(fm, cx));
+            cx.notify();
+        });
+
+        let composer = cx.new(|cx| SendComposer::new(terminal_id, quoted, position, cx));
+
+        cx.subscribe(&composer, |this, _, event: &SendComposerEvent, cx| {
+            match event {
+                SendComposerEvent::Close => this.hide_send_composer(cx),
+                SendComposerEvent::Send {
+                    terminal_id,
+                    quoted,
+                    note,
+                } => {
+                    let payload = okena_core::send_payload::SendPayload::output(
+                        okena_core::send_payload::OutputBlock {
+                            text: quoted.clone(),
+                            // Source and target are the same pane — naming it
+                            // back to itself would only be noise.
+                            source_label: None,
+                        },
+                    )
+                    .with_note(note.clone());
+                    let terminal_id = terminal_id.clone();
+                    this.request_broker.update(cx, |broker, cx| {
+                        broker.push_send_to_terminal_targeted(payload, terminal_id, cx);
+                    });
+                    this.hide_send_composer(cx);
+                }
+            }
+        })
+        .detach();
+
+        self.send_composer.set(composer);
+        cx.notify();
+    }
+
+    /// Hide the send composer, handing focus back to the terminal so the user
+    /// can review the pasted prompt and hit Enter.
+    pub fn hide_send_composer(&mut self, cx: &mut Context<Self>) {
+        if !self.send_composer.is_open() {
+            return;
+        }
+        self.send_composer.close();
+        let workspace = self.workspace.clone();
+        self.focus_manager.update(cx, |fm, cx| {
+            workspace.update(cx, |ws, cx| ws.restore_focused_terminal(fm, cx));
+            cx.notify();
+        });
+        cx.notify();
+    }
+
+    /// Get send composer entity for rendering.
+    pub fn render_send_composer(&self) -> Option<Entity<SendComposer>> {
+        self.send_composer.render()
+    }
+
+    // ========================================================================
     // Tab context menu (positioned popup)
     // ========================================================================
 
@@ -1352,7 +1457,7 @@ impl OverlayManager {
         cx: &mut Context<Self>,
     ) {
         self.close_modal(cx);
-        self.close_all_context_menus();
+        self.close_all_context_menus(cx);
 
         let menu = cx.new(|cx| {
             TabContextMenu::new(tab_index, num_tabs, project_id, layout_path, position, cx)
@@ -1436,7 +1541,7 @@ impl OverlayManager {
         params: (okena_transport::remote_action::RemoteActionClient, String),
         cx: &mut Context<Self>,
     ) {
-        self.close_all_context_menus();
+        self.close_all_context_menus(cx);
 
         let (client, daemon_id) = params;
         let workspace = self.workspace.clone();
@@ -1503,7 +1608,7 @@ impl OverlayManager {
         position: Point<Pixels>,
         cx: &mut Context<Self>,
     ) {
-        self.close_all_context_menus();
+        self.close_all_context_menus(cx);
 
         let workspace = self.workspace.clone();
         let popover = cx.new(|cx| ColorPickerPopover::new(workspace, target, position, cx));
@@ -2097,3 +2202,150 @@ impl OverlayManager {
 }
 
 impl EventEmitter<OverlayManagerEvent> for OverlayManager {}
+
+#[cfg(test)]
+mod send_composer_tests {
+    use super::OverlayManager;
+    use crate::workspace::focus::{FocusContext, FocusManager};
+    use crate::workspace::request_broker::RequestBroker;
+    use crate::workspace::state::{WindowId, Workspace, WorkspaceData};
+    use gpui::AppContext as _;
+    use gpui::{Entity, TestAppContext};
+
+    struct Harness {
+        overlay: Entity<OverlayManager>,
+        focus: Entity<FocusManager>,
+        broker: Entity<RequestBroker>,
+    }
+
+    fn harness(cx: &mut TestAppContext) -> Harness {
+        cx.update(|cx| {
+            let workspace = cx.new(|_| Workspace::new(WorkspaceData::empty()));
+            let focus = cx.new(|_| FocusManager::new());
+            let broker = cx.new(|_| RequestBroker::new());
+            let overlay = cx.new(|_| {
+                OverlayManager::new(
+                    WindowId::Main,
+                    workspace.clone(),
+                    focus.clone(),
+                    broker.clone(),
+                )
+            });
+            Harness {
+                overlay,
+                focus,
+                broker,
+            }
+        })
+    }
+
+    fn open(h: &Harness, quoted: &str, cx: &mut TestAppContext) {
+        h.overlay.update(cx, |om, cx| {
+            om.show_send_composer(
+                "term-1".into(),
+                quoted.into(),
+                gpui::point(gpui::px(10.0), gpui::px(20.0)),
+                cx,
+            );
+        });
+    }
+
+    /// The pane re-grabs focus on every render unless the focus context is
+    /// Modal, so an unbalanced enter/exit here means typing lands in the PTY.
+    #[gpui::test]
+    fn open_enters_modal_focus_and_close_leaves_it(cx: &mut TestAppContext) {
+        let h = harness(cx);
+        open(&h, "boom", cx);
+
+        assert!(h.overlay.read_with(cx, |om, _| om.has_send_composer()));
+        assert_eq!(
+            h.focus.read_with(cx, |fm, _| fm.context().clone()),
+            FocusContext::Modal
+        );
+
+        h.overlay.update(cx, |om, cx| om.hide_send_composer(cx));
+
+        assert!(!h.overlay.read_with(cx, |om, _| om.has_send_composer()));
+        assert_eq!(
+            h.focus.read_with(cx, |fm, _| fm.context().clone()),
+            FocusContext::Terminal
+        );
+    }
+
+    /// Reopening must not stack a second modal entry on the focus stack.
+    #[gpui::test]
+    fn reopening_does_not_leak_a_modal_entry(cx: &mut TestAppContext) {
+        let h = harness(cx);
+        open(&h, "first", cx);
+        open(&h, "second", cx);
+
+        h.overlay.update(cx, |om, cx| om.hide_send_composer(cx));
+
+        assert_eq!(
+            h.focus.read_with(cx, |fm, _| fm.context().clone()),
+            FocusContext::Terminal,
+            "one close should be enough to leave modal focus"
+        );
+    }
+
+    /// Closing a composer that was never open must not pop the focus stack.
+    #[gpui::test]
+    fn hiding_a_closed_composer_is_a_noop(cx: &mut TestAppContext) {
+        let h = harness(cx);
+        h.overlay.update(cx, |om, cx| om.hide_send_composer(cx));
+
+        assert_eq!(
+            h.focus.read_with(cx, |fm, _| fm.context().clone()),
+            FocusContext::Terminal
+        );
+    }
+
+    #[gpui::test]
+    fn send_queues_the_quote_and_note_for_the_source_terminal(cx: &mut TestAppContext) {
+        let h = harness(cx);
+        open(&h, "error: boom", cx);
+
+        let composer = h
+            .overlay
+            .read_with(cx, |om, _| om.render_send_composer())
+            .expect("composer is open");
+        composer.update(cx, |c, cx| {
+            c.set_note("fix it", cx);
+            c.send(cx);
+        });
+
+        let queued = h
+            .broker
+            .update(cx, |broker, _| broker.drain_send_to_terminal());
+        assert_eq!(queued.len(), 1);
+        let (payload, target) = &queued[0];
+        assert_eq!(
+            target.as_deref(),
+            Some("term-1"),
+            "annotation goes back to the terminal it came from, not to whatever has focus"
+        );
+        assert_eq!(payload.format(None), "```\nerror: boom\n```\n\nfix it");
+
+        assert!(
+            !h.overlay.read_with(cx, |om, _| om.has_send_composer()),
+            "sending closes the composer"
+        );
+    }
+
+    #[gpui::test]
+    fn send_without_a_note_queues_the_bare_quote(cx: &mut TestAppContext) {
+        let h = harness(cx);
+        open(&h, "error: boom", cx);
+
+        let composer = h
+            .overlay
+            .read_with(cx, |om, _| om.render_send_composer())
+            .expect("composer is open");
+        composer.update(cx, |c, cx| c.send(cx));
+
+        let queued = h
+            .broker
+            .update(cx, |broker, _| broker.drain_send_to_terminal());
+        assert_eq!(queued[0].0.format(None), "```\nerror: boom\n```");
+    }
+}

--- a/crates/okena-app/src/views/overlays/mod.rs
+++ b/crates/okena-app/src/views/overlays/mod.rs
@@ -35,6 +35,7 @@ pub mod remote_connect_dialog;
 pub mod remote_context_menu;
 pub mod remote_pair_dialog;
 pub mod rename_directory_dialog;
+pub mod send_composer;
 pub mod session_manager;
 pub mod settings_panel;
 pub mod shell_selector_overlay;

--- a/crates/okena-app/src/views/overlays/send_composer.rs
+++ b/crates/okena-app/src/views/overlays/send_composer.rs
@@ -1,0 +1,1 @@
+pub use okena_views_terminal::overlays::send_composer::*;

--- a/crates/okena-app/src/views/overlays/settings_panel/render_terminal.rs
+++ b/crates/okena-app/src/views/overlays/settings_panel/render_terminal.rs
@@ -70,6 +70,14 @@ impl SettingsPanel {
                     cx,
                 ))
                 .child(self.render_toggle(
+                    "double-click-selects",
+                    "Double Click Selects in Mouse Apps",
+                    s.terminal_double_click_selects_in_mouse_mode,
+                    true,
+                    |state, val, cx| state.set_terminal_double_click_selects_in_mouse_mode(val, cx),
+                    cx,
+                ))
+                .child(self.render_toggle(
                     "idle-detection",
                     "Idle Detection",
                     s.idle_timeout_secs > 0,

--- a/crates/okena-app/src/views/overlays/settings_panel/render_terminal.rs
+++ b/crates/okena-app/src/views/overlays/settings_panel/render_terminal.rs
@@ -54,6 +54,22 @@ impl SettingsPanel {
                     cx,
                 ))
                 .child(self.render_toggle(
+                    "right-click-menu",
+                    "Right Click Opens Menu",
+                    s.terminal_right_click_opens_menu,
+                    true,
+                    |state, val, cx| state.set_terminal_right_click_opens_menu(val, cx),
+                    cx,
+                ))
+                .child(self.render_toggle(
+                    "drag-selects",
+                    "Drag Selects in Mouse Apps",
+                    s.terminal_drag_selects_in_mouse_mode,
+                    true,
+                    |state, val, cx| state.set_terminal_drag_selects_in_mouse_mode(val, cx),
+                    cx,
+                ))
+                .child(self.render_toggle(
                     "idle-detection",
                     "Idle Detection",
                     s.idle_timeout_secs > 0,

--- a/crates/okena-app/src/views/window/handlers.rs
+++ b/crates/okena-app/src/views/window/handlers.rs
@@ -785,23 +785,7 @@ impl WindowView {
                 terminal_id,
                 position,
             } => {
-                // Alacritty already drops grid padding and rejoins wrapped
-                // lines; only the trailing blank line needs to go, or it would
-                // sit inside the fence.
-                let quoted = {
-                    let terminals = self.terminals.lock();
-                    terminals
-                        .get(terminal_id)
-                        .and_then(|terminal| terminal.get_selected_text())
-                        .map(|text| text.trim_end().to_string())
-                };
-                if let Some(quoted) = quoted.filter(|q| !q.is_empty()) {
-                    let terminal_id = terminal_id.clone();
-                    let position = *position;
-                    self.overlay_manager.update(cx, |om, cx| {
-                        om.show_send_composer(terminal_id, quoted, position, cx);
-                    });
-                }
+                self.open_send_composer(terminal_id, *position, cx);
             }
             OverlayManagerEvent::TerminalPaste { terminal_id } => {
                 let text = cx
@@ -1228,6 +1212,12 @@ impl WindowView {
                             );
                         });
                     }
+                    ProjectOverlayKind::AnnotateSelection {
+                        terminal_id,
+                        position,
+                    } => {
+                        self.open_send_composer(&terminal_id, position, cx);
+                    }
                     ProjectOverlayKind::TabContextMenu {
                         tab_index,
                         num_tabs,
@@ -1383,6 +1373,33 @@ impl WindowView {
                 }
             }
         }
+    }
+
+    /// Snapshot a terminal's selection and open the annotate composer over it.
+    /// Shared by the context-menu item and the keyboard action.
+    ///
+    /// Alacritty already drops grid padding and rejoins wrapped lines; only the
+    /// trailing blank line needs to go, or it would sit inside the fence.
+    fn open_send_composer(
+        &mut self,
+        terminal_id: &str,
+        position: gpui::Point<gpui::Pixels>,
+        cx: &mut Context<Self>,
+    ) {
+        let quoted = {
+            let terminals = self.terminals.lock();
+            terminals
+                .get(terminal_id)
+                .and_then(|terminal| terminal.get_selected_text())
+                .map(|text| text.trim_end().to_string())
+        };
+        let Some(quoted) = quoted.filter(|q| !q.is_empty()) else {
+            return;
+        };
+        let terminal_id = terminal_id.to_string();
+        self.overlay_manager.update(cx, |om, cx| {
+            om.show_send_composer(terminal_id, quoted, position, cx);
+        });
     }
 
     /// Drain the broker's "send to terminal" queue and paste each payload into

--- a/crates/okena-app/src/views/window/handlers.rs
+++ b/crates/okena-app/src/views/window/handlers.rs
@@ -154,25 +154,33 @@ impl WindowView {
         }
     }
 
-    /// Paste a "Send to Terminal" payload into the currently focused terminal.
+    /// Paste a "Send to Terminal" payload into `target` — or, when the sender
+    /// named no target, into the currently focused terminal.
     ///
-    /// Resolves the focused terminal's working directory (OSC 7-reported, else
+    /// Resolves the receiving terminal's working directory (OSC 7-reported, else
     /// the PTY's initial cwd) and formats the payload relative to it before
     /// sending. Always wrapped in bracketed-paste sequences — see
     /// `Terminal::send_paste_force_bracketed` for rationale on why we don't
     /// trust the tracked DECSET 2004 mode flag. Toasts a warning if no
     /// terminal is focused.
-    fn send_payload_to_active_terminal(
+    fn send_payload_to_terminal(
         &self,
         payload: okena_core::send_payload::SendPayload,
+        target: Option<String>,
         cx: &mut Context<Self>,
     ) {
-        let Some((_project_id, terminal_id)) = self.focused_terminal_id(cx) else {
-            okena_workspace::toast::ToastManager::warning(
-                "No active terminal to send selection to",
-                cx,
-            );
-            return;
+        let terminal_id = match target {
+            Some(id) => id,
+            None => {
+                let Some((_project_id, id)) = self.focused_terminal_id(cx) else {
+                    okena_workspace::toast::ToastManager::warning(
+                        "No active terminal to send selection to",
+                        cx,
+                    );
+                    return;
+                };
+                id
+            }
         };
         let terminals = self.terminals.lock();
         if let Some(terminal) = terminals.get(&terminal_id) {
@@ -773,6 +781,28 @@ impl WindowView {
                     cx.write_to_clipboard(ClipboardItem::new_string(text));
                 }
             }
+            OverlayManagerEvent::TerminalAnnotate {
+                terminal_id,
+                position,
+            } => {
+                // Alacritty already drops grid padding and rejoins wrapped
+                // lines; only the trailing blank line needs to go, or it would
+                // sit inside the fence.
+                let quoted = {
+                    let terminals = self.terminals.lock();
+                    terminals
+                        .get(terminal_id)
+                        .and_then(|terminal| terminal.get_selected_text())
+                        .map(|text| text.trim_end().to_string())
+                };
+                if let Some(quoted) = quoted.filter(|q| !q.is_empty()) {
+                    let terminal_id = terminal_id.clone();
+                    let position = *position;
+                    self.overlay_manager.update(cx, |om, cx| {
+                        om.show_send_composer(terminal_id, quoted, position, cx);
+                    });
+                }
+            }
             OverlayManagerEvent::TerminalPaste { terminal_id } => {
                 let text = cx
                     .read_from_clipboard()
@@ -1362,8 +1392,8 @@ impl WindowView {
         let payloads = self
             .request_broker
             .update(cx, |broker, _cx| broker.drain_send_to_terminal());
-        for payload in payloads {
-            self.send_payload_to_active_terminal(payload, cx);
+        for (payload, target) in payloads {
+            self.send_payload_to_terminal(payload, target, cx);
         }
     }
 

--- a/crates/okena-app/src/views/window/render.rs
+++ b/crates/okena-app/src/views/window/render.rs
@@ -618,6 +618,7 @@ impl Render for WindowView {
         let has_remote_context_menu = om.has_remote_context_menu();
         let has_terminal_context_menu = om.has_terminal_context_menu();
         let has_tab_context_menu = om.has_tab_context_menu();
+        let has_send_composer = om.has_send_composer();
         let has_worktree_list = om.has_worktree_list();
         let has_color_picker = om.has_color_picker();
 
@@ -1480,6 +1481,10 @@ impl Render for WindowView {
             // Tab context menu overlay (positioned popup)
             .when(has_tab_context_menu, |d| {
                 d.children(self.overlay_manager.read(cx).render_tab_context_menu())
+            })
+            // Send composer (positioned popup over the terminal selection)
+            .when(has_send_composer, |d| {
+                d.children(self.overlay_manager.read(cx).render_send_composer())
             })
             // Single active modal overlay (renders on top of everything)
             .when_some(self.overlay_manager.read(cx).render_modal(), |d, modal| {

--- a/crates/okena-core/src/send_payload.rs
+++ b/crates/okena-core/src/send_payload.rs
@@ -1,10 +1,10 @@
-//! Shared types for "Send to Terminal" — text or code-block payloads emitted by
-//! viewers (file viewer, diff viewer, commit graph) and consumed by the host
-//! that owns the active terminal.
+//! Shared types for "Send to Terminal" — text, code-block or terminal-output
+//! payloads emitted by viewers (file viewer, diff viewer, commit graph) and by
+//! terminal panes, and consumed by the host that owns the target terminal.
 //!
-//! Lives in `okena-core` so both the producers (`okena-files`, `okena-views-git`)
-//! and the broker queue type (`okena-workspace`) can refer to it without forming
-//! a dependency cycle.
+//! Lives in `okena-core` so both the producers (`okena-files`, `okena-views-git`,
+//! `okena-views-terminal`) and the broker queue type (`okena-workspace`) can
+//! refer to it without forming a dependency cycle.
 
 use std::path::{Path, PathBuf};
 
@@ -20,28 +20,102 @@ pub struct CodeBlock {
     pub text: String,
 }
 
-/// A "Send to Terminal" payload.
+/// A slice of terminal output: fenced verbatim, with no path to resolve.
+#[derive(Clone, Debug)]
+pub struct OutputBlock {
+    pub text: String,
+    /// Terminal name shown above the fence. `None` when the target terminal is
+    /// also the source — naming it there would just be noise.
+    pub source_label: Option<String>,
+}
+
+/// One part of a payload.
 ///
 /// - `Code` blocks know their absolute paths so the dispatcher can present them
 ///   relative to the terminal's CWD.
+/// - `Output` is terminal output, fenced as-is.
 /// - `Text` is pre-formatted (used for commit info).
 /// - `Path` is a file/directory reference; the dispatcher writes it relative to
 ///   the terminal's CWD and appends a trailing space so the user can type a
 ///   command after.
 #[derive(Clone, Debug)]
-pub enum SendPayload {
-    Code(Vec<CodeBlock>),
+pub enum SendChunk {
+    Code(CodeBlock),
+    Output(OutputBlock),
     Text(String),
     Path(PathBuf),
 }
 
-impl SendPayload {
-    pub fn is_empty(&self) -> bool {
+impl SendChunk {
+    fn is_empty(&self) -> bool {
         match self {
-            SendPayload::Code(blocks) => blocks.is_empty(),
-            SendPayload::Text(s) => s.is_empty(),
-            SendPayload::Path(p) => p.as_os_str().is_empty(),
+            SendChunk::Code(b) => b.text.is_empty(),
+            SendChunk::Output(b) => b.text.is_empty(),
+            SendChunk::Text(s) => s.is_empty(),
+            SendChunk::Path(p) => p.as_os_str().is_empty(),
         }
+    }
+
+    fn format(&self, terminal_cwd: Option<&Path>) -> String {
+        match self {
+            SendChunk::Code(b) => format_code_block(b, terminal_cwd),
+            SendChunk::Output(b) => format_output_block(b),
+            SendChunk::Text(s) => s.clone(),
+            SendChunk::Path(p) => format!("{} ", relative_to_cwd(p, terminal_cwd)),
+        }
+    }
+}
+
+/// A "Send to Terminal" payload: quoted chunks plus an optional user note.
+///
+/// The note is rendered *after* the chunks — receivers follow an instruction
+/// better when it trails the material it refers to.
+#[derive(Clone, Debug, Default)]
+pub struct SendPayload {
+    pub chunks: Vec<SendChunk>,
+    pub note: Option<String>,
+}
+
+impl SendPayload {
+    pub fn code(blocks: Vec<CodeBlock>) -> Self {
+        Self {
+            chunks: blocks.into_iter().map(SendChunk::Code).collect(),
+            note: None,
+        }
+    }
+
+    pub fn output(block: OutputBlock) -> Self {
+        Self {
+            chunks: vec![SendChunk::Output(block)],
+            note: None,
+        }
+    }
+
+    pub fn text(text: String) -> Self {
+        Self {
+            chunks: vec![SendChunk::Text(text)],
+            note: None,
+        }
+    }
+
+    pub fn path(path: PathBuf) -> Self {
+        Self {
+            chunks: vec![SendChunk::Path(path)],
+            note: None,
+        }
+    }
+
+    /// Attach a user note. Blank notes are dropped so callers can pass an
+    /// unedited input field straight through.
+    pub fn with_note(mut self, note: impl Into<String>) -> Self {
+        let note = note.into();
+        let trimmed = note.trim();
+        self.note = (!trimmed.is_empty()).then(|| trimmed.to_string());
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.note.is_none() && self.chunks.iter().all(SendChunk::is_empty)
     }
 
     /// Render the payload into the bytes to paste into the terminal.
@@ -56,17 +130,11 @@ impl SendPayload {
     /// trailing LF inside a bracketed paste as Enter and submit the prompt.
     /// This is the single home for that invariant — callers don't repeat it.
     pub fn format(&self, terminal_cwd: Option<&Path>) -> String {
-        let mut out = match self {
-            SendPayload::Code(blocks) => {
-                let rendered: Vec<String> = blocks
-                    .iter()
-                    .map(|b| format_code_block(b, terminal_cwd))
-                    .collect();
-                rendered.join("\n\n")
-            }
-            SendPayload::Text(s) => s.clone(),
-            SendPayload::Path(p) => format!("{} ", relative_to_cwd(p, terminal_cwd)),
-        };
+        let mut parts: Vec<String> = self.chunks.iter().map(|c| c.format(terminal_cwd)).collect();
+        if let Some(ref note) = self.note {
+            parts.push(note.clone());
+        }
+        let mut out = parts.join("\n\n");
         while out.ends_with('\n') {
             out.pop();
         }
@@ -82,7 +150,25 @@ fn format_code_block(block: &CodeBlock, terminal_cwd: Option<&Path>) -> String {
     } else {
         format!("{}:{}-{}", display_path, block.first, block.last)
     };
-    format!("{}\n```{}\n{}\n```", header, lang, block.text)
+    let fence = fence_for(&block.text);
+    format!("{}\n{}{}\n{}\n{}", header, fence, lang, block.text, fence)
+}
+
+fn format_output_block(block: &OutputBlock) -> String {
+    let fence = fence_for(&block.text);
+    match block.source_label {
+        Some(ref label) => format!("{}:\n{}\n{}\n{}", label, fence, block.text, fence),
+        None => format!("{}\n{}\n{}", fence, block.text, fence),
+    }
+}
+
+/// A fence long enough to survive the content it wraps.
+///
+/// Agent output routinely contains ``` fences of its own; a fixed 3-backtick
+/// wrapper would end the quote early and mangle everything after it.
+fn fence_for(text: &str) -> String {
+    let longest_run = text.split(|c| c != '`').map(str::len).max().unwrap_or(0);
+    "`".repeat(longest_run.max(2) + 1)
 }
 
 /// If `path` lives under `cwd`, return the path component relative to it
@@ -172,30 +258,37 @@ mod tests {
         }
     }
 
+    fn output(text: &str, label: Option<&str>) -> OutputBlock {
+        OutputBlock {
+            text: text.into(),
+            source_label: label.map(Into::into),
+        }
+    }
+
     #[test]
     fn single_block_with_no_cwd_uses_absolute_path() {
-        let p = SendPayload::Code(vec![block("/proj/src/foo.rs", 5, 5, "let x = 1;")]);
+        let p = SendPayload::code(vec![block("/proj/src/foo.rs", 5, 5, "let x = 1;")]);
         let out = p.format(None);
         assert_eq!(out, "/proj/src/foo.rs:5\n```rust\nlet x = 1;\n```");
     }
 
     #[test]
     fn single_block_uses_cwd_relative_path() {
-        let p = SendPayload::Code(vec![block("/proj/src/foo.rs", 5, 7, "a\nb\nc")]);
+        let p = SendPayload::code(vec![block("/proj/src/foo.rs", 5, 7, "a\nb\nc")]);
         let out = p.format(Some(Path::new("/proj")));
         assert_eq!(out, "./src/foo.rs:5-7\n```rust\na\nb\nc\n```");
     }
 
     #[test]
     fn block_outside_cwd_falls_back_to_absolute() {
-        let p = SendPayload::Code(vec![block("/other/src/foo.rs", 1, 1, "x")]);
+        let p = SendPayload::code(vec![block("/other/src/foo.rs", 1, 1, "x")]);
         let out = p.format(Some(Path::new("/proj")));
         assert_eq!(out, "/other/src/foo.rs:1\n```rust\nx\n```");
     }
 
     #[test]
     fn multiple_blocks_joined_with_blank_line() {
-        let p = SendPayload::Code(vec![
+        let p = SendPayload::code(vec![
             block("/proj/a.rs", 1, 1, "x"),
             block("/proj/b.rs", 2, 3, "y\nz"),
         ]);
@@ -208,9 +301,67 @@ mod tests {
 
     #[test]
     fn unknown_extension_yields_empty_lang_label() {
-        let p = SendPayload::Code(vec![block("/proj/notes.xyz", 1, 1, "hello")]);
+        let p = SendPayload::code(vec![block("/proj/notes.xyz", 1, 1, "hello")]);
         let out = p.format(Some(Path::new("/proj")));
         assert_eq!(out, "./notes.xyz:1\n```\nhello\n```");
+    }
+
+    #[test]
+    fn output_block_is_fenced_without_a_header() {
+        let p = SendPayload::output(output("error: boom\n  at line 3", None));
+        assert_eq!(p.format(None), "```\nerror: boom\n  at line 3\n```");
+    }
+
+    #[test]
+    fn output_block_with_label_names_the_source_terminal() {
+        let p = SendPayload::output(output("boom", Some("dev server")));
+        assert_eq!(p.format(None), "dev server:\n```\nboom\n```");
+    }
+
+    #[test]
+    fn note_follows_the_quoted_chunks() {
+        let p = SendPayload::output(output("boom", None)).with_note("why?");
+        assert_eq!(p.format(None), "```\nboom\n```\n\nwhy?");
+    }
+
+    #[test]
+    fn blank_note_is_dropped() {
+        let p = SendPayload::output(output("boom", None)).with_note("  \n ");
+        assert_eq!(p.format(None), "```\nboom\n```");
+        assert!(p.note.is_none());
+    }
+
+    #[test]
+    fn note_is_trimmed() {
+        let p = SendPayload::output(output("boom", None)).with_note("  fix it\n");
+        assert_eq!(p.format(None), "```\nboom\n```\n\nfix it");
+    }
+
+    /// Agent output usually contains fences of its own — a 3-backtick wrapper
+    /// would end the quote early and leak the rest as prose.
+    #[test]
+    fn fence_outgrows_backticks_in_the_quoted_text() {
+        let p = SendPayload::output(output("here:\n```rust\nlet x = 1;\n```", None));
+        assert_eq!(
+            p.format(None),
+            "````\nhere:\n```rust\nlet x = 1;\n```\n````"
+        );
+    }
+
+    #[test]
+    fn fence_outgrows_backticks_in_code_blocks_too() {
+        let p = SendPayload::code(vec![block("/p/a.md", 1, 1, "````\nnested\n````")]);
+        assert_eq!(
+            p.format(None),
+            "/p/a.md:1\n`````markdown\n````\nnested\n````\n`````"
+        );
+    }
+
+    #[test]
+    fn note_only_payload_sends_just_the_note() {
+        let p = SendPayload::default().with_note("hello");
+        assert_eq!(p.format(None), "hello");
+        assert!(!p.is_empty());
     }
 
     #[test]
@@ -226,16 +377,17 @@ mod tests {
 
     #[test]
     fn text_variant_is_passthrough_minus_trailing_lf() {
-        let p = SendPayload::Text("commit abc\n\n    subject\n".into());
+        let p = SendPayload::text("commit abc\n\n    subject\n".into());
         assert_eq!(p.format(None), "commit abc\n\n    subject");
     }
 
     #[test]
     fn never_ends_with_newline_anywhere() {
         let cases: Vec<SendPayload> = vec![
-            SendPayload::Text("trailing\n\n\n".into()),
-            SendPayload::Code(vec![block("/p/a.rs", 1, 1, "x\n")]),
-            SendPayload::Code(vec![]),
+            SendPayload::text("trailing\n\n\n".into()),
+            SendPayload::code(vec![block("/p/a.rs", 1, 1, "x\n")]),
+            SendPayload::code(vec![]),
+            SendPayload::output(output("boom\n", None)).with_note("why\n\n"),
         ];
         for p in cases {
             assert!(!p.format(None).ends_with('\n'), "{:?}", p);
@@ -244,14 +396,14 @@ mod tests {
 
     #[test]
     fn empty_code_payload_is_empty_string() {
-        let p = SendPayload::Code(vec![]);
+        let p = SendPayload::code(vec![]);
         assert_eq!(p.format(None), "");
         assert!(p.is_empty());
     }
 
     #[test]
     fn path_variant_resolves_cwd_relative_with_trailing_space() {
-        let p = SendPayload::Path(PathBuf::from("/proj/src/foo.rs"));
+        let p = SendPayload::path(PathBuf::from("/proj/src/foo.rs"));
         assert_eq!(p.format(Some(Path::new("/proj"))), "./src/foo.rs ");
         assert_eq!(p.format(None), "/proj/src/foo.rs ");
     }

--- a/crates/okena-files/src/file_viewer/context_menu.rs
+++ b/crates/okena-files/src/file_viewer/context_menu.rs
@@ -486,7 +486,7 @@ impl FileViewer {
                                         move |this, _, _, cx| {
                                             this.close_context_menu(cx);
                                             cx.emit(super::FileViewerEvent::SendToTerminal(
-                                                okena_core::send_payload::SendPayload::Path(
+                                                okena_core::send_payload::SendPayload::path(
                                                     path.clone(),
                                                 ),
                                             ));
@@ -602,7 +602,7 @@ impl FileViewer {
                                         move |this, _, _, cx| {
                                             this.tab_context_menu = None;
                                             cx.emit(super::FileViewerEvent::SendToTerminal(
-                                                okena_core::send_payload::SendPayload::Path(
+                                                okena_core::send_payload::SendPayload::path(
                                                     path.clone(),
                                                 ),
                                             ));

--- a/crates/okena-files/src/file_viewer/selection.rs
+++ b/crates/okena-files/src/file_viewer/selection.rs
@@ -64,7 +64,7 @@ impl FileViewer {
             .collect::<Vec<_>>()
             .join("\n");
 
-        Some(SendPayload::Code(vec![CodeBlock {
+        Some(SendPayload::code(vec![CodeBlock {
             absolute_path: self
                 .project_fs
                 .absolute_path(&tab.relative_path)

--- a/crates/okena-ui/src/simple_input.rs
+++ b/crates/okena-ui/src/simple_input.rs
@@ -32,6 +32,8 @@ pub struct SimpleInputState {
     icon: Option<SharedString>,
     highlight_vars: bool,
     multiline: bool,
+    /// Multiline only: plain Enter bubbles to the parent, Shift+Enter breaks the line.
+    submit_on_enter: bool,
     input_bounds: Option<Bounds<Pixels>>,
     /// Per-line TextLayouts for accurate click-to-cursor mapping via index_for_position().
     text_layouts: Vec<TextLayout>,
@@ -72,6 +74,7 @@ impl SimpleInputState {
             icon: None,
             highlight_vars: false,
             multiline: false,
+            submit_on_enter: false,
             input_bounds: None,
             text_layouts: Vec::new(),
             is_selecting: false,
@@ -104,6 +107,14 @@ impl SimpleInputState {
     /// Enable highlighting of `{var}` template variables in a distinct color.
     pub fn highlight_vars(mut self) -> Self {
         self.highlight_vars = true;
+        self
+    }
+
+    /// In multiline mode, hand plain Enter to the parent (to submit) and move
+    /// newline insertion onto Shift+Enter. No effect on single-line inputs,
+    /// which already bubble Enter.
+    pub fn submit_on_enter(mut self) -> Self {
+        self.submit_on_enter = true;
         self
     }
 
@@ -699,7 +710,7 @@ impl SimpleInputState {
                 return KeyHandled::NotHandled;
             }
             "enter" => {
-                if self.multiline {
+                if self.multiline && (!self.submit_on_enter || modifiers.shift) {
                     self.insert_text("\n", cx);
                     return KeyHandled::Handled;
                 }

--- a/crates/okena-views-git/src/commit_send.rs
+++ b/crates/okena-views-git/src/commit_send.rs
@@ -146,7 +146,7 @@ mod tests {
     fn wrapping_in_send_payload_strips_trailing_lf() {
         use okena_core::send_payload::SendPayload;
         let text = format_commit_send_text("abc1234", Some("subject"), None, None, &[]);
-        let formatted = SendPayload::Text(text).format(None);
+        let formatted = SendPayload::text(text).format(None);
         assert!(!formatted.ends_with('\n'), "got: {:?}", formatted);
         assert!(formatted.ends_with("    subject"));
     }

--- a/crates/okena-views-git/src/diff_viewer/context_menu.rs
+++ b/crates/okena-views-git/src/diff_viewer/context_menu.rs
@@ -367,7 +367,7 @@ impl DiffViewer {
                 .on_click(cx.listener(move |this, _, _, cx| {
                     this.close_commit_hash_menu(cx);
                     cx.emit(super::DiffViewerEvent::SendToTerminal(
-                        okena_core::send_payload::SendPayload::Text(send_text.clone()),
+                        okena_core::send_payload::SendPayload::text(send_text.clone()),
                     ));
                 })),
             )
@@ -490,7 +490,7 @@ impl DiffViewer {
                 .on_click(cx.listener(move |this, _, _, cx| {
                     this.close_context_menu(cx);
                     cx.emit(super::DiffViewerEvent::SendToTerminal(
-                        okena_core::send_payload::SendPayload::Path(abs_for_send.clone()),
+                        okena_core::send_payload::SendPayload::path(abs_for_send.clone()),
                     ));
                 })),
             );

--- a/crates/okena-views-git/src/diff_viewer/selection_ops.rs
+++ b/crates/okena-views-git/src/diff_viewer/selection_ops.rs
@@ -215,7 +215,7 @@ impl DiffViewer {
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(&stats.path));
 
-        Some(SendPayload::Code(vec![CodeBlock {
+        Some(SendPayload::code(vec![CodeBlock {
             absolute_path,
             first,
             last,

--- a/crates/okena-views-git/src/git_header/commit_log.rs
+++ b/crates/okena-views-git/src/git_header/commit_log.rs
@@ -656,7 +656,7 @@ impl GitHeader {
                     this.commit_row_menu = None;
                     request_broker.update(cx, |broker, cx| {
                         broker.push_send_to_terminal(
-                            okena_core::send_payload::SendPayload::Text(send_text.clone()),
+                            okena_core::send_payload::SendPayload::text(send_text.clone()),
                             cx,
                         );
                     });

--- a/crates/okena-views-terminal/src/actions.rs
+++ b/crates/okena-views-terminal/src/actions.rs
@@ -37,5 +37,6 @@ gpui::actions!(
         JumpToNextPrompt,
         JumpToPreviousFailedCommand,
         JumpToNextFailedCommand,
+        AnnotateSelection,
     ]
 );

--- a/crates/okena-views-terminal/src/layout/terminal_pane/actions.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/actions.rs
@@ -67,6 +67,43 @@ impl<D: ActionDispatch + Send + Sync> TerminalPane<D> {
         }
     }
 
+    /// Open the annotate composer over the current selection. The keyboard path
+    /// to the same thing the context menu offers — and the only one that works
+    /// while an app holds the mouse grabbed.
+    pub(super) fn handle_annotate_selection(&mut self, cx: &mut Context<Self>) {
+        let Some(terminal_id) = self.terminal_id.clone() else {
+            return;
+        };
+        let has_selection = self
+            .terminal
+            .as_ref()
+            .and_then(|t| t.get_selected_text())
+            .is_some_and(|text| !text.trim().is_empty());
+        if !has_selection {
+            return;
+        }
+        let position = self
+            .content
+            .read(cx)
+            .selection_anchor()
+            .unwrap_or_else(|| gpui::point(gpui::px(120.0), gpui::px(120.0)));
+        let project_id = self.project_id.clone();
+        self.request_broker.update(cx, |broker, cx| {
+            broker.push_overlay_request(
+                okena_workspace::requests::OverlayRequest::Project(
+                    okena_workspace::requests::ProjectOverlay {
+                        project_id,
+                        kind: okena_workspace::requests::ProjectOverlayKind::AnnotateSelection {
+                            terminal_id,
+                            position,
+                        },
+                    },
+                ),
+                cx,
+            );
+        });
+    }
+
     pub(super) fn handle_paste(&mut self, cx: &mut Context<Self>) {
         let Some(terminal) = self.terminal.clone() else {
             return;

--- a/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
@@ -58,6 +58,10 @@ pub struct TerminalContent {
     in_scroll_inertia: bool,
     mouse_down_cell: Option<(usize, i32)>,
     forwarded_button: Option<(u8, u8)>,
+    /// A left press held back under `drag_selects_in_mouse_mode`: `(mods, col, row)`.
+    /// Moving off the cell turns it into our selection; releasing on it forwards
+    /// the click to the app.
+    pending_click_forward: Option<(u8, usize, i32)>,
     /// Runs while a drag-selection is active, scrolling the viewport when the
     /// pointer is held past the top/bottom edge so selection can extend beyond
     /// the visible area (issue #132).
@@ -100,6 +104,7 @@ impl TerminalContent {
             in_scroll_inertia: false,
             mouse_down_cell: None,
             forwarded_button: None,
+            pending_click_forward: None,
             autoscroll_task: None,
         }
     }
@@ -160,6 +165,7 @@ impl TerminalContent {
         button_code: u8,
         event_position: Point<Pixels>,
         modifiers: &Modifiers,
+        cx: &App,
     ) -> bool {
         let Some(terminal) = self.terminal.as_ref() else {
             return false;
@@ -172,10 +178,24 @@ impl TerminalContent {
         if modifiers.shift {
             return false;
         }
+        let settings = crate::terminal_view_settings(cx);
+        // Right-click belongs to our context menu. Agent TUIs hold the mouse
+        // grabbed for as long as they run, which would otherwise swallow the
+        // menu outright. Matches GNOME Terminal / iTerm2 / WezTerm.
+        if button_code == 2 && settings.right_click_opens_menu {
+            return false;
+        }
         let Some((col, row, _)) = self.pixel_to_cell(event_position) else {
             return false;
         };
         let mods = Self::mouse_modifier_bits(modifiers);
+        // Hold a left press back until it is clear whether this is a click or a
+        // drag: a drag becomes our selection, a click is forwarded on release.
+        // Returning false lets the normal selection path start meanwhile.
+        if button_code == 0 && settings.drag_selects_in_mouse_mode {
+            self.pending_click_forward = Some((mods, col, row));
+            return false;
+        }
         terminal.send_mouse_button(button_code, true, col, row as usize, mods);
         self.forwarded_button = Some((button_code, mods));
         self.mouse_down_cell = None;
@@ -337,6 +357,21 @@ impl TerminalContent {
         Some((col, row, side))
     }
 
+    /// Window position to anchor a popup over the current selection: the start
+    /// column of the selection, just below its last line. Rows above the
+    /// viewport (scrolled-back selections) clamp to the top.
+    pub fn selection_anchor(&self) -> Option<Point<Pixels>> {
+        let bounds = self.element_bounds?;
+        let terminal = self.terminal.as_ref()?;
+        let ((start_col, _), (_, end_row)) = terminal.selection_bounds()?;
+        let (cell_width, cell_height) = terminal.cell_dimensions();
+        let x = f32::from(bounds.origin.x) + Self::TERMINAL_PADDING + start_col as f32 * cell_width;
+        let y = f32::from(bounds.origin.y)
+            + Self::TERMINAL_PADDING
+            + (end_row.max(0) + 1) as f32 * cell_height;
+        Some(point(px(x), px(y)))
+    }
+
     fn pixel_to_cell_raw(
         &self,
         pos: Point<Pixels>,
@@ -430,7 +465,7 @@ impl TerminalContent {
             }
         }
 
-        if self.try_forward_mouse_press(0, event.position, &event.modifiers) {
+        if self.try_forward_mouse_press(0, event.position, &event.modifiers, cx) {
             cx.notify();
             return;
         }
@@ -549,6 +584,15 @@ impl TerminalContent {
             cx.notify();
         }
 
+        // Leaving the press cell settles the held-back left press as a drag:
+        // the app never sees it and the selection below takes over.
+        if let Some((_, press_col, press_row)) = self.pending_click_forward
+            && let Some((col, row, _side)) = self.pixel_to_cell(event.position)
+            && (col != press_col || row != press_row)
+        {
+            self.pending_click_forward = None;
+        }
+
         if let Some((button, mods)) = self.forwarded_button {
             if let Some(ref terminal) = self.terminal
                 && terminal.supports_mouse_drag()
@@ -587,6 +631,20 @@ impl TerminalContent {
     }
 
     fn handle_mouse_up(&mut self, event: &MouseUpEvent, cx: &mut Context<Self>) {
+        // Released without moving off the cell, so it was a click after all —
+        // hand the app the press and release it never got.
+        if let Some((mods, col, row)) = self.pending_click_forward.take() {
+            if let Some(terminal) = self.terminal.as_ref() {
+                terminal.send_mouse_button(0, true, col, row as usize, mods);
+                terminal.send_mouse_button(0, false, col, row as usize, mods);
+                terminal.clear_selection();
+            }
+            self.is_selecting = false;
+            self.mouse_down_cell = None;
+            cx.notify();
+            return;
+        }
+
         if self.try_forward_mouse_release(0, event.position, &event.modifiers) {
             cx.notify();
             return;
@@ -816,7 +874,7 @@ impl Render for TerminalContent {
             .on_mouse_down(
                 MouseButton::Right,
                 cx.listener(|this, event: &MouseDownEvent, _window, cx| {
-                    if this.try_forward_mouse_press(2, event.position, &event.modifiers) {
+                    if this.try_forward_mouse_press(2, event.position, &event.modifiers, cx) {
                         cx.notify();
                         return;
                     }
@@ -851,7 +909,7 @@ impl Render for TerminalContent {
             .on_mouse_down(
                 MouseButton::Middle,
                 cx.listener(|this, event: &MouseDownEvent, _window, cx| {
-                    if this.try_forward_mouse_press(1, event.position, &event.modifiers) {
+                    if this.try_forward_mouse_press(1, event.position, &event.modifiers, cx) {
                         cx.notify();
                     } else {
                         #[cfg(target_os = "linux")]

--- a/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
@@ -185,6 +185,12 @@ impl TerminalContent {
         if button_code == 2 && settings.right_click_opens_menu {
             return false;
         }
+        // The second and third click of a gesture select a word/line here rather
+        // than reaching the app, which already got the first click.
+        if button_code == 0 && self.click_count >= 2 && settings.double_click_selects_in_mouse_mode
+        {
+            return false;
+        }
         let Some((col, row, _)) = self.pixel_to_cell(event_position) else {
             return false;
         };
@@ -465,11 +471,10 @@ impl TerminalContent {
             }
         }
 
-        if self.try_forward_mouse_press(0, event.position, &event.modifiers, cx) {
-            cx.notify();
-            return;
-        }
-
+        // Count the click before the forward gate. A forwarded press used to
+        // return early, leaving `last_click` untouched — so in a mouse-grabbing
+        // app every click looked like the first and a double-click could never
+        // register.
         let now = Instant::now();
 
         let click_count = if let Some((last_time, last_col, last_row)) = self.last_click {
@@ -491,6 +496,11 @@ impl TerminalContent {
 
         self.last_click = Some((now, col, row));
         self.click_count = click_count;
+
+        if self.try_forward_mouse_press(0, event.position, &event.modifiers, cx) {
+            cx.notify();
+            return;
+        }
 
         let Some(terminal) = self.terminal.as_ref() else {
             return;

--- a/crates/okena-views-terminal/src/layout/terminal_pane/render.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/render.rs
@@ -2,11 +2,12 @@
 
 use crate::ActionDispatch;
 use crate::actions::{
-    AddTab, CloseSearch, CloseTerminal, Copy, FocusDown, FocusLeft, FocusNextTerminal,
-    FocusPrevTerminal, FocusRight, FocusUp, FullscreenNextTerminal, FullscreenPrevTerminal,
-    JumpToNextFailedCommand, JumpToNextPrompt, JumpToPreviousFailedCommand, JumpToPreviousPrompt,
-    MinimizeTerminal, Paste, ResetZoom, Search, SearchNext, SearchPrev, SendBacktab, SendEscape,
-    SendTab, SplitHorizontal, SplitVertical, ToggleFullscreen, ZoomIn, ZoomOut,
+    AddTab, AnnotateSelection, CloseSearch, CloseTerminal, Copy, FocusDown, FocusLeft,
+    FocusNextTerminal, FocusPrevTerminal, FocusRight, FocusUp, FullscreenNextTerminal,
+    FullscreenPrevTerminal, JumpToNextFailedCommand, JumpToNextPrompt, JumpToPreviousFailedCommand,
+    JumpToPreviousPrompt, MinimizeTerminal, Paste, ResetZoom, Search, SearchNext, SearchPrev,
+    SendBacktab, SendEscape, SendTab, SplitHorizontal, SplitVertical, ToggleFullscreen, ZoomIn,
+    ZoomOut,
 };
 use crate::layout::navigation::NavigationDirection;
 use crate::terminal_view_settings;
@@ -155,6 +156,9 @@ impl<D: ActionDispatch + Send + Sync> Render for TerminalPane<D> {
             }))
             .on_action(cx.listener(|this, _: &Copy, _window, cx| {
                 this.handle_copy(cx);
+            }))
+            .on_action(cx.listener(|this, _: &AnnotateSelection, _window, cx| {
+                this.handle_annotate_selection(cx);
             }))
             .on_action(cx.listener(|this, _: &Paste, _window, cx| {
                 this.handle_paste(cx);

--- a/crates/okena-views-terminal/src/lib.rs
+++ b/crates/okena-views-terminal/src/lib.rs
@@ -116,6 +116,10 @@ pub struct TerminalViewSettings {
     /// click is still forwarded to the app.
     #[serde(default)]
     pub drag_selects_in_mouse_mode: bool,
+    /// When true, the second and third click of a gesture select a word/line
+    /// here instead of reaching a mouse-reporting app.
+    #[serde(default)]
+    pub double_click_selects_in_mouse_mode: bool,
 }
 
 pub(crate) fn default_true() -> bool {
@@ -144,6 +148,7 @@ pub fn terminal_view_settings(cx: &gpui::App) -> TerminalViewSettings {
             ctrl_c_copies_selection: false,
             right_click_opens_menu: true,
             drag_selects_in_mouse_mode: false,
+            double_click_selects_in_mouse_mode: false,
         })
 }
 

--- a/crates/okena-views-terminal/src/lib.rs
+++ b/crates/okena-views-terminal/src/lib.rs
@@ -108,6 +108,18 @@ pub struct TerminalViewSettings {
     /// When true, Ctrl+C copies the active selection (and clears it) instead of sending SIGINT.
     /// Ctrl+C without a selection always sends SIGINT.
     pub ctrl_c_copies_selection: bool,
+    /// When true, right-click opens the context menu instead of being forwarded
+    /// to an app that requested mouse reporting.
+    #[serde(default = "crate::default_true")]
+    pub right_click_opens_menu: bool,
+    /// When true, a drag selects in Okena under mouse reporting while a plain
+    /// click is still forwarded to the app.
+    #[serde(default)]
+    pub drag_selects_in_mouse_mode: bool,
+}
+
+pub(crate) fn default_true() -> bool {
+    true
 }
 
 /// Read current terminal view settings from ExtensionSettingsStore.
@@ -130,6 +142,8 @@ pub fn terminal_view_settings(cx: &gpui::App) -> TerminalViewSettings {
             default_shell: okena_terminal::shell_config::ShellType::Default,
             hooks: Default::default(),
             ctrl_c_copies_selection: false,
+            right_click_opens_menu: true,
+            drag_selects_in_mouse_mode: false,
         })
 }
 

--- a/crates/okena-views-terminal/src/overlays/mod.rs
+++ b/crates/okena-views-terminal/src/overlays/mod.rs
@@ -4,9 +4,11 @@
 //! - Detached terminal windows
 //! - Terminal context menu (right-click)
 //! - Tab context menu (right-click on tab)
+//! - Send composer (annotate a selection, paste it back)
 //! - Shared terminal overlay utilities
 
 pub mod detached_terminal;
+pub mod send_composer;
 pub mod tab_context_menu;
 pub mod terminal_context_menu;
 pub mod terminal_overlay_utils;

--- a/crates/okena-views-terminal/src/overlays/send_composer.rs
+++ b/crates/okena-views-terminal/src/overlays/send_composer.rs
@@ -1,0 +1,223 @@
+//! Annotate a terminal selection and paste it back into that same terminal.
+//!
+//! The usual subject is an agent's own output: quote the part you mean, add a
+//! note, and it lands in the agent's prompt unsent so you can still edit it.
+
+use crate::actions::Cancel;
+use gpui::prelude::*;
+use gpui::*;
+use okena_ui::button::{button, button_primary};
+use okena_ui::simple_input::{SimpleInput, SimpleInputState};
+use okena_ui::theme::theme;
+use okena_ui::tokens::*;
+
+/// Lines of the quoted selection shown in the preview before it is elided.
+const PREVIEW_LINES: usize = 6;
+
+pub enum SendComposerEvent {
+    Close,
+    Send {
+        terminal_id: String,
+        quoted: String,
+        note: String,
+    },
+}
+
+pub struct SendComposer {
+    terminal_id: String,
+    /// Selection snapshot taken when the composer opened — the pane keeps
+    /// running underneath, and the selection can be cleared by a stray click.
+    quoted: String,
+    position: Point<Pixels>,
+    note_input: Entity<SimpleInputState>,
+    focus_handle: FocusHandle,
+}
+
+impl SendComposer {
+    pub fn new(
+        terminal_id: String,
+        quoted: String,
+        position: Point<Pixels>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let note_input = cx.new(|cx| {
+            SimpleInputState::new(cx)
+                .multiline()
+                .submit_on_enter()
+                .placeholder("Add a note…")
+        });
+        Self {
+            terminal_id,
+            quoted,
+            position,
+            note_input,
+            focus_handle: cx.focus_handle(),
+        }
+    }
+
+    pub fn close(&self, cx: &mut Context<Self>) {
+        cx.emit(SendComposerEvent::Close);
+    }
+
+    pub fn send(&mut self, cx: &mut Context<Self>) {
+        let note = self.note_input.read(cx).value().to_string();
+        cx.emit(SendComposerEvent::Send {
+            terminal_id: self.terminal_id.clone(),
+            quoted: self.quoted.clone(),
+            note,
+        });
+    }
+
+    /// Set the note text (used by tests and future prefill paths).
+    pub fn set_note(&mut self, note: impl Into<String>, cx: &mut Context<Self>) {
+        self.note_input
+            .update(cx, |input, cx| input.set_value(note.into(), cx));
+    }
+
+    /// First few lines of the quote, with a count of what is hidden.
+    fn preview(&self) -> (String, Option<String>) {
+        let lines: Vec<&str> = self.quoted.lines().collect();
+        if lines.len() <= PREVIEW_LINES {
+            return (self.quoted.clone(), None);
+        }
+        let shown = lines[..PREVIEW_LINES].join("\n");
+        let hidden = lines.len() - PREVIEW_LINES;
+        (shown, Some(format!("+{} more lines", hidden)))
+    }
+}
+
+impl EventEmitter<SendComposerEvent> for SendComposer {}
+
+impl Render for SendComposer {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let t = theme(cx);
+        let position = self.position;
+        let (preview, elided) = self.preview();
+
+        // The note is the point of the overlay — focus it, not the panel.
+        let note_focus = self.note_input.read(cx).focus_handle(cx);
+        if !note_focus.is_focused(window) {
+            window.focus(&note_focus, cx);
+        }
+
+        div()
+            .track_focus(&self.focus_handle)
+            .key_context("SendComposer")
+            .on_action(cx.listener(|this, _: &Cancel, _window, cx| {
+                this.close(cx);
+            }))
+            // Plain Enter submits; the input keeps Shift+Enter for line breaks
+            // (see SimpleInputState::submit_on_enter).
+            .on_key_down(cx.listener(|this, event: &KeyDownEvent, _window, cx| {
+                if event.keystroke.key == "enter" && !event.keystroke.modifiers.shift {
+                    this.send(cx);
+                }
+            }))
+            .absolute()
+            .inset_0()
+            .id("send-composer-backdrop")
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, _window, cx| {
+                    this.close(cx);
+                }),
+            )
+            // Right-click too: the backdrop covers the whole window, so without
+            // this a right-click would open a context menu behind it.
+            .on_mouse_down(
+                MouseButton::Right,
+                cx.listener(|this, _, _window, cx| {
+                    this.close(cx);
+                }),
+            )
+            .child(deferred(
+                anchored().position(position).snap_to_window().child(
+                    div()
+                        .id("send-composer")
+                        .w(px(420.0))
+                        .bg(rgb(t.bg_primary))
+                        .border_1()
+                        .border_color(rgb(t.border))
+                        .rounded(px(8.0))
+                        .shadow_xl()
+                        .p(SPACE_LG)
+                        .flex()
+                        .flex_col()
+                        .gap(SPACE_MD)
+                        .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                            cx.stop_propagation();
+                        })
+                        .on_scroll_wheel(|_, _, cx| {
+                            cx.stop_propagation();
+                        })
+                        // Quoted selection
+                        .child(
+                            div()
+                                .bg(rgb(t.bg_secondary))
+                                .border_l_2()
+                                .border_color(rgb(t.border_active))
+                                .rounded(RADIUS_STD)
+                                .px(SPACE_MD)
+                                .py(SPACE_SM)
+                                .text_size(TEXT_SM)
+                                .text_color(rgb(t.text_secondary))
+                                .font_family("monospace")
+                                .child(preview)
+                                .when_some(elided, |d, label| {
+                                    d.child(
+                                        div()
+                                            .pt(SPACE_XS)
+                                            .text_size(TEXT_XS)
+                                            .text_color(rgb(t.text_muted))
+                                            .child(label),
+                                    )
+                                }),
+                        )
+                        // Note
+                        .child(
+                            div()
+                                .bg(rgb(t.bg_secondary))
+                                .border_1()
+                                .border_color(rgb(t.border_focused))
+                                .rounded(RADIUS_STD)
+                                .child(SimpleInput::new(&self.note_input).text_size(TEXT_MD)),
+                        )
+                        .child(
+                            div()
+                                .flex()
+                                .items_center()
+                                .justify_between()
+                                .gap(SPACE_MD)
+                                .child(
+                                    div()
+                                        .text_size(TEXT_XS)
+                                        .text_color(rgb(t.text_muted))
+                                        .child("Shift+Enter for a new line"),
+                                )
+                                .child(
+                                    div()
+                                        .flex()
+                                        .gap(SPACE_MD)
+                                        .child(
+                                            button("send-composer-cancel", "Cancel", &t).on_click(
+                                                cx.listener(|this, _, _window, cx| this.close(cx)),
+                                            ),
+                                        )
+                                        .child(
+                                            button_primary("send-composer-send", "Send", &t)
+                                                .on_click(cx.listener(|this, _, _window, cx| {
+                                                    this.send(cx)
+                                                })),
+                                        ),
+                                ),
+                        ),
+                ),
+            ))
+    }
+}
+
+impl Focusable for SendComposer {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}

--- a/crates/okena-views-terminal/src/overlays/terminal_context_menu.rs
+++ b/crates/okena-views-terminal/src/overlays/terminal_context_menu.rs
@@ -15,6 +15,11 @@ pub enum TerminalContextMenuEvent {
     Copy {
         terminal_id: String,
     },
+    /// Annotate the selection and send it back into this terminal.
+    AnnotateSelection {
+        terminal_id: String,
+        position: Point<Pixels>,
+    },
     Paste {
         terminal_id: String,
     },
@@ -161,6 +166,24 @@ impl Render for TerminalContextMenu {
                                 el.on_click(cx.listener(|this, _, _window, cx| {
                                     cx.emit(TerminalContextMenuEvent::Copy {
                                         terminal_id: this.terminal_id.clone(),
+                                    });
+                                }))
+                            }),
+                        )
+                        // Send to Terminal (conditional - requires selection)
+                        .child(
+                            menu_item_conditional(
+                                "ctx-annotate",
+                                "icons/terminal.svg",
+                                "Send to Terminal…",
+                                has_selection,
+                                &t,
+                            )
+                            .when(has_selection, |el| {
+                                el.on_click(cx.listener(move |this, _, _window, cx| {
+                                    cx.emit(TerminalContextMenuEvent::AnnotateSelection {
+                                        terminal_id: this.terminal_id.clone(),
+                                        position: this.position,
                                     });
                                 }))
                             }),

--- a/crates/okena-workspace/src/request_broker.rs
+++ b/crates/okena-workspace/src/request_broker.rs
@@ -11,7 +11,7 @@ use std::collections::VecDeque;
 pub struct RequestBroker {
     overlay_requests: VecDeque<OverlayRequest>,
     sidebar_requests: VecDeque<SidebarRequest>,
-    send_to_terminal: VecDeque<SendPayload>,
+    send_to_terminal: VecDeque<(SendPayload, Option<String>)>,
 }
 
 impl Default for RequestBroker {
@@ -39,10 +39,27 @@ impl RequestBroker {
         cx.notify();
     }
 
-    /// Queue a "Send to Terminal" payload. The host drains this on observation,
-    /// resolves the focused terminal's CWD, and formats + pastes the result.
+    /// Queue a "Send to Terminal" payload for the focused terminal. The host
+    /// drains this on observation, resolves that terminal's CWD, and formats +
+    /// pastes the result.
     pub fn push_send_to_terminal(&mut self, payload: SendPayload, cx: &mut Context<Self>) {
-        self.send_to_terminal.push_back(payload);
+        self.send_to_terminal.push_back((payload, None));
+        cx.notify();
+    }
+
+    /// Queue a payload for one specific terminal, regardless of focus.
+    ///
+    /// Annotating a terminal's own output sends it back to that same terminal,
+    /// and by then the composer overlay holds focus — so the target can't be
+    /// inferred the way `push_send_to_terminal` does it.
+    pub fn push_send_to_terminal_targeted(
+        &mut self,
+        payload: SendPayload,
+        terminal_id: String,
+        cx: &mut Context<Self>,
+    ) {
+        self.send_to_terminal
+            .push_back((payload, Some(terminal_id)));
         cx.notify();
     }
 
@@ -54,7 +71,7 @@ impl RequestBroker {
         self.sidebar_requests.drain(..).collect()
     }
 
-    pub fn drain_send_to_terminal(&mut self) -> Vec<SendPayload> {
+    pub fn drain_send_to_terminal(&mut self) -> Vec<(SendPayload, Option<String>)> {
         self.send_to_terminal.drain(..).collect()
     }
 

--- a/crates/okena-workspace/src/requests.rs
+++ b/crates/okena-workspace/src/requests.rs
@@ -52,6 +52,12 @@ pub enum ProjectOverlayKind {
         has_selection: bool,
         link_url: Option<String>,
     },
+    /// Annotate the terminal's current selection and send it back to it.
+    /// `position` anchors the composer, normally just under the selection.
+    AnnotateSelection {
+        terminal_id: String,
+        position: gpui::Point<gpui::Pixels>,
+    },
     TabContextMenu {
         tab_index: usize,
         num_tabs: usize,

--- a/crates/okena-workspace/src/settings.rs
+++ b/crates/okena-workspace/src/settings.rs
@@ -393,6 +393,14 @@ pub struct AppSettings {
     #[serde(default)]
     pub terminal_drag_selects_in_mouse_mode: bool,
 
+    /// When true, double-click selects a word (and triple-click a line) even
+    /// while the app has requested mouse reporting. The app still receives the
+    /// first click of the gesture; the second and third are kept here, so no
+    /// click has to wait on a double-click timeout.
+    /// Default: false — the app sees one click where the user made two.
+    #[serde(default)]
+    pub terminal_double_click_selects_in_mouse_mode: bool,
+
     /// File finder filter preferences. The "Go to File" dialog reads these
     /// when opened and writes them back when the user toggles a filter, so
     /// the last-used state is also the default for future opens.
@@ -464,6 +472,7 @@ impl Default for AppSettings {
             terminal_ctrl_c_copies_selection: false,
             terminal_right_click_opens_menu: true,
             terminal_drag_selects_in_mouse_mode: false,
+            terminal_double_click_selects_in_mouse_mode: false,
             file_finder: FileFinderSettings::default(),
             header_density: HeaderDensity::default(),
             notifications: NotificationSettings::default(),

--- a/crates/okena-workspace/src/settings.rs
+++ b/crates/okena-workspace/src/settings.rs
@@ -378,6 +378,21 @@ pub struct AppSettings {
     #[serde(default)]
     pub terminal_ctrl_c_copies_selection: bool,
 
+    /// When true, right-click always opens Okena's terminal context menu, even
+    /// while the running app has requested mouse reporting. Agent TUIs (Claude
+    /// Code, Codex) keep the mouse grabbed, which otherwise swallows the menu.
+    /// Default: true (matches GNOME Terminal / iTerm2 / WezTerm).
+    #[serde(default = "default_true")]
+    pub terminal_right_click_opens_menu: bool,
+
+    /// When true, a left-button *drag* selects text in Okena even while the app
+    /// has requested mouse reporting; a plain click is still forwarded to the
+    /// app (delivered on release, once it is known not to be a drag).
+    /// Default: false — apps that use drag themselves (tmux pane resize, vim
+    /// visual mode) would otherwise lose it. Shift+drag selects either way.
+    #[serde(default)]
+    pub terminal_drag_selects_in_mouse_mode: bool,
+
     /// File finder filter preferences. The "Go to File" dialog reads these
     /// when opened and writes them back when the user toggles a filter, so
     /// the last-used state is also the default for future opens.
@@ -447,6 +462,8 @@ impl Default for AppSettings {
             worktree: WorktreeConfig::default(),
             remote_connections: Vec::new(),
             terminal_ctrl_c_copies_selection: false,
+            terminal_right_click_opens_menu: true,
+            terminal_drag_selects_in_mouse_mode: false,
             file_finder: FileFinderSettings::default(),
             header_density: HeaderDensity::default(),
             notifications: NotificationSettings::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -688,6 +688,10 @@ fn main() {
                             default_shell: s.settings.default_shell.clone(),
                             hooks: s.settings.hooks.clone(),
                             ctrl_c_copies_selection: s.settings.terminal_ctrl_c_copies_selection,
+                            right_click_opens_menu: s.settings.terminal_right_click_opens_menu,
+                            drag_selects_in_mouse_mode: s
+                                .settings
+                                .terminal_drag_selects_in_mouse_mode,
                         }).ok()
                     }
                     "git" => {
@@ -722,6 +726,8 @@ fn main() {
                                 state.settings.default_shell = tvs.default_shell;
                                 state.settings.hooks = tvs.hooks;
                                 state.settings.terminal_ctrl_c_copies_selection = tvs.ctrl_c_copies_selection;
+                                state.settings.terminal_right_click_opens_menu = tvs.right_click_opens_menu;
+                                state.settings.terminal_drag_selects_in_mouse_mode = tvs.drag_selects_in_mouse_mode;
                                 state.save_and_notify(cx);
                             });
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -692,6 +692,9 @@ fn main() {
                             drag_selects_in_mouse_mode: s
                                 .settings
                                 .terminal_drag_selects_in_mouse_mode,
+                            double_click_selects_in_mouse_mode: s
+                                .settings
+                                .terminal_double_click_selects_in_mouse_mode,
                         }).ok()
                     }
                     "git" => {
@@ -728,6 +731,7 @@ fn main() {
                                 state.settings.terminal_ctrl_c_copies_selection = tvs.ctrl_c_copies_selection;
                                 state.settings.terminal_right_click_opens_menu = tvs.right_click_opens_menu;
                                 state.settings.terminal_drag_selects_in_mouse_mode = tvs.drag_selects_in_mouse_mode;
+                                state.settings.terminal_double_click_selects_in_mouse_mode = tvs.double_click_selects_in_mouse_mode;
                                 state.save_and_notify(cx);
                             });
                         }

--- a/src/smoke_tests.rs
+++ b/src/smoke_tests.rs
@@ -56,6 +56,10 @@ mod tests {
                                 ctrl_c_copies_selection: s
                                     .settings
                                     .terminal_ctrl_c_copies_selection,
+                                right_click_opens_menu: s.settings.terminal_right_click_opens_menu,
+                                drag_selects_in_mouse_mode: s
+                                    .settings
+                                    .terminal_drag_selects_in_mouse_mode,
                             })
                             .ok()
                         }

--- a/src/smoke_tests.rs
+++ b/src/smoke_tests.rs
@@ -60,6 +60,9 @@ mod tests {
                                 drag_selects_in_mouse_mode: s
                                     .settings
                                     .terminal_drag_selects_in_mouse_mode,
+                                double_click_selects_in_mouse_mode: s
+                                    .settings
+                                    .terminal_double_click_selects_in_mouse_mode,
                             })
                             .ok()
                         }


### PR DESCRIPTION
## Problem

Asking an agent about something it just printed means quoting it back: copy the lines, paste them, type a question around them. "Send to Terminal" already existed in the file viewer, diff viewer and commit log, but it always pasted into the **focused** terminal — which, for a selection made *in* a terminal, is that same terminal. It would have echoed into itself, so terminals never offered it.

## What this adds

Select part of a terminal's output → right-click → **Send to Terminal…** → write a note → Enter. The quoted lines and the note land in that terminal's prompt, unsent, so the prompt stays editable.

````
```
FAILED src/app.rs:120 — assertion failed
```

why does this happen
````

The note renders *after* the quote: receivers follow an instruction better when it trails the material it refers to. Nothing is submitted — `SendPayload::format` strips trailing newlines, which is what stops a bracketed paste from acting as Enter in a TUI.

`SendPayload` becomes a struct of `chunks` + `note` (the old variants move to `SendChunk`), so a payload can carry a user note across its parts. The fence now also grows past the longest backtick run in the content — a fix for code blocks too, where a markdown selection containing its own ``` used to end the quote early and leak the rest as prose.

## The half that took the work: apps that grab the mouse

The first version worked in a plain shell and did nothing in a Claude Code pane — which is exactly where you want to annotate.

Agent TUIs turn on mouse reporting and keep it on. `try_forward_mouse_press` handed them every button, right-click included, so the context menu never opened there. Not a regression from this branch: `content.rs` is untouched by it, and **Copy was equally unreachable** in agent panes. Shift bypassed it, but needing Shift for every menu is not a fix.

Three settings, in Settings → Terminal:

| Setting | Default | Effect under mouse reporting |
|---|---|---|
| Right Click Opens Menu | **on** | Right-click opens our menu instead of reaching the app. GNOME Terminal, iTerm2 and WezTerm all reserve the right button; TUIs essentially never use it. |
| Drag Selects in Mouse Apps | off | The left press is held back until it is known to be a click or a drag: moving off the press cell makes it our selection, releasing on it forwards press+release. Off by default because drag is genuinely used — tmux pane resize, vim visual. |
| Double Click Selects in Mouse Apps | off | The app keeps the first click of the gesture; the second and third stay here and select a word or line. |

Double-click needed two things fixed: the press was forwarded *before* the click was counted, and the early return left `last_click` untouched — so in a mouse-grabbing app every click looked like the first and a double-click could never register. Counting first also means no click waits on a double-click timeout.

`Cmd/Ctrl+Shift+A` opens the composer over the current selection, anchored below its last line. An app can still take the drag even with the right-click fix, so the keyboard is the one entry nothing intercepts.

## Notes on the design

- **Target is the source pane, not the focused one.** The broker queue carries an optional terminal id; existing producers pass none and keep the focused-terminal behaviour. The composer holds focus by the time it sends, so the target cannot be inferred.
- **The composer holds the modal focus context while open.** A terminal pane re-grabs focus on every render unless `FocusManager` is in `Modal` (`terminal_pane/render.rs`), so against a streaming agent the note input would lose focus mid-sentence. `close_all_context_menus` takes a `cx` for the same reason — closing the composer has to hand that context back, which a raw slot close cannot do.
- **Enter submits, Shift+Enter breaks the line**, via an opt-in `submit_on_enter()` on `SimpleInputState`. The settings panel's hook editors are multiline too and still want plain Enter to insert a newline.

## Verification

Unit and GPUI tests cover payload formatting (note placement, fence escalation, the never-ends-with-newline invariant) and the overlay (modal focus balance across open/reopen/close, targeted broker payload, close-on-send).

The rest ran end to end under a nested headless GNOME, driving the real app with a virtual pointer and keyboard, asserting through `okena read` against the terminal's own contents — including against a stand-in that grabs the mouse exactly the way Claude Code does:

| Case | Result |
|---|---|
| Plain shell: menu → composer → Enter | quote + note in the prompt, not submitted |
| Escape in the composer | closes, nothing sent |
| **Mouse-grabbing app**: plain right-click → annotate → Enter | menu opens, payload pasted |
| **Mouse-grabbing app**: double-click a word | word selects; PTY log shows exactly **one** forwarded press/release pair for the two clicks |
| `Ctrl+Shift+A` over a selection | composer opens, payload sent |

Full workspace: 1743 tests pass, clippy clean.

## What this does not fix

With both opt-in settings off, selecting inside an agent pane still needs **Shift+drag** — the standard everywhere for apps that hold the mouse. Turning them on removes that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S63Q5kXgrw85F85QS1cntR
