### PR TITLE
Lay out the rendered Markdown as a reading column

### DIFF
--- a/crates/okena-files/src/file_viewer/render.rs
+++ b/crates/okena-files/src/file_viewer/render.rs
@@ -16,6 +16,7 @@ use gpui_component::{h_flex, v_flex};
 use okena_core::theme::ThemeColors;
 use okena_markdown::RenderedNode;
 use okena_ui::code_block::code_block_container;
+use okena_ui::color_utils::raised_surface_border;
 use okena_ui::file_icon::file_icon;
 use okena_ui::modal::{
     detached_needs_controls, fullscreen_overlay, fullscreen_panel, window_drag_spacer,
@@ -2118,13 +2119,14 @@ impl Render for FileViewer {
                                                     .overflow_x_scroll()
                                                     .child(
                                                         div()
-                                                            .p(px(12.0))
+                                                            .px(px(14.0))
+                                                            .py(px(10.0))
                                                             .font_family("monospace")
                                                             .text_size(ui_text(
                                                                 this.file_font_size,
                                                                 cx,
                                                             ))
-                                                            .text_color(rgb(t.text_secondary))
+                                                            .text_color(rgb(t.text_primary))
                                                             .flex()
                                                             .flex_col()
                                                             .children(line_children),
@@ -2230,22 +2232,40 @@ impl Render for FileViewer {
                                                 ))
                                                 .flex()
                                                 .flex_col()
-                                                .rounded(px(4.0))
+                                                .rounded(px(6.0))
                                                 .border_1()
-                                                .border_color(rgb(t.border))
+                                                .border_color(rgb(raised_surface_border(
+                                                    t.bg_secondary,
+                                                    t.border,
+                                                )))
                                                 .overflow_x_scroll()
                                                 .children(table_rows);
 
                                             table.into_any_element()
                                         }
                                         };
-                                        // Per-block wrapper carries the spacing
-                                        // and max width the old container provided.
+                                        // Per-block wrapper centers the reading
+                                        // column and carries the block's own
+                                        // vertical rhythm (headings take more
+                                        // space above than below).
+                                        let (space_above, space_below) = this
+                                            .active_tab()
+                                            .markdown_doc
+                                            .as_ref()
+                                            .map(|doc| doc.node_spacing(node_idx))
+                                            .unwrap_or((px(0.0), px(12.0)));
                                         div()
                                             .w_full()
-                                            .max_w(px(900.0))
-                                            .pb(px(12.0))
-                                            .child(element)
+                                            .flex()
+                                            .justify_center()
+                                            .pt(space_above)
+                                            .pb(space_below)
+                                            .child(
+                                                div()
+                                                    .w_full()
+                                                    .max_w(okena_markdown::DOC_MAX_WIDTH)
+                                                    .child(element),
+                                            )
                                             .into_any_element()
                                     })
                                 });
@@ -2256,7 +2276,12 @@ impl Render for FileViewer {
                                         .relative()
                                         .flex_1()
                                         .min_h_0()
-                                        .p(px(16.0))
+                                        // Side padding only matters once the pane
+                                        // is narrower than the column; the top gap
+                                        // keeps the document off the tab bar.
+                                        .px(px(28.0))
+                                        .pt(px(24.0))
+                                        .pb(px(16.0))
                                         .bg(rgb(t.bg_secondary))
                                         .cursor(CursorStyle::IBeam)
                                         .on_mouse_up(

--- a/crates/okena-markdown/src/lib.rs
+++ b/crates/okena-markdown/src/lib.rs
@@ -6,12 +6,15 @@
 
 mod parser;
 mod render;
+mod style;
 mod types;
 
 use gpui::*;
 
 use okena_core::selection::SelectionState;
 use types::Node;
+
+pub use style::DOC_MAX_WIDTH;
 
 /// Type alias for markdown selection (1D character offset).
 pub type MarkdownSelection = SelectionState<usize>;

--- a/crates/okena-markdown/src/parser.rs
+++ b/crates/okena-markdown/src/parser.rs
@@ -5,6 +5,21 @@ use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, T
 use super::MarkdownDocument;
 use super::types::{FmValue, Frontmatter, Inline, Node};
 
+/// Append `text` to the innermost inline run, merging it into the preceding text
+/// rather than starting a new one. The renderer lays each run out as its own
+/// inline flex item, so an unmerged run per source line would make a paragraph
+/// break wherever the author happened to wrap the file, not where the column
+/// ends.
+fn push_text(stack: &mut [Vec<Inline>], text: &str) {
+    let Some(current) = stack.last_mut() else {
+        return;
+    };
+    match current.last_mut() {
+        Some(Inline::Text(prev)) => prev.push_str(text),
+        _ => current.push(Inline::Text(text.to_string())),
+    }
+}
+
 impl MarkdownDocument {
     /// Parse markdown content into a document.
     pub fn parse(content: &str) -> Self {
@@ -28,6 +43,10 @@ impl MarkdownDocument {
         let parser = Parser::new_ext(markdown, options);
 
         let mut inline_stack: Vec<Vec<Inline>> = vec![Vec::new()];
+        // URLs of the links currently open, parallel to their `inline_stack`
+        // frames. Kept beside the tree rather than as a sentinel inside it, so
+        // the label text is free to merge with its neighbours.
+        let mut link_urls: Vec<String> = Vec::new();
 
         // State
         let mut in_heading: Option<u8> = None;
@@ -198,33 +217,11 @@ impl MarkdownDocument {
                 }
                 Event::Start(Tag::Link { dest_url, .. }) => {
                     inline_stack.push(Vec::new());
-                    // Store URL temporarily - we'll use it on End
-                    if let Some(last) = inline_stack.last_mut() {
-                        last.push(Inline::Text(format!("\x00LINK:{}\x00", dest_url)));
-                    }
+                    link_urls.push(dest_url.to_string());
                 }
                 Event::End(TagEnd::Link) => {
-                    let mut children = inline_stack.pop().unwrap_or_default();
-                    // Extract URL from marker
-                    let url = children
-                        .iter()
-                        .find_map(|c| {
-                            if let Inline::Text(t) = c
-                                && t.starts_with("\x00LINK:")
-                                && t.ends_with("\x00")
-                            {
-                                return Some(t[6..t.len() - 1].to_string());
-                            }
-                            None
-                        })
-                        .unwrap_or_default();
-                    children.retain(|c| {
-                        if let Inline::Text(t) = c {
-                            !t.starts_with("\x00LINK:")
-                        } else {
-                            true
-                        }
-                    });
+                    let children = inline_stack.pop().unwrap_or_default();
+                    let url = link_urls.pop().unwrap_or_default();
                     if let Some(last) = inline_stack.last_mut() {
                         last.push(Inline::Link {
                             _url: url,
@@ -242,15 +239,15 @@ impl MarkdownDocument {
                 Event::Text(text) => {
                     if in_code_block {
                         code_block_content.push_str(&text);
-                    } else if let Some(last) = inline_stack.last_mut() {
-                        last.push(Inline::Text(text.to_string()));
+                    } else {
+                        push_text(&mut inline_stack, &text);
                     }
                 }
                 Event::SoftBreak | Event::HardBreak => {
                     if in_code_block {
                         code_block_content.push('\n');
-                    } else if let Some(last) = inline_stack.last_mut() {
-                        last.push(Inline::Text(" ".to_string()));
+                    } else {
+                        push_text(&mut inline_stack, " ");
                     }
                 }
                 _ => {}
@@ -424,6 +421,19 @@ fn parse_frontmatter(inner: &str) -> Option<Node> {
 #[cfg(test)]
 mod tests {
     use super::super::MarkdownDocument;
+
+    /// Adjacent text is merged into one run so a paragraph wraps at the column
+    /// rather than at the author's line breaks. A link label is a run of its
+    /// own, and must survive that merging.
+    #[test]
+    fn link_label_and_soft_wrapped_text_survive_merging() {
+        let doc = MarkdownDocument::parse("A [label](https://example.com) here.");
+        assert_eq!(doc.plain_text, "A label here.\n");
+
+        // A soft break inside a paragraph becomes a space, not a line break.
+        let doc = MarkdownDocument::parse("first line\nsecond line");
+        assert_eq!(doc.plain_text, "first line second line\n");
+    }
 
     /// The precomputed `node_offsets` must match a running offset computed by
     /// walking `node_text_length` over the nodes (the previous behavior).

--- a/crates/okena-markdown/src/render.rs
+++ b/crates/okena-markdown/src/render.rs
@@ -5,15 +5,32 @@ use gpui::*;
 use gpui_component::{h_flex, v_flex};
 use okena_core::theme::ThemeColors;
 use okena_ui::code_block::code_block_container;
-use okena_ui::tokens::{ui_text, ui_text_md, ui_text_xl};
+use okena_ui::tokens::ui_text_md;
 
+use super::style::{
+    MdColors, body_line_height, body_size, heading_style, inline_code_size, node_spacing,
+    table_line_height,
+};
 use super::types::{FmValue, Frontmatter, Inline, Node, char_len, slice_by_chars};
 use super::{MarkdownDocument, RenderedNode};
+
+/// Height of one code line. Code blocks are laid out line by line (each line is
+/// its own selectable element), so this stands in for `line_height`.
+const CODE_LINE_HEIGHT: Pixels = px(20.0);
 
 impl MarkdownDocument {
     /// Number of top-level blocks in the document. Each maps to one list item.
     pub fn node_count(&self) -> usize {
         self.nodes.len()
+    }
+
+    /// Vertical space `(above, below)` the block at `idx`, for the caller to put
+    /// on its per-block wrapper. Out-of-range indices get the paragraph rhythm.
+    pub fn node_spacing(&self, idx: usize) -> (Pixels, Pixels) {
+        match self.nodes.get(idx) {
+            Some(node) => node_spacing(node, idx == 0),
+            None => (px(0.0), px(12.0)),
+        }
     }
 
     /// Render a single top-level node by index, ready for the caller to wrap
@@ -61,13 +78,13 @@ impl MarkdownDocument {
                     let line_div = if let Some((sel_start, sel_end)) = line_sel {
                         let (before, selected, after) = slice_by_chars(line, sel_start, sel_end);
                         div()
-                            .h(px(18.0))
+                            .h(CODE_LINE_HEIGHT)
                             .flex()
                             .child(div().child(before))
                             .child(div().bg(selection_bg).child(selected))
                             .child(div().child(after))
                     } else {
-                        div().h(px(18.0)).child(if line.is_empty() {
+                        div().h(CODE_LINE_HEIGHT).child(if line.is_empty() {
                             " ".to_string()
                         } else {
                             line.to_string()
@@ -90,6 +107,7 @@ impl MarkdownDocument {
             } => {
                 // Return tables with individual rows for per-row selection.
                 // Column widths are precomputed at parse time.
+                let c = MdColors::new(t);
                 let mut row_offset = offset;
                 let mut rendered_rows = Vec::new();
                 let mut rendered_header = None;
@@ -138,17 +156,18 @@ impl MarkdownDocument {
                             div().min_w(px(min_w)).px(px(12.0)).py(px(8.0)).child(
                                 Self::render_inlines_with_selection(header, t, cx, cell_sel)
                                     .text_size(ui_text_md(cx))
+                                    .line_height(table_line_height(cx))
                                     .font_weight(FontWeight::SEMIBOLD)
-                                    .text_color(rgb(t.text_primary)),
+                                    .text_color(rgb(c.heading)),
                             ),
                         );
                         cell_offset += cell_len;
                     }
 
                     let header_div = header_row
-                        .bg(rgb(t.bg_header))
+                        .bg(rgb(c.surface))
                         .border_b_1()
-                        .border_color(rgb(t.border));
+                        .border_color(rgb(c.surface_border));
                     rendered_header = Some((header_div, row_offset, header_end));
                     row_offset = header_end;
                 }
@@ -175,10 +194,10 @@ impl MarkdownDocument {
 
                     let mut row_div = h_flex();
                     if row_idx % 2 == 1 {
-                        row_div = row_div.bg(rgb(t.bg_secondary));
+                        row_div = row_div.bg(rgb(c.surface));
                     }
                     if row_idx < rows.len() - 1 {
-                        row_div = row_div.border_b_1().border_color(rgb(t.border));
+                        row_div = row_div.border_b_1().border_color(rgb(c.surface_border));
                     }
 
                     let mut cell_offset = 0usize;
@@ -203,7 +222,8 @@ impl MarkdownDocument {
                             div().min_w(px(min_w)).px(px(12.0)).py(px(6.0)).child(
                                 Self::render_inlines_with_selection(cell, t, cx, cell_sel)
                                     .text_size(ui_text_md(cx))
-                                    .text_color(rgb(t.text_secondary)),
+                                    .line_height(table_line_height(cx))
+                                    .text_color(rgb(c.body)),
                             ),
                         );
                         cell_offset += cell_len;
@@ -292,16 +312,10 @@ impl MarkdownDocument {
         cx: &App,
         selection: Option<(usize, usize)>,
     ) -> Div {
+        let c = MdColors::new(t);
         match node {
             Node::Heading { level, children } => {
-                let (size, weight) = match level {
-                    1 => (px(28.0), FontWeight::BOLD),
-                    2 => (px(24.0), FontWeight::BOLD),
-                    3 => (px(20.0), FontWeight::SEMIBOLD),
-                    4 => (px(18.0), FontWeight::SEMIBOLD),
-                    5 => (px(16.0), FontWeight::MEDIUM),
-                    _ => (px(14.0), FontWeight::MEDIUM),
-                };
+                let (size, line_height) = heading_style(*level, cx);
 
                 // For headings, render inline content with selection support
                 // but apply heading styles to the container
@@ -314,17 +328,18 @@ impl MarkdownDocument {
                 };
 
                 div()
+                    .w_full()
                     .text_size(size)
-                    .font_weight(weight)
-                    .text_color(rgb(t.text_primary))
-                    .pb(px(4.0))
-                    .when(*level <= 2, |d| {
-                        d.border_b_1().border_color(rgb(t.border)).mb(px(4.0))
-                    })
+                    .line_height(line_height)
+                    .font_weight(FontWeight::BOLD)
+                    .text_color(rgb(c.heading))
                     .child(content)
             }
+            // `w_full` gives the inline flow a definite width to wrap against.
+            // Without it the run is sized from its own content and spills past
+            // the reading column instead of breaking at its edge.
             Node::Paragraph { children } => {
-                Self::render_inlines_with_selection(children, t, cx, selection)
+                Self::render_inlines_with_selection(children, t, cx, selection).w_full()
             }
             Node::CodeBlock { language, code } => {
                 let selection_bg = rgba(0x3390ff40);
@@ -348,13 +363,13 @@ impl MarkdownDocument {
                     let line_div = if let Some((sel_start, sel_end)) = line_sel {
                         let (before, selected, after) = slice_by_chars(line, sel_start, sel_end);
                         div()
-                            .h(px(18.0))
+                            .h(CODE_LINE_HEIGHT)
                             .flex()
                             .child(div().child(before))
                             .child(div().bg(selection_bg).child(selected))
                             .child(div().child(after))
                     } else {
-                        div().h(px(18.0)).child(if line.is_empty() {
+                        div().h(CODE_LINE_HEIGHT).child(if line.is_empty() {
                             " ".to_string()
                         } else {
                             line.to_string()
@@ -367,17 +382,22 @@ impl MarkdownDocument {
 
                 code_block_container(language.as_deref(), t, cx).child(
                     div()
-                        .p(px(12.0))
+                        .px(px(14.0))
+                        .py(px(10.0))
                         .font_family("monospace")
                         .text_size(ui_text_md(cx))
-                        .text_color(rgb(t.text_secondary))
+                        .text_color(rgb(c.body))
                         .flex()
                         .flex_col()
                         .children(code_lines),
                 )
             }
             Node::List { ordered, items } => {
-                let mut list = v_flex().gap(px(4.0)).pl(px(16.0));
+                // One marker column for both list kinds, right-aligned in it, so
+                // the text hangs at the same indent whatever the marker is —
+                // including two-digit numbers.
+                let marker_width = px(22.0);
+                let mut list = v_flex().w_full().gap(px(6.0)).pl(px(4.0));
                 let mut offset = 0usize;
 
                 for (i, item_inlines) in items.iter().enumerate() {
@@ -401,13 +421,18 @@ impl MarkdownDocument {
                     list = list.child(
                         div()
                             .flex()
-                            .gap(px(8.0))
+                            .items_start()
+                            .gap(px(10.0))
                             .child(
                                 div()
-                                    .text_size(ui_text_xl(cx))
-                                    .text_color(rgb(t.text_muted))
-                                    .w(px(16.0))
+                                    .text_size(body_size(cx))
+                                    // Match the body leading so the marker sits
+                                    // on the item's first line, not above it.
+                                    .line_height(body_line_height(cx))
+                                    .text_color(rgb(c.muted))
+                                    .w(marker_width)
                                     .flex_shrink_0()
+                                    .text_right()
                                     .child(marker),
                             )
                             .child(
@@ -425,15 +450,18 @@ impl MarkdownDocument {
                 col_widths,
             } => Self::render_table_with_selection(headers, rows, col_widths, t, cx, selection),
             Node::Blockquote { children } => div()
-                .pl(px(12.0))
+                .pl(px(14.0))
                 .border_l_2()
-                .border_color(rgb(t.text_muted))
+                .border_color(rgb(c.surface_border))
                 .child(
                     Self::render_inlines_with_selection(children, t, cx, selection)
-                        .text_color(rgb(t.text_muted))
+                        .w_full()
+                        .text_color(rgb(c.muted))
                         .italic(),
                 ),
-            Node::HorizontalRule => div().w_full().h(px(1.0)).bg(rgb(t.border)).my(px(8.0)),
+            // Whitespace is what separates sections here, so an explicit rule
+            // stays as a hairline that barely registers.
+            Node::HorizontalRule => div().w_full().h(px(1.0)).bg(rgb(c.rule)),
             // Frontmatter renders as a self-contained metadata card. Partial
             // (inline) selection highlighting is intentionally omitted; block
             // selection and copy still work through the flat-text offsets.
@@ -443,28 +471,28 @@ impl MarkdownDocument {
 
     /// Render a frontmatter block as a bordered metadata card.
     fn render_frontmatter(fm: &Frontmatter, t: &ThemeColors, cx: &App) -> Div {
+        let c = MdColors::new(t);
         let card = v_flex()
             .gap(px(4.0))
             .w_full()
-            .p(px(12.0))
-            .mb(px(8.0))
+            .px(px(14.0))
+            .py(px(12.0))
             .rounded(px(6.0))
-            .bg(rgb(t.bg_secondary))
+            .bg(rgb(c.surface))
             .border_1()
-            .border_color(rgb(t.border))
-            .text_size(ui_text_md(cx));
+            .border_color(rgb(c.surface_border))
+            .text_size(ui_text_md(cx))
+            .line_height(table_line_height(cx));
 
         match fm {
             Frontmatter::Raw(raw) => {
                 card.font_family("monospace")
                     .children(raw.lines().map(|line| {
-                        div()
-                            .text_color(rgb(t.text_secondary))
-                            .child(if line.is_empty() {
-                                " ".to_string()
-                            } else {
-                                line.to_string()
-                            })
+                        div().text_color(rgb(c.body)).child(if line.is_empty() {
+                            " ".to_string()
+                        } else {
+                            line.to_string()
+                        })
                     }))
             }
             Frontmatter::Parsed(entries) => card.children(
@@ -478,10 +506,11 @@ impl MarkdownDocument {
     /// Render a single `key: value` frontmatter entry. Scalars sit inline next
     /// to the key; lists and nested maps stack below it, indented.
     fn render_fm_entry(key: &str, value: &FmValue, t: &ThemeColors, cx: &App) -> Div {
+        let c = MdColors::new(t);
         let key_label = || {
             div()
                 .font_weight(FontWeight::MEDIUM)
-                .text_color(rgb(t.text_muted))
+                .text_color(rgb(c.muted))
                 .child(key.to_string())
         };
 
@@ -490,22 +519,12 @@ impl MarkdownDocument {
                 .gap(px(8.0))
                 .items_baseline()
                 .child(key_label().min_w(px(120.0)).flex_shrink_0())
-                .child(
-                    div()
-                        .flex_1()
-                        .text_color(rgb(t.text_primary))
-                        .child(s.clone()),
-                ),
+                .child(div().flex_1().text_color(rgb(c.body)).child(s.clone())),
             FmValue::Empty => h_flex()
                 .gap(px(8.0))
                 .items_baseline()
                 .child(key_label().min_w(px(120.0)).flex_shrink_0())
-                .child(
-                    div()
-                        .italic()
-                        .text_color(rgb(t.text_muted))
-                        .child("\u{2014}"),
-                ),
+                .child(div().italic().text_color(rgb(c.muted)).child("\u{2014}")),
             FmValue::List(items) => v_flex()
                 .gap(px(2.0))
                 .child(key_label())
@@ -521,23 +540,24 @@ impl MarkdownDocument {
 
     /// Render a frontmatter sequence as a bulleted, indented list.
     fn render_fm_list(items: &[FmValue], t: &ThemeColors, cx: &App) -> Div {
+        let c = MdColors::new(t);
         let mut list = v_flex().gap(px(2.0)).pl(px(16.0));
         for item in items {
             list = list.child(match item {
                 FmValue::Scalar(s) => h_flex()
                     .gap(px(8.0))
                     .items_baseline()
-                    .child(div().text_color(rgb(t.text_muted)).child("\u{2022}"))
-                    .child(div().text_color(rgb(t.text_primary)).child(s.clone())),
+                    .child(div().text_color(rgb(c.muted)).child("\u{2022}"))
+                    .child(div().text_color(rgb(c.body)).child(s.clone())),
                 FmValue::Empty => h_flex()
                     .gap(px(8.0))
-                    .child(div().text_color(rgb(t.text_muted)).child("\u{2022}")),
+                    .child(div().text_color(rgb(c.muted)).child("\u{2022}")),
                 FmValue::List(inner) => v_flex()
-                    .child(div().text_color(rgb(t.text_muted)).child("\u{2022}"))
+                    .child(div().text_color(rgb(c.muted)).child("\u{2022}"))
                     .child(Self::render_fm_list(inner, t, cx)),
                 FmValue::Map(sub) => v_flex()
                     .gap(px(4.0))
-                    .child(div().text_color(rgb(t.text_muted)).child("\u{2022}"))
+                    .child(div().text_color(rgb(c.muted)).child("\u{2022}"))
                     .child(
                         v_flex()
                             .gap(px(4.0))
@@ -593,9 +613,9 @@ impl MarkdownDocument {
             // narrow width — inflating the block with a huge vertical gap.
             .min_w_0()
             .items_baseline()
-            .text_size(ui_text_xl(cx))
-            .line_height(px(22.0))
-            .text_color(rgb(t.text_secondary))
+            .text_size(body_size(cx))
+            .line_height(body_line_height(cx))
+            .text_color(rgb(MdColors::new(t).body))
             .children(elements)
     }
 
@@ -607,6 +627,7 @@ impl MarkdownDocument {
         selection: Option<(usize, usize)>,
     ) -> Div {
         let selection_bg = rgba(0x3390ff40);
+        let c = MdColors::new(t);
 
         match inline {
             Inline::Text(text) => {
@@ -614,36 +635,37 @@ impl MarkdownDocument {
                     let (before, selected, after) = slice_by_chars(text, start, end);
                     div()
                         .flex()
-                        .child(div().child(before))
-                        .child(div().bg(selection_bg).child(selected))
-                        .child(div().child(after))
+                        .min_w_0()
+                        .child(div().min_w_0().child(before))
+                        .child(div().min_w_0().bg(selection_bg).child(selected))
+                        .child(div().min_w_0().child(after))
                 } else {
-                    div().child(text.clone())
+                    // `min-width: 0` lets a long run shrink to the column width
+                    // and wrap inside it. On `min-width: auto` the run keeps its
+                    // unwrapped width and paints past the edge of the column.
+                    div().min_w_0().child(text.clone())
                 }
             }
             Inline::Code(code) => {
+                // Emphasis, not a badge: the monospace face and a barely-there
+                // tint carry it, so a paragraph full of code reads as prose.
+                let chip = |d: Div| {
+                    d.font_family("monospace")
+                        .text_size(inline_code_size(cx))
+                        .px(px(3.0))
+                        .rounded(px(3.0))
+                        .bg(rgb(c.inline_code_bg))
+                        .text_color(rgb(c.body))
+                };
                 if let Some((start, end)) = selection {
                     let (before, selected, after) = slice_by_chars(code, start, end);
-                    div()
-                        .font_family("monospace")
-                        .text_size(ui_text(13.0, cx))
-                        .px(px(4.0))
-                        .rounded(px(3.0))
-                        .bg(rgb(t.bg_primary))
-                        .text_color(rgb(t.text_primary))
+                    chip(div())
                         .flex()
                         .child(div().child(before))
                         .child(div().bg(selection_bg).child(selected))
                         .child(div().child(after))
                 } else {
-                    div()
-                        .font_family("monospace")
-                        .text_size(ui_text(13.0, cx))
-                        .px(px(4.0))
-                        .rounded(px(3.0))
-                        .bg(rgb(t.bg_primary))
-                        .text_color(rgb(t.text_primary))
-                        .child(code.clone())
+                    chip(div()).child(code.clone())
                 }
             }
             Inline::Bold(children) => {
@@ -693,11 +715,7 @@ impl MarkdownDocument {
                 container
             }
             Inline::Link { children, .. } => {
-                let mut container = div()
-                    .text_color(rgb(t.term_blue))
-                    .underline()
-                    .flex()
-                    .flex_wrap();
+                let mut container = div().text_color(rgb(c.link)).underline().flex().flex_wrap();
                 let mut offset = 0usize;
                 for child in children {
                     let child_len = match child {
@@ -732,10 +750,11 @@ impl MarkdownDocument {
         selection: Option<(usize, usize)>,
     ) -> Div {
         // Column widths are precomputed at parse time.
+        let c = MdColors::new(t);
         let mut table = v_flex()
-            .rounded(px(4.0))
+            .rounded(px(6.0))
             .border_1()
-            .border_color(rgb(t.border))
+            .border_color(rgb(c.surface_border))
             .overflow_hidden();
 
         let mut offset = 0usize;
@@ -744,9 +763,9 @@ impl MarkdownDocument {
         if !headers.is_empty() {
             let mut header_row = div()
                 .flex()
-                .bg(rgb(t.bg_header))
+                .bg(rgb(c.surface))
                 .border_b_1()
-                .border_color(rgb(t.border));
+                .border_color(rgb(c.surface_border));
 
             for (i, header) in headers.iter().enumerate() {
                 let cell_len = Self::inlines_text_length(header) + if i > 0 { 1 } else { 0 }; // +1 for tab
@@ -769,8 +788,9 @@ impl MarkdownDocument {
                     div().min_w(px(min_w)).px(px(12.0)).py(px(8.0)).child(
                         Self::render_inlines_with_selection(header, t, cx, cell_sel)
                             .text_size(ui_text_md(cx))
+                            .line_height(table_line_height(cx))
                             .font_weight(FontWeight::SEMIBOLD)
-                            .text_color(rgb(t.text_primary)),
+                            .text_color(rgb(c.heading)),
                     ),
                 );
                 offset += cell_len;
@@ -783,10 +803,10 @@ impl MarkdownDocument {
         for (row_idx, row) in rows.iter().enumerate() {
             let mut row_div = div()
                 .flex()
-                .when(row_idx % 2 == 1, |d| d.bg(rgb(t.bg_secondary)));
+                .when(row_idx % 2 == 1, |d| d.bg(rgb(c.surface)));
 
             if row_idx < rows.len() - 1 {
-                row_div = row_div.border_b_1().border_color(rgb(t.border));
+                row_div = row_div.border_b_1().border_color(rgb(c.surface_border));
             }
 
             for (i, cell) in row.iter().enumerate() {
@@ -810,7 +830,8 @@ impl MarkdownDocument {
                     div().min_w(px(min_w)).px(px(12.0)).py(px(6.0)).child(
                         Self::render_inlines_with_selection(cell, t, cx, cell_sel)
                             .text_size(ui_text_md(cx))
-                            .text_color(rgb(t.text_secondary)),
+                            .line_height(table_line_height(cx))
+                            .text_color(rgb(c.body)),
                     ),
                 );
                 offset += cell_len;

--- a/crates/okena-markdown/src/style.rs
+++ b/crates/okena-markdown/src/style.rs
@@ -1,0 +1,121 @@
+//! Document style for the markdown renderer: colors, type scale, rhythm.
+//!
+//! Everything here is derived from the active `ThemeColors` so custom themes
+//! keep working — there is no separate markdown palette.
+
+use gpui::{App, Pixels, px};
+use okena_core::theme::ThemeColors;
+use okena_ui::color_utils::{raised_surface, raised_surface_border, tint_color};
+use okena_ui::tokens::ui_text;
+
+use super::types::Node;
+
+/// Max width of the document column. The caller centers the column in whatever
+/// width is left, so wide panes get margins instead of very long lines.
+pub const DOC_MAX_WIDTH: Pixels = px(860.0);
+
+/// Body size and leading, before the `ui_font_size` scale is applied.
+const BODY_PT: f32 = 14.0;
+const BODY_LEADING: f32 = 1.65;
+/// Monospace reads a little larger than proportional text at the same nominal
+/// size, so inline code sits just below the body size.
+const INLINE_CODE_PT: f32 = 12.5;
+/// Heading leading — tight enough that a wrapped heading still reads as one unit.
+const HEADING_LEADING: f32 = 1.3;
+
+pub(crate) fn body_size(cx: &App) -> Pixels {
+    ui_text(BODY_PT, cx)
+}
+
+pub(crate) fn body_line_height(cx: &App) -> Pixels {
+    ui_text(BODY_PT * BODY_LEADING, cx)
+}
+
+pub(crate) fn inline_code_size(cx: &App) -> Pixels {
+    ui_text(INLINE_CODE_PT, cx)
+}
+
+/// Table cells run at UI size, with their own leading — body leading would make
+/// a dense table too airy.
+pub(crate) fn table_line_height(cx: &App) -> Pixels {
+    ui_text(18.0, cx)
+}
+
+/// Size and line height for a heading level. H1 dominates, H2 opens a section,
+/// H3 stays close to body size so it reads as a label, not a banner — size and
+/// the space around a heading carry the hierarchy, weight only separates
+/// headings from body text.
+///
+/// Every level is bold: intermediate weights depend on the font shipping that
+/// face, and a heading that silently falls back to regular stops reading as one.
+pub(crate) fn heading_style(level: u8, cx: &App) -> (Pixels, Pixels) {
+    let pt = match level {
+        1 => 28.0,
+        2 => 21.0,
+        3 => 17.0,
+        4 => 15.0,
+        5 => 14.0,
+        _ => 13.0,
+    };
+    (ui_text(pt, cx), ui_text(pt * HEADING_LEADING, cx))
+}
+
+/// Markdown colors derived from the app theme.
+#[derive(Clone, Copy)]
+pub(crate) struct MdColors {
+    /// Headings — one step brighter than body copy.
+    pub heading: u32,
+    /// Body copy. Full text contrast, not the dimmer secondary tone.
+    pub body: u32,
+    /// Secondary content: list markers, quotes, metadata keys, captions.
+    pub muted: u32,
+    /// Raised surface for code blocks and metadata cards.
+    pub surface: u32,
+    /// Border of that surface — only just visible against it.
+    pub surface_border: u32,
+    /// Inline code: a hint of a surface, not a badge.
+    pub inline_code_bg: u32,
+    /// Horizontal rules and other structural lines.
+    pub rule: u32,
+    /// Link text.
+    pub link: u32,
+}
+
+impl MdColors {
+    pub(crate) fn new(t: &ThemeColors) -> Self {
+        // Push toward the theme's foreground extreme, so headings land brighter
+        // than body text on dark themes and darker on light ones.
+        let extreme = if t.is_dark() { 0xffffff } else { 0x000000 };
+        Self {
+            heading: tint_color(t.text_primary, extreme, 0.35),
+            body: t.text_primary,
+            muted: t.text_secondary,
+            surface: raised_surface(t.bg_secondary, t.text_primary),
+            surface_border: raised_surface_border(t.bg_secondary, t.border),
+            inline_code_bg: tint_color(t.bg_secondary, t.text_primary, 0.08),
+            rule: tint_color(t.bg_secondary, t.border, 0.8),
+            // The plain blue is a terminal color picked to sit on the terminal
+            // background; the bright variant holds up against document text.
+            link: t.term_bright_blue,
+        }
+    }
+}
+
+/// Vertical space `(above, below)` a block. Headings carry most of their space
+/// above so a section reads as attached to the heading that opens it — that
+/// gap, not a rule, is what separates sections.
+pub(crate) fn node_spacing(node: &Node, is_first: bool) -> (Pixels, Pixels) {
+    let (above, below) = match node {
+        Node::Heading { level, .. } => match level {
+            1 => (30.0, 10.0),
+            2 => (24.0, 8.0),
+            3 => (18.0, 6.0),
+            _ => (14.0, 4.0),
+        },
+        Node::Paragraph { .. } | Node::List { .. } => (0.0, 12.0),
+        Node::CodeBlock { .. } | Node::Table { .. } | Node::Blockquote { .. } => (2.0, 14.0),
+        Node::HorizontalRule => (10.0, 10.0),
+        Node::Frontmatter { .. } => (0.0, 16.0),
+    };
+    (px(if is_first { 0.0 } else { above }), px(below))
+}

--- a/crates/okena-markdown/tests/inline_layout.rs
+++ b/crates/okena-markdown/tests/inline_layout.rs
@@ -54,10 +54,11 @@ fn measure_block_height(cx: &mut TestAppContext, md: &str, width: f32) -> f32 {
 #[gpui::test]
 fn list_item_with_long_trailing_text_is_not_inflated(cx: &mut TestAppContext) {
     // A bullet (flex child) — the shape that triggered the bug. Pre-fix this
-    // measured 220px (10 lines); the same text as a paragraph is ~66px.
+    // measured 220px (10 lines); wrapped correctly it is ~138px (6 lines at the
+    // body leading), so 160px sits clear of both.
     let height = measure_block_height(cx, &format!("- {BODY}"), 600.0);
     assert!(
-        height < 132.0,
+        height < 160.0,
         "list block height {height}px is inflated (expected a handful of text lines)"
     );
 }
@@ -68,7 +69,7 @@ fn paragraph_with_long_trailing_text_is_not_inflated(cx: &mut TestAppContext) {
     // baseline so the list assertion stays meaningful.
     let height = measure_block_height(cx, BODY, 600.0);
     assert!(
-        height < 132.0,
+        height < 160.0,
         "paragraph block height {height}px is inflated (expected a handful of text lines)"
     );
 }

--- a/crates/okena-ui/src/code_block.rs
+++ b/crates/okena-ui/src/code_block.rs
@@ -1,5 +1,6 @@
 //! Code block container component.
 
+use crate::color_utils::{raised_surface, raised_surface_border};
 use crate::theme::ThemeColors;
 use crate::tokens::*;
 use gpui::prelude::FluentBuilder;
@@ -8,23 +9,27 @@ use gpui_component::v_flex;
 
 /// Code block container with rounded corners, bg, border, overflow_hidden, and optional language label.
 ///
+/// The surface is one small step off the page rather than the darkest theme
+/// background, so a document full of code reads as text with code in it instead
+/// of a stack of black rectangles.
+///
 /// Caller adds `.child(...)` for the code content area.
 pub fn code_block_container(language: Option<&str>, t: &ThemeColors, cx: &App) -> Div {
     let lang_label = language.unwrap_or("");
+    let surface = raised_surface(t.bg_secondary, t.text_primary);
+    let border = raised_surface_border(t.bg_secondary, t.border);
     v_flex()
         .rounded(px(6.0))
-        .bg(rgb(t.bg_primary))
+        .bg(rgb(surface))
         .border_1()
-        .border_color(rgb(t.border))
+        .border_color(rgb(border))
         .overflow_hidden()
         .when(!lang_label.is_empty(), |d| {
+            // A quiet caption, not a title bar — no fill, no divider.
             d.child(
                 div()
-                    .px(SPACE_LG)
-                    .py(SPACE_XS)
-                    .bg(rgb(t.bg_header))
-                    .border_b_1()
-                    .border_color(rgb(t.border))
+                    .px(px(14.0))
+                    .pt(SPACE_MD)
                     .text_size(ui_text_sm(cx))
                     .text_color(rgb(t.text_muted))
                     .child(lang_label.to_string()),

--- a/crates/okena-ui/src/color_utils.rs
+++ b/crates/okena-ui/src/color_utils.rs
@@ -8,3 +8,16 @@ pub fn tint_color(base: u32, tint: u32, amount: f32) -> u32 {
     let b = lerp(base & 0xFF, tint & 0xFF);
     (r << 16) | (g << 8) | b
 }
+
+/// A surface one small step off the page background `bg`, nudged toward the
+/// foreground `fg`. Reads as a distinct panel without becoming a heavy block —
+/// and stays on the right side of the page in both dark and light themes.
+pub fn raised_surface(bg: u32, fg: u32) -> u32 {
+    tint_color(bg, fg, 0.05)
+}
+
+/// The hairline that goes with [`raised_surface`]: the theme border pulled back
+/// toward the page so it outlines the surface without framing it.
+pub fn raised_surface_border(bg: u32, border: u32) -> u32 {
+    tint_color(bg, border, 0.7)
+}


### PR DESCRIPTION
The Markdown preview rendered raw blocks stretched across the whole editor pane. Body copy ran at the dim secondary tone, every H1/H2 dragged a full-width rule behind it, code blocks sat on the darkest theme background as black rectangles, and inline code read as a row of dark badges.

## What changed

**Reading column.** The document is capped at 860px and centered in whatever width the pane leaves, with `px 28 / pt 24` around it so it neither hugs the left edge nor starts against the tab bar.

**Vertical rhythm.** `MarkdownDocument::node_spacing(idx)` gives every block its own space, and headings take most of theirs above (H1 30/10, H2 24/8, H3 18/6). The gap that opens a section — not a rule — is what separates it, so the rules under H1/H2 are gone and an explicit `---` is now a hairline.

**Contrast and hierarchy.** Body copy moves from `text_secondary` to `text_primary`, headings to a tone 35% brighter still, secondary content stays at `text_secondary`. Sizes go 28/21/17/15/14/13 (from 28/24/20/18/16/14), body leading 1.65.

**Surfaces.** Code blocks, table headers and the frontmatter card sit one small step *off* the page (+5% toward the foreground) instead of below it, with a hairline border pulled 70% back toward the page. Inline code is the same idea at +8%, so it reads as emphasis rather than a badge. The language label lost its title bar.

**Lists.** One 22px marker column for both bullets and numbers, right-aligned, so text hangs at the same indent whatever the marker — two-digit numbers included.

Everything derives from the active `ThemeColors`; there is no separate Markdown palette. `raised_surface` / `raised_surface_border` name that derivation once so the shared code-block component and the document agree on it.

## Two defects found while verifying

Both were visible in the before/after renders, not in any test:

* **Paragraphs broke at the author's line wraps.** Each text run is its own inline flex item and pulldown-cmark emits one per source line, so a paragraph broke wherever the file happened to wrap. Adjacent text is now merged into one run, and a long run can shrink to the column and wrap inside it.
* **`[label](url)` rendered empty.** The parser smuggled the URL through a sentinel `Inline::Text` inside the tree; once labels merged with their neighbours the label joined the sentinel and was dropped with it. Open link URLs now travel beside the tree, which retires the sentinel too.

## Known limitations, not addressed here

* **Text still does not flow across an inline boundary.** After a long `` `code` `` chip the rest of a sentence breaks to the next line as a whole. That is inherent to the div-per-run model the text selection is built on; fixing it means moving inline layout to `StyledText` with runs.
* **`font_weight` did not resolve above ~14px** in the harness used to verify this (14px BOLD renders, 21px does not — confirmed with an A/B probe in plain GPUI, outside any Markdown code). The headings in the "before" screenshot look unweighted too, so this likely predates the PR and is font fallback rather than Markdown. Hierarchy therefore rests on size, color and spacing; `BOLD` is set on every level so it applies wherever the font supplies the face.

## Verification

`cargo build`, `cargo clippy --all-targets` and `cargo test -p okena-markdown` are clean. Rendering was checked against the original screenshot by driving a temporary preview harness inside a nested headless GNOME compositor and measuring the result: the column lands at exactly 860 logical px, margins are symmetric, and the code-block surface reads `0x2d2d2e` against the `0x252526` page. The harness was deleted afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4NA8nMG19L14ne3ZRKgeg
