### PR TITLE
chore: release v0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "okena"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "core-text",
@@ -6018,7 +6018,7 @@ dependencies = [
 
 [[package]]
 name = "okena-app"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "okena-daemon"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "okena-daemon-core"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -6375,7 +6375,7 @@ dependencies = [
 
 [[package]]
 name = "okena-remote-server"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -6495,7 +6495,7 @@ dependencies = [
 
 [[package]]
 name = "okena-tui"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/okena-mobile-ffi", "crates/okena-core", "crates/okena-tr
 resolver = "2"
 
 [workspace.package]
-version = "0.28.0"
+version = "0.29.0"
 
 [package]
 name = "okena"


### PR DESCRIPTION
## Summary

- bump the workspace version to 0.29.0
- refresh workspace package versions in Cargo.lock

## Verification

- cpu-lease run -n 4 -- cargo check --workspace --all-targets