### PR TITLE
fix(terminal): stop URL wrap detection swallowing the next line

### DIFF
--- a/crates/okena-terminal/src/terminal/links.rs
+++ b/crates/okena-terminal/src/terminal/links.rs
@@ -327,6 +327,7 @@ impl Terminal {
                 // ── Extension loop ──
                 let mut extended_url = matches[last_idx].text.clone();
                 let mut current_row = m_line;
+                let mut url_end_col = m_col + m_len;
 
                 loop {
                     let next_row = current_row + 1;
@@ -336,6 +337,14 @@ impl Terminal {
 
                     let next_row_text = read_row(next_row);
                     let next_rtrimmed = next_row_text.trim_end();
+
+                    // A mid-token wrap fills the row to the layout edge, so a
+                    // continuation can never be wider than the row it
+                    // continues.  A wider next row means the break was a word
+                    // break — the URL ended on its own line.
+                    if next_rtrimmed.chars().count() > url_end_col + 3 {
+                        break;
+                    }
 
                     // Strip leading whitespace (TUI indentation).
                     let content = next_rtrimmed.trim_start_matches(' ');
@@ -440,6 +449,7 @@ impl Terminal {
                         break;
                     }
 
+                    url_end_col = indent + ext_char_len;
                     current_row = next_row;
                 }
 

--- a/crates/okena-terminal/src/terminal/tests/url_detect.rs
+++ b/crates/okena-terminal/src/terminal/tests/url_detect.rs
@@ -374,6 +374,30 @@ fn detect_url_not_extended_by_prose_word() {
 }
 
 #[test]
+fn detect_url_not_extended_when_next_line_is_longer() {
+    // A genuine mid-token wrap fills the row to the layout edge, so a
+    // continuation row can never be wider than the row it continues.
+    // Here the URL ends a short line and the next line is 6 cols longer —
+    // a word break, not a wrap.  Reproduces Claude Code's PR output:
+    // "https://…/pull/4" / "(docs/data-flow-findings-and-system-audit → main)."
+    let links = detect_urls_in(
+        "  https://github.com/NPI-Cloud/npi-docs/pull/4\r\n  (docs/data-flow-findings-and-system-audit \u{2192} main).\r\n",
+        60,
+    );
+    let url_links: Vec<&DetectedLink> = links.iter().filter(|l| l.is_url).collect();
+    assert_eq!(
+        url_links.len(),
+        1,
+        "Branch name on the next line must not be absorbed: {:?}",
+        links
+    );
+    assert_eq!(
+        url_links[0].text,
+        "https://github.com/NPI-Cloud/npi-docs/pull/4"
+    );
+}
+
+#[test]
 fn detect_url_uuid_continuation_with_trailing_prose() {
     // URL wraps mid-UUID, continuation line has prose after the UUID
     // fragment.  The UUID part (digits + hex letters + dashes) must


### PR DESCRIPTION
## Problem

Phase 2 of URL detection (`links.rs`) extends a URL onto the following row when a TUI wraps the line itself, i.e. without a `WRAPLINE` flag. Its "URL reaches the end of the visible content" guard compared the URL's end against **the URL row's own** trimmed length — trivially satisfied by every row that ends with a URL. From there the only thing standing between the URL and the next line was the weak-extension guard, which lets through any token containing a `/`.

Claude Code's PR output hit exactly that shape, so the branch name landed inside the link:

```
  https://github.com/org/repo/pull/4
  (docs/data-flow-findings-and-system-audit → main).
```

Detected text before the fix:

```
https://github.com/org/repo/pull/4(docs/data-flow-findings-and-system-audit
```

The whole branch name was underlined and clicking the link opened the wrong URL.

## Fix

A mid-token wrap fills the row to the layout edge, so a continuation row can never be wider than the row it continues. In the case above the URL row ends at column 46 while the next row runs to 52 — proof that the break was a word break, not a wrap.

- Reject the extension when the next row is wider than the URL's end column, using the same `+3` tolerance the other guards use.
- Track `url_end_col` across iterations so multi-row extensions compare against the row they actually continue.

Phase 1 (real `WRAPLINE` wraps) is untouched.

## Tests

New regression test `detect_url_not_extended_when_next_line_is_longer`, built from the screenshot above.

`cargo test -p okena-terminal` → 173 passed, 0 failed. All existing wrap tests still pass, including `detect_url_wrapped_tui_narrow_layout` and `detect_url_wrapped_with_trailing_text`, which cover genuine TUI-wrapped URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZXzxKAXvZc2RrjYWRAbMX