### PR TITLE
Cut okena's memory growth: honor scrollback, close the OSC 52 leak, bound hook terminals

### DIFF
--- a/crates/okena-app-core/src/settings.rs
+++ b/crates/okena-app-core/src/settings.rs
@@ -500,6 +500,11 @@ pub fn open_settings_file() {
 #[cfg(feature = "gpui")]
 pub fn init_settings(cx: &mut App) -> Entity<SettingsState> {
     let settings = load_settings();
+    // Terminals are built from a dozen places that have no route to settings,
+    // so the scrollback depth travels as a process-wide default (same shape as
+    // the terminal palette). Set it before any terminal exists; the daemon's
+    // value replaces it when the connection delivers `SettingsChanged`.
+    okena_terminal::terminal::set_process_scrollback_lines(settings.scrollback_lines);
     let entity = cx.new(|_cx| SettingsState::new(settings));
     cx.set_global(GlobalSettings(entity.clone()));
     entity

--- a/crates/okena-app-core/src/workspace/actions/execute/mod.rs
+++ b/crates/okena-app-core/src/workspace/actions/execute/mod.rs
@@ -30,6 +30,8 @@ use okena_workspace::context::WorkspaceCx;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+pub use project::{MAX_FINISHED_HOOK_TERMINALS, evict_stale_hook_terminals, teardown_hook_terminal};
+
 pub use files::{
     PreparedContentSearch, execute_prepared_content_search,
     execute_prepared_content_search_with_cancellation, prepare_content_search,

--- a/crates/okena-app-core/src/workspace/actions/execute/project.rs
+++ b/crates/okena-app-core/src/workspace/actions/execute/project.rs
@@ -652,14 +652,61 @@ pub(super) fn dismiss_hook(
         return ActionResult::Err(format!("hook terminal not found: {terminal_id}"));
     }
 
-    backend.kill(&terminal_id);
-    if let Some(monitor) = cx.hook_monitor() {
-        monitor.cancel_by_terminal_id(&terminal_id);
-    }
-    ws.cancel_pending_worktree_close(&terminal_id);
-    ws.remove_hook_terminal(&terminal_id, cx);
-    terminals.lock().remove(&terminal_id);
+    teardown_hook_terminal(ws, &terminal_id, backend, terminals, cx);
     ActionResult::Ok(None)
+}
+
+/// Kill a hook terminal's PTY and drop every trace of it: monitor entry, any
+/// pending worktree close it gated, the workspace record, and the registry
+/// handle holding its scrollback grid.
+///
+/// Shared by the user-driven dismiss above and the daemon's automatic eviction
+/// of old finished hooks, so both release exactly the same things.
+pub fn teardown_hook_terminal(
+    ws: &mut Workspace,
+    terminal_id: &str,
+    backend: &dyn TerminalBackend,
+    terminals: &TerminalsRegistry,
+    cx: &mut impl WorkspaceCx,
+) {
+    backend.kill(terminal_id);
+    if let Some(monitor) = cx.hook_monitor() {
+        monitor.cancel_by_terminal_id(terminal_id);
+    }
+    ws.cancel_pending_worktree_close(terminal_id);
+    ws.remove_hook_terminal(terminal_id, cx);
+    terminals.lock().remove(terminal_id);
+}
+
+/// How many finished hook terminals a project keeps before the oldest are
+/// retired. Each one holds a scrollback grid in the daemon and in every client
+/// mirroring it, so an unbounded list is a slow leak; a handful is enough to
+/// still read what recently ran.
+pub const MAX_FINISHED_HOOK_TERMINALS: usize = 5;
+
+/// Retire finished hook terminals beyond [`MAX_FINISHED_HOOK_TERMINALS`].
+///
+/// Called after a hook reaches a terminal status. Skips anything still gating a
+/// pending worktree close — that path removes the terminal itself once it
+/// resolves, and tearing it down early would drop the gate.
+pub fn evict_stale_hook_terminals(
+    ws: &mut Workspace,
+    project_id: &str,
+    backend: &dyn TerminalBackend,
+    terminals: &TerminalsRegistry,
+    cx: &mut impl WorkspaceCx,
+) {
+    let stale = ws.finished_hook_terminals_to_evict(project_id, MAX_FINISHED_HOOK_TERMINALS);
+    if stale.is_empty() {
+        return;
+    }
+    let gated = ws.pending_worktree_close_terminal_ids();
+    for terminal_id in stale {
+        if gated.contains(&terminal_id) {
+            continue;
+        }
+        teardown_hook_terminal(ws, &terminal_id, backend, terminals, cx);
+    }
 }
 
 #[cfg(test)]
@@ -787,6 +834,7 @@ mod hook_action_tests {
                 hook_type: "on_project_open".to_string(),
                 command: "export OKENA_PROJECT_ID='p1'; echo test".to_string(),
                 cwd: "/tmp/test".to_string(),
+                finished_at: None,
             },
         );
         let project = ProjectData {

--- a/crates/okena-app-core/src/workspace/actions/execute/session.rs
+++ b/crates/okena-app-core/src/workspace/actions/execute/session.rs
@@ -379,6 +379,7 @@ pub fn begin_workspace_replacement(
                 hook_type: result.hook_type.to_string(),
                 command: result.command.clone(),
                 cwd: result.cwd.clone(),
+                finished_at: None,
             },
         );
         project
@@ -961,6 +962,7 @@ mod tests {
                 hook_type: "on_project_open".to_string(),
                 command: "echo old".to_string(),
                 cwd: "/tmp".to_string(),
+                finished_at: None,
             },
         );
         ProjectData {

--- a/crates/okena-app/src/app/mod.rs
+++ b/crates/okena-app/src/app/mod.rs
@@ -415,6 +415,7 @@ impl Okena {
                 let settings = settings.as_ref().clone();
                 let mode = settings.theme_mode;
                 let custom_id = settings.custom_theme_id.clone();
+                this.apply_scrollback_setting(settings.scrollback_lines);
                 crate::settings::settings_entity(cx).update(cx, |state, cx| {
                     state.replace_from_daemon(settings.clone(), cx);
                 });
@@ -868,6 +869,28 @@ impl Okena {
     /// then re-points the loopback connection at the new endpoint/token.
     /// Single-flight and quit-aware; mirrors `perform_restart_daemon`'s pattern
     /// of running the blocking remote-server call on the background pool.
+    /// Apply the daemon's scrollback depth to this process.
+    ///
+    /// The client keeps its own alacritty grid per terminal, so the setting has
+    /// to be honored on both sides of the wire or the mirror alone would still
+    /// hold 10 000 lines (~50 MB per fully-scrolled terminal). Sets the
+    /// process-wide default for terminals created later and resizes the ones
+    /// already live.
+    pub(crate) fn apply_scrollback_setting(&self, lines: u32) {
+        if okena_terminal::terminal::process_scrollback_lines() == lines {
+            return;
+        }
+        okena_terminal::terminal::set_process_scrollback_lines(lines);
+
+        // Clone the handles out before resizing: `set_scrollback_lines` takes
+        // each terminal's own lock, and holding the registry lock across that
+        // would block the tokio reader tasks enqueueing output.
+        let live: Vec<_> = self.terminals.lock().values().cloned().collect();
+        for terminal in live {
+            terminal.set_scrollback_lines(lines);
+        }
+    }
+
     fn recover_local_daemon(&mut self, cx: &mut Context<Self>) {
         if self.quitting.load(Ordering::SeqCst) {
             return;

--- a/crates/okena-app/src/app/mod.rs
+++ b/crates/okena-app/src/app/mod.rs
@@ -194,6 +194,9 @@ pub struct Okena {
     pub(super) extra_window_handles: HashMap<WindowId, AnyWindowHandle>,
     pub(crate) workspace: Entity<Workspace>,
     pub(crate) terminals: TerminalsRegistry,
+    /// Visible-project set the scrollback pass last acted on, so it can skip
+    /// the walk when nothing moved. Cleared when the depth itself changes.
+    scrollback_visible_projects: parking_lot::Mutex<Option<std::collections::HashSet<String>>>,
     /// Track which detached windows we've already opened
     pub(crate) opened_detached_windows: HashSet<String>,
     /// Remote connection manager. Held so extras spawned at runtime can
@@ -327,6 +330,7 @@ impl Okena {
             extra_window_handles: HashMap::new(),
             workspace: workspace.clone(),
             terminals,
+            scrollback_visible_projects: parking_lot::Mutex::new(None),
             opened_detached_windows: HashSet::new(),
             remote_manager: remote_manager.clone(),
             terminal_activity_repaints: ActivityRepaintBatch::default(),
@@ -415,7 +419,7 @@ impl Okena {
                 let settings = settings.as_ref().clone();
                 let mode = settings.theme_mode;
                 let custom_id = settings.custom_theme_id.clone();
-                this.apply_scrollback_setting(settings.scrollback_lines);
+                this.apply_scrollback_setting(settings.scrollback_lines, cx);
                 crate::settings::settings_entity(cx).update(cx, |state, cx| {
                     state.replace_from_daemon(settings.clone(), cx);
                 });
@@ -668,6 +672,67 @@ impl Okena {
         self.remote_manager.update(cx, |manager, _cx| {
             manager.publish_visible_projects(&visible)
         });
+        self.sync_hidden_project_scrollback(&visible, cx);
+    }
+
+    /// Free the scrollback of terminals in projects no window is showing, and
+    /// restore it when one comes back.
+    ///
+    /// The client mirrors every terminal the daemon has, not just the ones it
+    /// renders, because bells, OSC notifications, titles and clipboard requests
+    /// from a background project still have to reach the user. What it does not
+    /// need is that project's *history*: nothing can scroll a pane that is not
+    /// on screen. Keeping it costs a full grid per hidden terminal, up to ~50 MB
+    /// each once filled, which on a workspace with dozens of background projects
+    /// is most of the client's memory.
+    ///
+    /// The daemon still holds the full history, so re-showing a project restores
+    /// the cap and history refills from there. Scrollback recorded while hidden
+    /// is lost — the same trade the web client already makes, where switching
+    /// projects unsubscribes and drops the buffer outright.
+    fn sync_hidden_project_scrollback(
+        &self,
+        visible: &std::collections::HashSet<String>,
+        cx: &mut Context<Self>,
+    ) {
+        let full = okena_terminal::terminal::process_scrollback_lines();
+        // This runs from the visible-projects tick, which fires on every
+        // workspace mutation — including activity bumps on PTY output. Walking
+        // every project's layout allocates, so do it only when the visible set
+        // actually moved. `set_scrollback_lines` resizes the grid that holds
+        // history even while the app is in the alternate screen, so there is
+        // nothing to catch up on later.
+        {
+            let mut last = self.scrollback_visible_projects.lock();
+            if last.as_ref() == Some(visible) {
+                return;
+            }
+            *last = Some(visible.clone());
+        }
+
+        let by_project: Vec<(bool, Vec<String>)> = {
+            let workspace = self.workspace.read(cx);
+            workspace
+                .projects()
+                .iter()
+                .map(|project| {
+                    (
+                        visible.contains(&project.id),
+                        workspace.all_terminal_ids_for_project(&project.id),
+                    )
+                })
+                .collect()
+        };
+
+        let registry = self.terminals.lock();
+        for (is_visible, terminal_ids) in by_project {
+            let depth = scrollback_depth_for(is_visible, full);
+            for terminal_id in terminal_ids {
+                if let Some(terminal) = registry.get(&terminal_id) {
+                    terminal.set_scrollback_lines(depth);
+                }
+            }
+        }
     }
 
     fn queue_terminal_activity_repaints(
@@ -874,21 +939,18 @@ impl Okena {
     /// The client keeps its own alacritty grid per terminal, so the setting has
     /// to be honored on both sides of the wire or the mirror alone would still
     /// hold 10 000 lines (~50 MB per fully-scrolled terminal). Sets the
-    /// process-wide default for terminals created later and resizes the ones
-    /// already live.
-    pub(crate) fn apply_scrollback_setting(&self, lines: u32) {
+    /// process-wide default for terminals created later, then re-syncs the live
+    /// ones — through the visibility pass, so a project nobody is showing keeps
+    /// its freed history instead of being handed the new depth.
+    pub(crate) fn apply_scrollback_setting(&self, lines: u32, cx: &mut Context<Self>) {
         if okena_terminal::terminal::process_scrollback_lines() == lines {
             return;
         }
         okena_terminal::terminal::set_process_scrollback_lines(lines);
-
-        // Clone the handles out before resizing: `set_scrollback_lines` takes
-        // each terminal's own lock, and holding the registry lock across that
-        // would block the tokio reader tasks enqueueing output.
-        let live: Vec<_> = self.terminals.lock().values().cloned().collect();
-        for terminal in live {
-            terminal.set_scrollback_lines(lines);
-        }
+        // The visible set has not moved, but the depth every visible terminal
+        // should hold just did — clear the memo so the sync actually runs.
+        self.scrollback_visible_projects.lock().take();
+        self.publish_visible_projects(cx);
     }
 
     fn recover_local_daemon(&mut self, cx: &mut Context<Self>) {
@@ -1094,12 +1156,22 @@ impl Okena {
     }
 }
 
+/// Scrollback a client mirror should hold for a terminal, given whether any
+/// window is showing its project.
+///
+/// Hidden means zero: the mirror still parses output so bells, notifications
+/// and titles keep working, but no pane can scroll history the user cannot see,
+/// and the daemon retains the real thing.
+fn scrollback_depth_for(project_is_visible: bool, configured: u32) -> u32 {
+    if project_is_visible { configured } else { 0 }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         RECOVERY_ESCALATE_AFTER_ATTEMPTS, RECOVERY_TOAST_AFTER_ATTEMPTS, WindowLayoutSaveTracker,
         flush_window_layout_saves_before_final, is_okena_process, recovery_backoff_delay,
-        should_escalate_recovery,
+        scrollback_depth_for, should_escalate_recovery,
     };
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
@@ -1219,5 +1291,18 @@ mod tests {
         }
         // The one-shot give-up toast fires during the ramp, not only at the cap.
         const { assert!(RECOVERY_TOAST_AFTER_ATTEMPTS >= 4) };
+    }
+
+    #[test]
+    fn a_visible_project_keeps_the_configured_scrollback() {
+        assert_eq!(scrollback_depth_for(true, 10_000), 10_000);
+        assert_eq!(scrollback_depth_for(true, 500), 500);
+    }
+
+    #[test]
+    fn a_hidden_project_keeps_no_scrollback() {
+        // The whole point of the pass: a mirror of a project no window shows
+        // holds no history, which is where most of the client's memory went.
+        assert_eq!(scrollback_depth_for(false, 10_000), 0);
     }
 }

--- a/crates/okena-core/src/api.rs
+++ b/crates/okena-core/src/api.rs
@@ -400,6 +400,10 @@ pub struct ApiHookTerminalEntry {
     pub hook_type: String,
     pub command: String,
     pub cwd: String,
+    /// Unix seconds at which the hook finished, `None` while running. Older
+    /// daemons omit it; the client only uses it to order eviction candidates.
+    #[serde(default)]
+    pub finished_at: Option<u64>,
 }
 
 /// Wire mirror of `okena_hooks::HookStatus`. Durations are carried as whole
@@ -1367,6 +1371,7 @@ mod tests {
                     hook_type: "on_project_open".into(),
                     command: "echo hi".into(),
                     cwd: "/tmp".into(),
+                    finished_at: None,
                 }],
                 hooks: ApiHooksConfig {
                     project: ApiProjectHooks {

--- a/crates/okena-daemon-core/src/command_loop.rs
+++ b/crates/okena-daemon-core/src/command_loop.rs
@@ -183,6 +183,32 @@ fn publish_committed_settings_change(
     }
 }
 
+/// Re-apply the scrollback depth after the user edits it.
+///
+/// The process-wide default only affects terminals built from here on, so live
+/// grids have to be resized explicitly. Shrinking frees the excess history
+/// immediately, which is the point: this is the daemon's half of the ~50 MB
+/// per fully-scrolled terminal that okena otherwise holds forever.
+fn apply_scrollback_after_committed_settings_change(
+    outcome: &SettingsUpdateOutcome,
+    settings: &Arc<Mutex<AppSettings>>,
+    terminals: &TerminalsRegistry,
+) {
+    if !outcome.committed {
+        return;
+    }
+    let lines = settings.lock().scrollback_lines;
+    okena_terminal::terminal::set_process_scrollback_lines(lines);
+
+    // Clone the handles out before touching any terminal: `set_scrollback_lines`
+    // takes the per-terminal locks, and holding the registry lock across that
+    // would serialize it against the PTY loop.
+    let live: Vec<_> = terminals.lock().values().cloned().collect();
+    for terminal in live {
+        terminal.set_scrollback_lines(lines);
+    }
+}
+
 fn refresh_claude_pty_env_after_committed_settings_change(
     outcome: &SettingsUpdateOutcome,
     settings: &Arc<Mutex<AppSettings>>,
@@ -2697,6 +2723,9 @@ pub async fn daemon_command_loop(
                             &outcome,
                             &settings,
                             backend.as_ref(),
+                        );
+                        apply_scrollback_after_committed_settings_change(
+                            &outcome, &settings, &terminals,
                         );
                         publish_committed_settings_change(&outcome, &state_version);
                         outcome.result

--- a/crates/okena-daemon-core/src/command_loop.rs
+++ b/crates/okena-daemon-core/src/command_loop.rs
@@ -4608,6 +4608,7 @@ mod tests {
                 hook_type: "on_project_open".to_string(),
                 command: "echo hook".to_string(),
                 cwd: path.to_string(),
+                finished_at: None,
             },
         );
         Workspace::new(data)
@@ -6676,6 +6677,7 @@ mod tests {
                 hook_type: "on_project_open".to_string(),
                 command: "echo old".to_string(),
                 cwd: tmp_path.to_string(),
+                finished_at: None,
             },
         );
         let workspace = Arc::new(Mutex::new(Workspace::new(data)));
@@ -6771,6 +6773,7 @@ mod tests {
                 hook_type: "on_project_open".to_string(),
                 command: "echo old".to_string(),
                 cwd: "/tmp".to_string(),
+                finished_at: None,
             },
         );
         let workspace = Arc::new(Mutex::new(Workspace::new(data)));
@@ -7573,6 +7576,7 @@ mod tests {
                 hook_type: "on_project_open".to_string(),
                 command: "echo hook".to_string(),
                 cwd: worktree.to_string_lossy().into_owned(),
+                finished_at: None,
             },
         );
         data.projects[1]
@@ -7586,6 +7590,7 @@ mod tests {
                 hook_type: "on_project_open".to_string(),
                 command: "echo completed".to_string(),
                 cwd: worktree.to_string_lossy().into_owned(),
+                finished_at: None,
             },
         );
         let metadata = data.projects[1]
@@ -8069,6 +8074,7 @@ mod tests {
                 hook_type: "on_project_open".to_string(),
                 command: "echo completed".to_string(),
                 cwd: old_path.to_string_lossy().into_owned(),
+                finished_at: None,
             },
         );
         let mut nested = data.projects[0].clone();

--- a/crates/okena-daemon-core/src/daemon.rs
+++ b/crates/okena-daemon-core/src/daemon.rs
@@ -383,6 +383,13 @@ impl DaemonCore {
             okena_terminal::terminal::set_process_palette(colors);
         }
 
+        // Scrollback depth, same shape as the palette above: one user setting
+        // that has to reach terminals built anywhere in the process (hook
+        // runner, service manager, PTY loop), most of which have no route to
+        // `AppSettings`. Terminals created before this point would silently get
+        // alacritty's 10 000-line default, so set it before any PTY spawns.
+        okena_terminal::terminal::set_process_scrollback_lines(settings.lock().scrollback_lines);
+
         // ── 5. Server wiring channels ────────────────────────────────────────
         // Shared-watch trick: `tokio::sync::watch::Sender` is `Clone` and clones
         // share one underlying channel. The server + command loop READ this

--- a/crates/okena-daemon-core/src/daemon.rs
+++ b/crates/okena-daemon-core/src/daemon.rs
@@ -390,6 +390,30 @@ impl DaemonCore {
         // alacritty's 10 000-line default, so set it before any PTY spawns.
         okena_terminal::terminal::set_process_scrollback_lines(settings.lock().scrollback_lines);
 
+        // Retire hook terminals that piled up before eviction existed (or under
+        // an older build). Their PTYs did not survive the restart, so this only
+        // drops persisted records — no terminal is registered yet at this point.
+        {
+            let no_hook_runner = None;
+            let no_hook_monitor = None;
+            let mut cx = crate::workspace_cx::DaemonWorkspaceCx::new(
+                &reactor.workspace_tick,
+                &no_hook_runner,
+                &no_hook_monitor,
+            );
+            let mut ws = reactor.workspace.lock();
+            let project_ids: Vec<String> =
+                ws.projects().iter().map(|project| project.id.clone()).collect();
+            for project_id in project_ids {
+                for terminal_id in ws.finished_hook_terminals_to_evict(
+                    &project_id,
+                    okena_app_core::workspace::actions::execute::MAX_FINISHED_HOOK_TERMINALS,
+                ) {
+                    ws.remove_hook_terminal(&terminal_id, &mut cx);
+                }
+            }
+        }
+
         // ── 5. Server wiring channels ────────────────────────────────────────
         // Shared-watch trick: `tokio::sync::watch::Sender` is `Clone` and clones
         // share one underlying channel. The server + command loop READ this
@@ -836,6 +860,7 @@ mod shutdown_tests {
                     hook_type: "on_project_open".to_string(),
                     command: "true".to_string(),
                     cwd: "/tmp".to_string(),
+                    finished_at: None,
                 },
             )]),
             pinned: false,
@@ -942,6 +967,7 @@ mod shutdown_tests {
                 hook_type: "on_project_open".to_string(),
                 command: "echo hook".to_string(),
                 cwd: "/tmp".to_string(),
+                finished_at: None,
             },
         );
         data.projects.push(project);

--- a/crates/okena-daemon-core/src/pty_loop.rs
+++ b/crates/okena-daemon-core/src/pty_loop.rs
@@ -36,6 +36,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use async_channel::Receiver;
+use okena_app_core::workspace::actions::execute::evict_stale_hook_terminals;
 use okena_hooks::{HookMonitor, HookRunner};
 use okena_services::manager::ServiceManager;
 use okena_terminal::TerminalsRegistry;
@@ -315,6 +316,7 @@ fn process_osc_hook_exits(
     if !status_updates.is_empty() {
         let mut cx = reactor.workspace_cx();
         let mut ws = reactor.workspace.lock();
+        let mut touched_projects: Vec<String> = Vec::new();
         for (tid, status, exit_code) in status_updates {
             if let Some(monitor) = reactor.hook_monitor.as_ref() {
                 monitor.finish_by_terminal_id(&tid, exit_code);
@@ -324,8 +326,25 @@ fn process_osc_hook_exits(
                 HookTerminalStatus::Failed { exit_code } => *exit_code,
                 HookTerminalStatus::Running => unreachable!("OSC produces a completed hook status"),
             };
+            if let Some(project_id) = ws.is_hook_terminal(&tid)
+                && !touched_projects.contains(&project_id)
+            {
+                touched_projects.push(project_id);
+            }
             ws.update_hook_terminal_status(&tid, status, &mut cx);
             results.push((tid, code));
+        }
+        // A keep-alive hook's PTY outlives its command, so nothing else ever
+        // releases this terminal. Retire the oldest finished ones now that this
+        // project has one more.
+        for project_id in touched_projects {
+            evict_stale_hook_terminals(
+                &mut ws,
+                &project_id,
+                reactor.backend.as_ref(),
+                terminals,
+                &mut cx,
+            );
         }
     }
     results
@@ -634,6 +653,10 @@ fn handle_hook_terminal_exits(
 
     let global_hooks = context.reactor.settings.lock().hooks.clone();
 
+    // Projects whose hook set gained a finished entry in this batch, revisited
+    // after the loop to retire the oldest ones.
+    let mut finished_in_projects: Vec<String> = Vec::new();
+
     for (terminal_id, generation, exit_code) in exit_events {
         if !hook_tids.contains(terminal_id) {
             continue;
@@ -655,6 +678,13 @@ fn handle_hook_terminal_exits(
         // scrollback remains registered; its late PTY exit must not rewrite it.
         if !hook_is_running {
             continue;
+        }
+        // Capture the owner while the entry is still present: the close paths
+        // below may remove it before the loop ends.
+        if let Some(project_id) = ws.is_hook_terminal(&tid)
+            && !finished_in_projects.contains(&project_id)
+        {
+            finished_in_projects.push(project_id);
         }
 
         if let Some(monitor) = context.reactor.hook_monitor.as_ref() {
@@ -765,8 +795,26 @@ fn handle_hook_terminal_exits(
                 }
             }
         }
-        // Hook terminal persists on non-close paths — no auto-cleanup. A client
-        // can dismiss or rerun it.
+        // Hook terminal persists on non-close paths — a client can dismiss or
+        // rerun it, and the eviction pass below retires the oldest.
+    }
+
+    // A finished hook keeps its entry, its PTY and a full scrollback grid — in
+    // the daemon and in every client mirroring it — and nothing on this path
+    // removes one. Retire the oldest so a project whose hooks fire on every
+    // worktree operation stops accumulating them for the life of the workspace.
+    if !finished_in_projects.is_empty() {
+        let mut cx = context.reactor.workspace_cx();
+        let mut ws = context.reactor.workspace.lock();
+        for project_id in finished_in_projects {
+            evict_stale_hook_terminals(
+                &mut ws,
+                &project_id,
+                context.reactor.backend.as_ref(),
+                context.terminals,
+                &mut cx,
+            );
+        }
     }
 
     hook_tids
@@ -1012,6 +1060,7 @@ mod tests {
                     hook_type: "before_worktree_remove".into(),
                     command: "true".into(),
                     cwd: worktree.to_string_lossy().into_owned(),
+                    finished_at: None,
                 },
             )]),
             pinned: false,
@@ -1134,6 +1183,7 @@ mod tests {
                 hook_type: "on_project_open".into(),
                 command: "exit 7".into(),
                 cwd: "/tmp/project-one".into(),
+                finished_at: None,
             },
         );
         let workspace = Workspace::new(WorkspaceData {
@@ -1182,6 +1232,105 @@ mod tests {
             HookStatus::Failed { exit_code: 7, .. }
         ));
         assert_eq!(monitor.drain_pending_toasts().len(), 1);
+    }
+
+    #[test]
+    fn osc_hook_exit_evicts_the_oldest_finished_hook_terminals() {
+        // A finished hook keeps its entry, its PTY and a full scrollback grid,
+        // in the daemon and in every client mirroring it. Nothing but a manual
+        // dismiss ever removed one, so a project whose hooks fire on every
+        // worktree operation accumulated them for the life of the workspace.
+        let mut project = plain_project("hook-new");
+
+        // Six already-finished hooks, oldest first, one over the budget of five.
+        for i in 0..6u64 {
+            project.hook_terminals.insert(
+                format!("hook-{i}"),
+                HookTerminalEntry {
+                    label: format!("Old hook {i}"),
+                    status: HookTerminalStatus::Succeeded,
+                    hook_type: "on_project_open".into(),
+                    command: "true".into(),
+                    cwd: "/tmp/project-one".into(),
+                    finished_at: Some(1_700_000_000 + i),
+                },
+            );
+        }
+        // Plus the one about to report its own exit through OSC.
+        project.hook_terminals.insert(
+            "hook-new".into(),
+            HookTerminalEntry {
+                label: "New hook".into(),
+                status: HookTerminalStatus::Running,
+                hook_type: "on_project_open".into(),
+                command: "true".into(),
+                cwd: "/tmp/project-one".into(),
+                finished_at: None,
+            },
+        );
+
+        let workspace = Workspace::new(WorkspaceData {
+            version: 1,
+            projects: vec![project],
+            project_order: vec!["project-1".into()],
+            folders: Vec::new(),
+            service_panel_heights: Default::default(),
+            hook_panel_heights: Default::default(),
+            main_window: Default::default(),
+            extra_windows: Vec::new(),
+        });
+        let reactor = test_reactor(workspace, AppSettings::default());
+
+        // Every hook terminal is registered, holding a grid, as it would be live.
+        let terminals: TerminalsRegistry = Arc::new(Mutex::new(Default::default()));
+        for i in 0..6u64 {
+            let id = format!("hook-{i}");
+            terminals.lock().insert(
+                id.clone(),
+                Arc::new(Terminal::new(
+                    id,
+                    terminal_size(),
+                    reactor.backend.transport(),
+                    "/tmp/project-one".into(),
+                )),
+            );
+        }
+        let terminal = Arc::new(Terminal::new(
+            "hook-new".into(),
+            terminal_size(),
+            reactor.backend.transport(),
+            "/tmp/project-one".into(),
+        ));
+        terminal.process_output(b"\x1b]0;__okena_hook_exit:0\x07");
+        terminals.lock().insert("hook-new".into(), terminal);
+
+        process_osc_hook_exits(&["hook-new".into()], &terminals, &reactor);
+
+        let workspace = reactor.workspace.lock();
+        let hooks = &workspace.project("project-1").expect("project").hook_terminals;
+        assert_eq!(
+            hooks.len(),
+            5,
+            "seven finished hooks must be trimmed to the budget, got {:?}",
+            hooks.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            hooks.contains_key("hook-new"),
+            "the one that just finished must survive"
+        );
+        assert!(
+            !hooks.contains_key("hook-0") && !hooks.contains_key("hook-1"),
+            "the two oldest must go: {:?}",
+            hooks.keys().collect::<Vec<_>>()
+        );
+        // The point of the eviction: the grids are released, not just the rows.
+        let registry = terminals.lock();
+        assert!(
+            !registry.contains_key("hook-0") && !registry.contains_key("hook-1"),
+            "evicted hooks must release their terminals: {:?}",
+            registry.keys().collect::<Vec<_>>()
+        );
+        assert!(registry.contains_key("hook-new"));
     }
 
     #[tokio::test]
@@ -1531,6 +1680,7 @@ mod tests {
                 hook_type: "on_project_open".into(),
                 command: "echo done".into(),
                 cwd: "/tmp/project-one".into(),
+                finished_at: None,
             },
         );
         let workspace = Workspace::new(WorkspaceData {

--- a/crates/okena-daemon-core/src/worktree_close_watchdog.rs
+++ b/crates/okena-daemon-core/src/worktree_close_watchdog.rs
@@ -123,6 +123,7 @@ mod tests {
                 hook_type: "before_worktree_remove".into(),
                 command: "true".into(),
                 cwd: project.path.clone(),
+                finished_at: None,
             },
         );
         let mut workspace = Workspace::new(WorkspaceData {

--- a/crates/okena-services/src/docker_compose.rs
+++ b/crates/okena-services/src/docker_compose.rs
@@ -568,14 +568,38 @@ fn ps_snapshot() -> crate::ServiceResult<Vec<ContainerSnapshot>> {
                 .map(|(_, snap)| snap.clone())
         })
     };
+    // Same read without the freshness filter, for callers that would rather
+    // have a stale answer than block behind an in-flight refresh.
+    let cached_snapshot = || {
+        PS_SNAPSHOT
+            .lock()
+            .ok()
+            .and_then(|g| g.as_ref().map(|(_, snap)| snap.clone()))
+    };
 
     if let Some(snap) = fresh_cached() {
         return Ok(snap);
     }
 
-    // Stale: serialize refreshes. Whoever gets the lock first refreshes; the
-    // rest re-check below and reuse the freshly stored snapshot.
-    let _flight = PS_REFRESH_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // Stale: one caller refreshes, the rest carry on with what they have.
+    //
+    // This used to block on the lock, which parked a thread per polling
+    // project for the duration of a `docker ps` (up to the 3s timeout) on
+    // every 5s tick. Each of those threads is a `smol::unblock` task, and the
+    // blocking pool retires idle threads between ticks, so a machine with a
+    // couple of dozen compose projects churned through millions of thread
+    // spawns a week — all of them waiting to read a value one of them was
+    // already fetching.
+    let Ok(_flight) = PS_REFRESH_LOCK.try_lock() else {
+        // Serve the stale snapshot; it is at most one refresh out of date, and
+        // a container's state does not change meaningfully within one tick.
+        return match cached_snapshot() {
+            Some(snap) => Ok(snap),
+            // Nothing cached yet (first poll after boot, or just invalidated).
+            // The winner will store one shortly.
+            None => Err(crate::error::ServiceError::RefreshInFlight),
+        };
+    };
     if let Some(snap) = fresh_cached() {
         return Ok(snap);
     }
@@ -974,5 +998,56 @@ mod tests {
 
         ensure_no_compose_containers_under_with(&[], &runner)
             .expect("missing Docker means there is no local integration");
+    }
+
+    /// Serializes the tests that touch the process-wide snapshot statics.
+    static SNAPSHOT_TEST_GUARD: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn ps_snapshot_serves_stale_data_instead_of_blocking_on_a_refresh() {
+        let _guard = SNAPSHOT_TEST_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        // A snapshot exists but has aged past the TTL, and someone else is
+        // already refreshing it — the shape every poller but one sees when a
+        // shared tick comes around.
+        *PS_SNAPSHOT.lock().unwrap() = Some((
+            Instant::now() - PS_SNAPSHOT_TTL - Duration::from_secs(1),
+            vec![ContainerSnapshot {
+                working_dir: None,
+                service: "web".to_string(),
+                state: "running".to_string(),
+                exit_code: None,
+                ports: Vec::new(),
+            }],
+        ));
+        let held = PS_REFRESH_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let snapshot = ps_snapshot().expect("stale data beats parking a thread");
+
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].service, "web");
+        drop(held);
+        *PS_SNAPSHOT.lock().unwrap() = None;
+    }
+
+    #[test]
+    fn ps_snapshot_reports_in_flight_when_nothing_is_cached_yet() {
+        let _guard = SNAPSHOT_TEST_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        *PS_SNAPSHOT.lock().unwrap() = None;
+        let held = PS_REFRESH_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let result = ps_snapshot();
+
+        assert!(
+            matches!(result, Err(crate::error::ServiceError::RefreshInFlight)),
+            "first poll after boot has nothing to serve, and must say so rather \
+             than block or look like a docker failure"
+        );
+        drop(held);
     }
 }

--- a/crates/okena-services/src/error.rs
+++ b/crates/okena-services/src/error.rs
@@ -20,6 +20,13 @@ pub enum ServiceError {
         #[source]
         source: std::io::Error,
     },
+
+    /// Another caller is already refreshing the shared `docker ps` snapshot
+    /// and no usable snapshot exists yet. Not a failure: the caller should
+    /// keep whatever it last displayed and try again next tick, rather than
+    /// hold a thread parked on the refresh lock.
+    #[error("docker ps refresh already in flight")]
+    RefreshInFlight,
 }
 
 /// Convenience alias for `Result<T, ServiceError>`.

--- a/crates/okena-services/src/manager/docker.rs
+++ b/crates/okena-services/src/manager/docker.rs
@@ -13,6 +13,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+/// Steady-state gap between docker status polls for one project.
+const DOCKER_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
 const DOCKER_DISCOVERY_RETRY_DELAYS: [Duration; 5] = [
     Duration::from_secs(5),
     Duration::from_secs(10),
@@ -20,6 +23,15 @@ const DOCKER_DISCOVERY_RETRY_DELAYS: [Duration; 5] = [
     Duration::from_secs(40),
     Duration::from_secs(60),
 ];
+
+/// Per-project offset within the poll interval, so pollers wake staggered
+/// instead of together. Stable for a given project id.
+fn poll_stagger(project_id: &str) -> Duration {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    project_id.hash(&mut hasher);
+    Duration::from_millis(hasher.finish() % DOCKER_POLL_INTERVAL.as_millis() as u64)
+}
 
 fn reconcile_docker_statuses(
     instances: &mut HashMap<(String, String), ServiceInstance>,
@@ -413,8 +425,11 @@ impl ServiceManager {
         let file = compose_file.to_string();
 
         cx.spawn_main(async move |this, cx| {
-            // Small initial delay
-            cx.timer(Duration::from_secs(1)).await;
+            // Small initial delay, spread across the poll window so N projects
+            // don't all wake in the same instant and pile up on the shared
+            // `docker ps` snapshot. Derived from the project id so a given
+            // project keeps its slot across restarts.
+            cx.timer(Duration::from_secs(1) + poll_stagger(&pid)).await;
 
             let mut consecutive_failures: u32 = 0;
 
@@ -492,6 +507,11 @@ impl ServiceManager {
                             return;
                         }
                     }
+                    // Another project's poller is fetching the shared snapshot
+                    // and there is nothing cached yet. Not a docker failure —
+                    // keep the current statuses and retry on the normal cadence
+                    // rather than backing off.
+                    Err(crate::error::ServiceError::RefreshInFlight) => {}
                     Err(e) => {
                         consecutive_failures += 1;
                         log::warn!("Docker status poll failed for project {}: {}", pid, e);
@@ -500,11 +520,13 @@ impl ServiceManager {
 
                 // Back off on repeated failures: 5s → 10s → 20s → 40s → 60s (cap)
                 let delay = if consecutive_failures == 0 {
-                    5
+                    DOCKER_POLL_INTERVAL
                 } else {
-                    (5u64 << consecutive_failures.min(4)).min(60)
+                    Duration::from_secs(
+                        (DOCKER_POLL_INTERVAL.as_secs() << consecutive_failures.min(4)).min(60),
+                    )
                 };
-                cx.timer(Duration::from_secs(delay)).await;
+                cx.timer(delay).await;
             }
         });
     }
@@ -660,6 +682,34 @@ mod tests {
                 Duration::from_secs(40),
                 Duration::from_secs(60),
             ]
+        );
+    }
+
+    #[test]
+    fn poll_stagger_spreads_projects_across_the_interval() {
+        let ids = [
+            "project-a",
+            "project-b",
+            "project-c",
+            "project-d",
+            "project-e",
+            "project-f",
+        ];
+        let offsets: Vec<_> = ids.iter().map(|id| poll_stagger(id)).collect();
+
+        for offset in &offsets {
+            assert!(
+                *offset < DOCKER_POLL_INTERVAL,
+                "an offset past the interval would skip a whole poll cycle"
+            );
+        }
+        // Stable per id, so a project keeps its slot across restarts.
+        assert_eq!(poll_stagger("project-a"), offsets[0]);
+        // And genuinely spread, rather than every project landing together.
+        let distinct: std::collections::HashSet<_> = offsets.iter().collect();
+        assert!(
+            distinct.len() >= ids.len() - 1,
+            "expected distinct offsets, got {offsets:?}"
         );
     }
 }

--- a/crates/okena-state/src/lib.rs
+++ b/crates/okena-state/src/lib.rs
@@ -23,5 +23,5 @@ pub use window_id::WindowId;
 pub use window_state::{ProjectLayoutMode, ProjectSortMode, WindowBounds, WindowState};
 pub use workspace_data::{
     FolderData, HookTerminalEntry, HookTerminalStatus, ProjectData, WorkspaceData,
-    WorktreeMetadata, is_bash_prompt_title,
+    WorktreeMetadata, is_bash_prompt_title, now_unix_seconds,
 };

--- a/crates/okena-state/src/workspace_data.rs
+++ b/crates/okena-state/src/workspace_data.rs
@@ -112,6 +112,21 @@ pub struct HookTerminalEntry {
     pub command: String,
     /// Working directory for the hook command.
     pub cwd: String,
+    /// Unix seconds at which the hook reached a terminal status, or `None`
+    /// while it is still running (and on entries written before this field
+    /// existed). Used to evict the oldest finished hooks — a finished hook
+    /// holds a full terminal grid in the daemon and in every client mirroring
+    /// it, and nothing else ever removes one.
+    #[serde(default)]
+    pub finished_at: Option<u64>,
+}
+
+/// Wall-clock seconds since the Unix epoch, for stamping `finished_at`.
+pub fn now_unix_seconds() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 impl HookTerminalStatus {
@@ -150,6 +165,7 @@ impl HookTerminalEntry {
             hook_type: self.hook_type.clone(),
             command: self.command.clone(),
             cwd: self.cwd.clone(),
+            finished_at: self.finished_at,
         }
     }
 
@@ -163,6 +179,7 @@ impl HookTerminalEntry {
                 hook_type: api.hook_type.clone(),
                 command: api.command.clone(),
                 cwd: api.cwd.clone(),
+                finished_at: api.finished_at,
             },
         )
     }
@@ -439,6 +456,46 @@ mod tests {
 
         assert_eq!(project.id, "p1");
         assert_eq!(project.connection_id.as_deref(), Some("c1"));
+    }
+
+    #[test]
+    fn hook_terminal_entry_loads_without_a_finish_time() {
+        // Every workspace.json written before `finished_at` existed omits it.
+        // Such entries must load and simply sort oldest for eviction.
+        let json = r#"{
+            "label": "on_project_open",
+            "status": "Succeeded",
+            "hook_type": "on_project_open",
+            "command": "echo hi",
+            "cwd": "/tmp"
+        }"#;
+
+        let entry: HookTerminalEntry = serde_json::from_str(json).unwrap();
+
+        assert_eq!(entry.finished_at, None);
+        assert_eq!(entry.status, HookTerminalStatus::Succeeded);
+    }
+
+    #[test]
+    fn hook_terminal_entry_round_trips_its_finish_time() {
+        let entry = HookTerminalEntry {
+            label: "on_project_open".to_string(),
+            status: HookTerminalStatus::Failed { exit_code: 2 },
+            hook_type: "on_project_open".to_string(),
+            command: "echo hi".to_string(),
+            cwd: "/tmp".to_string(),
+            finished_at: Some(1_700_000_000),
+        };
+
+        let json = serde_json::to_string(&entry).unwrap();
+        let restored: HookTerminalEntry = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.finished_at, Some(1_700_000_000));
+
+        // And across the wire mirror, which carries the same field.
+        let (id, from_wire) = HookTerminalEntry::from_api(&entry.to_api("h1".to_string()));
+        assert_eq!(id, "h1");
+        assert_eq!(from_wire.finished_at, Some(1_700_000_000));
     }
 
     #[test]

--- a/crates/okena-terminal/src/pty_manager.rs
+++ b/crates/okena-terminal/src/pty_manager.rs
@@ -2158,6 +2158,14 @@ impl crate::terminal::TerminalTransport for PtyManager {
         self.uses_mouse_backend()
     }
 
+    /// The PTY owner is the headless daemon: no system clipboard to write to,
+    /// no UI thread to answer a read request, and nothing that drains the
+    /// queues. Dropping OSC 52 here is what keeps them from growing forever.
+    /// The client mirroring this terminal still services them.
+    fn handles_clipboard(&self) -> bool {
+        false
+    }
+
     fn load_terminal_modes(&self, terminal_id: &str) -> Option<crate::terminal::TerminalModeState> {
         #[cfg(unix)]
         if self.session_backend() == ResolvedBackend::Dtach {

--- a/crates/okena-terminal/src/terminal/event_listener.rs
+++ b/crates/okena-terminal/src/terminal/event_listener.rs
@@ -139,6 +139,15 @@ impl ZedEventListener {
     }
 }
 
+/// Cap on queued OSC 52 clipboard writes per terminal. Each entry is a whole
+/// clipboard payload, so this bounds a burst of copies rather than a count of
+/// small events. Only reached if the UI stops draining.
+const MAX_PENDING_CLIPBOARD_WRITES: usize = 16;
+
+/// Cap on queued OSC 52 clipboard *read* requests per terminal. Mirrors
+/// `OSC99_MAX_PENDING` in the OSC sidecar, including its drop-new policy.
+const MAX_PENDING_CLIPBOARD_READS: usize = 32;
+
 /// Process-wide fallback palette for answering OSC color queries when no
 /// per-terminal palette was pushed (headless daemon — no views). Set once at
 /// boot and on theme changes via [`set_process_palette`].
@@ -187,7 +196,20 @@ impl EventListener for ZedEventListener {
                 self.bell_pending.store(true, Ordering::Relaxed);
             }
             TermEvent::ClipboardStore(_, text) => {
-                self.clipboard.writes.lock().push(text);
+                // Only a side with a clipboard queues these. The daemon parses
+                // the same stream but has no clipboard and no drain, so a queue
+                // there would grow for the life of the terminal.
+                if !self.transport.handles_clipboard() {
+                    return;
+                }
+                let mut writes = self.clipboard.writes.lock();
+                // Bound regardless: an app can emit OSC 52 far faster than the
+                // UI drains, and payloads are whole clipboard buffers. Oldest
+                // out — a stale copy is worth less than the newest one.
+                if writes.len() >= MAX_PENDING_CLIPBOARD_WRITES {
+                    writes.remove(0);
+                }
+                writes.push(text);
             }
             TermEvent::ClipboardLoad(_ty, formatter) => {
                 // An app asked to READ the clipboard (`OSC 52 ; c ; ?`). We
@@ -197,7 +219,20 @@ impl EventListener for ZedEventListener {
                 // setting. The `ClipboardType` is ignored — primary-selection
                 // requests are answered from the regular clipboard like the
                 // rest, which matches what most terminals do.
-                self.clipboard.reads.lock().push(formatter);
+                //
+                // Dropping the formatter on a side that cannot answer is the
+                // same outcome the UI produces when `allow_clipboard_read` is
+                // off (`drop_clipboard_reads`): the app simply gets no reply.
+                if !self.transport.handles_clipboard() {
+                    return;
+                }
+                let mut reads = self.clipboard.reads.lock();
+                // Drop-new once saturated, matching `OSC99_MAX_PENDING`: the
+                // in-flight requests are the ones the app is still waiting on.
+                if reads.len() >= MAX_PENDING_CLIPBOARD_READS {
+                    return;
+                }
+                reads.push(formatter);
             }
             TermEvent::ColorRequest(index, response_fn) => {
                 // Mirrors must not answer queries — the PTY owner is the

--- a/crates/okena-terminal/src/terminal/mod.rs
+++ b/crates/okena-terminal/src/terminal/mod.rs
@@ -45,8 +45,9 @@ pub use resize_authority::{
 };
 pub use transport::TerminalTransport;
 pub use types::{
-    AppCursorShape, ClipboardReadResponder, DetectedLink, PromptMark, PromptMarkKind, ResizeState,
-    SelectionState, TerminalProgress, TerminalProgressState, TerminalSize,
+    AppCursorShape, ClipboardReadResponder, DEFAULT_SCROLLBACK_LINES, DetectedLink, PromptMark,
+    PromptMarkKind, ResizeState, SelectionState, TerminalOptions, TerminalProgress,
+    TerminalProgressState, TerminalSize, process_scrollback_lines, set_process_scrollback_lines,
 };
 
 pub use osc_sidecar::TerminalNotification;
@@ -341,15 +342,43 @@ pub struct Terminal {
     /// lock-free by the idle-detection loop. Prevents flagging fresh
     /// terminals as idle before the user has interacted.
     pub(super) had_user_input: AtomicBool,
+
+    /// The exact `TermConfig` handed to `Term::new`, kept so
+    /// `set_scrollback_lines` can re-apply an otherwise-identical config with
+    /// only `scrolling_history` changed. alacritty's `Term::set_options`
+    /// resets the kitty-keyboard stacks when that flag differs and always
+    /// re-emits a title event, so the re-applied config must match this one
+    /// in every other field.
+    pub(super) term_config: Mutex<TermConfig>,
 }
 
 impl Terminal {
-    /// Create a new terminal
+    /// Create a new terminal, sized from the process-wide scrollback setting
+    /// (see [`set_process_scrollback_lines`]). Use [`Terminal::with_options`]
+    /// only when this terminal needs a depth different from every other one —
+    /// e.g. a client mirror of a project the user cannot currently see.
     pub fn new(
         terminal_id: String,
         size: TerminalSize,
         transport: Arc<dyn TerminalTransport>,
         initial_cwd: String,
+    ) -> Self {
+        Self::with_options(
+            terminal_id,
+            size,
+            transport,
+            initial_cwd,
+            TerminalOptions::default(),
+        )
+    }
+
+    /// Create a new terminal, sizing its scrollback from `options`.
+    pub fn with_options(
+        terminal_id: String,
+        size: TerminalSize,
+        transport: Arc<dyn TerminalTransport>,
+        initial_cwd: String,
+        options: TerminalOptions,
     ) -> Self {
         // Use HollowBlock as a sentinel for "app has not set a cursor shape
         // via DECSCUSR" — no real DECSCUSR code maps to HollowBlock, so if
@@ -375,6 +404,12 @@ impl Terminal {
             // (off by default). The actual security gate lives in Okena, not
             // here — alacritty just hands us the request.
             osc52: alacritty_terminal::term::Osc52::CopyPaste,
+            // Scrollback depth. alacritty's default is 10 000 lines, which at
+            // ~24 bytes per cell costs ~50 MB per fully-scrolled 200-column
+            // terminal — doubled, because the daemon and every client mirror
+            // keep their own grid. Honor the user's `scrollback_lines` setting
+            // instead of silently ignoring it.
+            scrolling_history: options.scrollback_lines as usize,
             ..TermConfig::default()
         };
         let term_size = TermSize::new(size.cols as usize, size.rows as usize);
@@ -402,7 +437,7 @@ impl Terminal {
             transport.clone(),
             terminal_id.clone(),
         );
-        let mut term = Term::new(config, &term_size, event_listener);
+        let mut term = Term::new(config.clone(), &term_size, event_listener);
         let mut processor = Processor::new();
         if let Some(modes) = transport.load_terminal_modes(&terminal_id) {
             processor.advance(&mut term, &modes.to_ansi());
@@ -459,6 +494,48 @@ impl Terminal {
             waiting_for_input: AtomicBool::new(false),
             had_user_input: AtomicBool::new(false),
             last_viewed_time: Arc::new(Mutex::new(Instant::now())),
+            term_config: Mutex::new(config),
         }
+    }
+
+    /// Resize the scrollback buffer of a live terminal.
+    ///
+    /// Shrinking drops the excess history immediately (alacritty's
+    /// `Grid::update_history` calls `Storage::shrink_lines`, which frees the
+    /// row allocations once more than one batch is spare); growing only raises
+    /// the cap, with rows allocated on demand. Used both when the user edits
+    /// `scrollback_lines` and when a project is hidden in every window, where
+    /// the client mirror does not need to hold history it cannot show.
+    ///
+    /// Only the *active* grid is updated, matching alacritty: a terminal
+    /// currently in the alternate screen keeps its primary-grid history until
+    /// this is called again after it leaves alt-screen.
+    pub fn set_scrollback_lines(&self, lines: u32) {
+        let mut config = self.term_config.lock();
+        if config.scrolling_history == lines as usize {
+            return;
+        }
+        config.scrolling_history = lines as usize;
+        let updated = config.clone();
+        drop(config);
+
+        use alacritty_terminal::grid::Dimensions;
+        let mut term = self.term.lock();
+        let before = term.grid().history_size();
+        term.set_options(updated);
+        let after = term.grid().history_size();
+        drop(term);
+
+        // Prompt marks are stored relative to the grid's top; dropping history
+        // rows invalidates the ones that fell off. `on_history_changed` only
+        // handles growth (it shifts marks down), so prune explicitly here.
+        if after < before {
+            self.prompt_tracker.lock().drop_marks_above(after);
+        }
+    }
+
+    /// The scrollback depth currently configured for this terminal.
+    pub fn scrollback_lines(&self) -> u32 {
+        self.term_config.lock().scrolling_history as u32
     }
 }

--- a/crates/okena-terminal/src/terminal/osc_sidecar.rs
+++ b/crates/okena-terminal/src/terminal/osc_sidecar.rs
@@ -34,6 +34,12 @@ pub struct TerminalNotification {
 const OSC99_MAX_FIELD_LEN: usize = 4096;
 const OSC99_MAX_PENDING: usize = 32;
 
+/// Cap on notifications queued for the host to raise. Both processes drain
+/// these every PTY batch, so this only bites if a drain stops (or a future
+/// caller forgets one) — but an undrained queue is per-terminal and unbounded,
+/// which is exactly how the OSC 52 queues grew in the daemon.
+const MAX_PENDING_NOTIFICATIONS: usize = 64;
+
 /// Reassembly buffer for a chunked `OSC 99` notification keyed by its `i=` id.
 #[derive(Default)]
 struct Osc99Accumulator {
@@ -204,7 +210,16 @@ impl SidecarPerform {
         } else {
             return; // nothing to show
         };
-        self.pending_notifications.lock().push(notification);
+        self.push_notification(notification);
+    }
+
+    /// Queue a notification for the host, dropping the oldest once saturated.
+    fn push_notification(&self, notification: TerminalNotification) {
+        let mut pending = self.pending_notifications.lock();
+        if pending.len() >= MAX_PENDING_NOTIFICATIONS {
+            pending.remove(0);
+        }
+        pending.push(notification);
     }
 
     /// Handle the ConEmu / Windows Terminal progress protocol
@@ -325,12 +340,10 @@ impl Perform for SidecarPerform {
                     .join(";");
                 let message = message.trim();
                 if !message.is_empty() {
-                    self.pending_notifications
-                        .lock()
-                        .push(TerminalNotification {
-                            title: None,
-                            body: message.to_string(),
-                        });
+                    self.push_notification(TerminalNotification {
+                        title: None,
+                        body: message.to_string(),
+                    });
                 }
             }
             b"777" => {
@@ -356,12 +369,10 @@ impl Perform for SidecarPerform {
                     .join(";");
                 let body = body.trim();
                 if !body.is_empty() {
-                    self.pending_notifications
-                        .lock()
-                        .push(TerminalNotification {
-                            title: (!title.is_empty()).then(|| title.to_string()),
-                            body: body.to_string(),
-                        });
+                    self.push_notification(TerminalNotification {
+                        title: (!title.is_empty()).then(|| title.to_string()),
+                        body: body.to_string(),
+                    });
                 }
             }
             b"99" => self.handle_osc99(params),

--- a/crates/okena-terminal/src/terminal/prompt_marks.rs
+++ b/crates/okena-terminal/src/terminal/prompt_marks.rs
@@ -60,6 +60,16 @@ impl PromptTracker {
         });
     }
 
+    /// Drop marks that no longer have a row, after the scrollback was
+    /// shrunk to `history_size` lines. `on_history_changed` only handles
+    /// growth (its `saturating_sub` makes a shrink a no-op), so an explicit
+    /// `set_scrollback_lines` has to prune here or stale marks would point
+    /// above the grid and `jump_to_prompt_*` would scroll nowhere.
+    pub(super) fn drop_marks_above(&mut self, history_size: usize) {
+        let topmost = -(history_size as i32);
+        self.marks.retain(|mark| mark.line >= topmost);
+    }
+
     pub(super) fn snapshot(&self) -> Vec<PromptMark> {
         self.marks.iter().copied().collect()
     }

--- a/crates/okena-terminal/src/terminal/tests/helpers.rs
+++ b/crates/okena-terminal/src/terminal/tests/helpers.rs
@@ -52,6 +52,34 @@ impl MirrorTransport {
     }
 }
 
+/// A PTY-owning transport in a headless process: it answers terminal queries
+/// (it owns the PTY) but reaches no system clipboard. Matches `PtyManager`
+/// inside the daemon.
+pub(crate) struct HeadlessOwnerTransport {
+    pub(crate) inner: CapturingTransport,
+}
+
+impl HeadlessOwnerTransport {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: CapturingTransport::new(),
+        }
+    }
+}
+
+impl TerminalTransport for HeadlessOwnerTransport {
+    fn send_input(&self, terminal_id: &str, data: &[u8]) {
+        self.inner.send_input(terminal_id, data);
+    }
+    fn resize(&self, _terminal_id: &str, _cols: u16, _rows: u16) {}
+    fn uses_mouse_backend(&self) -> bool {
+        false
+    }
+    fn handles_clipboard(&self) -> bool {
+        false
+    }
+}
+
 impl TerminalTransport for MirrorTransport {
     fn send_input(&self, terminal_id: &str, data: &[u8]) {
         self.inner.send_input(terminal_id, data);

--- a/crates/okena-terminal/src/terminal/tests/mod.rs
+++ b/crates/okena-terminal/src/terminal/tests/mod.rs
@@ -12,4 +12,6 @@ mod unread;
 mod url_detect;
 mod xterm_color;
 
-pub(crate) use helpers::{CapturingTransport, MirrorTransport, NullTransport};
+pub(crate) use helpers::{
+    CapturingTransport, HeadlessOwnerTransport, MirrorTransport, NullTransport,
+};

--- a/crates/okena-terminal/src/terminal/tests/mod.rs
+++ b/crates/okena-terminal/src/terminal/tests/mod.rs
@@ -6,6 +6,7 @@ mod modes;
 mod osc;
 mod prompt_jump;
 mod resize_authority;
+mod scrollback;
 mod snapshot_watermark;
 mod unread;
 mod url_detect;

--- a/crates/okena-terminal/src/terminal/tests/osc.rs
+++ b/crates/okena-terminal/src/terminal/tests/osc.rs
@@ -1251,3 +1251,94 @@ fn test_process_palette_answers_color_query_without_per_terminal_palette() {
         "unexpected reply: {reply:?}"
     );
 }
+
+// ── OSC 52 queue bounds ────────────────────────────────────────────────────
+//
+// The daemon parses the same byte stream as the UI but has no clipboard and no
+// drain, so anything queued there is never read and never freed. These pin
+// that it queues nothing, and that a side which does queue stays bounded.
+
+#[test]
+fn test_osc52_write_is_dropped_without_a_clipboard() {
+    let transport = Arc::new(super::HeadlessOwnerTransport::new());
+    let terminal = Terminal::new(
+        "t".into(),
+        TerminalSize::default(),
+        transport.clone(),
+        "/tmp".into(),
+    );
+
+    // base64("hello") — a normal editor yank travelling over OSC 52.
+    terminal.process_output(b"\x1b]52;c;aGVsbG8=\x07");
+
+    assert!(
+        terminal.take_pending_clipboard_writes().is_empty(),
+        "a process with no clipboard must not accumulate copy payloads"
+    );
+}
+
+#[test]
+fn test_osc52_read_is_dropped_without_a_clipboard() {
+    let transport = Arc::new(super::HeadlessOwnerTransport::new());
+    let terminal = Terminal::new(
+        "t".into(),
+        TerminalSize::default(),
+        transport.clone(),
+        "/tmp".into(),
+    );
+
+    terminal.process_output(b"\x1b]52;c;?\x07");
+
+    assert!(
+        !terminal.has_pending_clipboard_reads(),
+        "a process that cannot answer must not hold the responder"
+    );
+    assert!(
+        transport.inner.writes().is_empty(),
+        "and must not reply on its own: {:?}",
+        transport.inner.writes()
+    );
+}
+
+#[test]
+fn test_osc52_writes_stay_bounded_when_the_host_stops_draining() {
+    let transport = Arc::new(CapturingTransport::new());
+    let terminal = Terminal::new(
+        "t".into(),
+        TerminalSize::default(),
+        transport.clone(),
+        "/tmp".into(),
+    );
+
+    // 100 copies with no drain in between. Each payload is a whole clipboard
+    // buffer, so an unbounded queue here is a real memory hazard.
+    for _ in 0..100 {
+        terminal.process_output(b"\x1b]52;c;aGVsbG8=\x07");
+    }
+
+    let queued = terminal.take_pending_clipboard_writes();
+    assert_eq!(queued.len(), 16, "queue must be capped");
+    assert!(
+        queued.iter().all(|text| text == "hello"),
+        "the retained entries must still be the decoded payloads"
+    );
+}
+
+#[test]
+fn test_osc52_reads_stay_bounded_when_the_host_stops_draining() {
+    let transport = Arc::new(CapturingTransport::new());
+    let terminal = Terminal::new(
+        "t".into(),
+        TerminalSize::default(),
+        transport.clone(),
+        "/tmp".into(),
+    );
+
+    for _ in 0..100 {
+        terminal.process_output(b"\x1b]52;c;?\x07");
+    }
+
+    // Answering drains the queue and replies once per retained request.
+    terminal.answer_clipboard_reads("hi");
+    assert_eq!(transport.writes().len(), 32, "queue must be capped");
+}

--- a/crates/okena-terminal/src/terminal/tests/scrollback.rs
+++ b/crates/okena-terminal/src/terminal/tests/scrollback.rs
@@ -1,0 +1,171 @@
+//! Scrollback depth: construction-time sizing and runtime resizing.
+//!
+//! The grid is okena's dominant memory cost (24 bytes per cell × columns ×
+//! history), and it is paid twice — once in the daemon that owns the PTY and
+//! again in every client mirroring it. These tests pin that the user's
+//! `scrollback_lines` setting actually reaches alacritty, and that shrinking a
+//! live terminal really drops the rows rather than just capping future growth.
+
+use super::super::{Terminal, TerminalOptions, TerminalSize};
+use super::helpers::NullTransport;
+use alacritty_terminal::grid::Dimensions;
+use std::sync::Arc;
+
+fn terminal_with(scrollback_lines: u32) -> Terminal {
+    Terminal::with_options(
+        "scrollback-test".to_string(),
+        TerminalSize::default(),
+        Arc::new(NullTransport),
+        "/tmp".to_string(),
+        TerminalOptions::with_scrollback_lines(scrollback_lines),
+    )
+}
+
+fn feed_lines(terminal: &Terminal, count: usize) {
+    for i in 0..count {
+        terminal.process_output(format!("line {i}\r\n").as_bytes());
+    }
+}
+
+fn history_size(terminal: &Terminal) -> usize {
+    terminal.with_content(|term| term.grid().history_size())
+}
+
+#[test]
+fn options_cap_the_history_at_the_configured_depth() {
+    let terminal = terminal_with(200);
+    feed_lines(&terminal, 1000);
+
+    assert_eq!(
+        history_size(&terminal),
+        200,
+        "history must stop growing at the configured scrollback depth"
+    );
+}
+
+#[test]
+fn default_options_keep_alacrittys_ten_thousand_lines() {
+    let terminal = Terminal::new(
+        "default-scrollback".to_string(),
+        TerminalSize::default(),
+        Arc::new(NullTransport),
+        "/tmp".to_string(),
+    );
+
+    assert_eq!(terminal.scrollback_lines(), 10_000);
+}
+
+#[test]
+fn shrinking_drops_history_rows() {
+    let terminal = terminal_with(500);
+    feed_lines(&terminal, 1000);
+    assert_eq!(history_size(&terminal), 500);
+
+    terminal.set_scrollback_lines(50);
+
+    assert_eq!(
+        history_size(&terminal),
+        50,
+        "shrinking must truncate existing history, not just cap future growth"
+    );
+    assert_eq!(terminal.scrollback_lines(), 50);
+}
+
+#[test]
+fn shrinking_to_zero_leaves_only_the_viewport() {
+    let terminal = terminal_with(500);
+    feed_lines(&terminal, 1000);
+
+    // What hiding a project does to a client mirror: keep the visible rows,
+    // drop everything the user cannot see.
+    terminal.set_scrollback_lines(0);
+
+    assert_eq!(history_size(&terminal), 0);
+    let visible = terminal.with_content(|term| term.grid().screen_lines());
+    assert_eq!(visible, TerminalSize::default().rows as usize);
+}
+
+#[test]
+fn growing_again_lets_history_refill() {
+    let terminal = terminal_with(500);
+    feed_lines(&terminal, 1000);
+    terminal.set_scrollback_lines(0);
+    assert_eq!(history_size(&terminal), 0);
+
+    // Showing the project again restores the cap; new output refills history.
+    terminal.set_scrollback_lines(500);
+    feed_lines(&terminal, 300);
+
+    assert_eq!(history_size(&terminal), 300);
+}
+
+#[test]
+fn resizing_scrollback_preserves_the_rest_of_the_config() {
+    let terminal = terminal_with(500);
+    // Kitty keyboard support is enabled in the config literal; `set_options`
+    // resets the keyboard-mode stacks when that flag differs between the old
+    // and new config, so a scrollback change must not disturb it.
+    terminal.process_output(b"\x1b[>1u");
+    assert!(
+        terminal
+            .kitty_keyboard_flags()
+            .disambiguate_escape_codes,
+        "expected the app's kitty keyboard request to take effect"
+    );
+
+    terminal.set_scrollback_lines(100);
+
+    assert!(
+        terminal
+            .kitty_keyboard_flags()
+            .disambiguate_escape_codes,
+        "changing scrollback must not reset kitty keyboard state"
+    );
+}
+
+#[test]
+fn setting_the_same_depth_is_a_no_op() {
+    let terminal = terminal_with(500);
+    feed_lines(&terminal, 1000);
+    terminal.process_output(b"\x1b]0;my title\x07");
+
+    terminal.set_scrollback_lines(500);
+
+    // `Term::set_options` unconditionally re-emits a title event, which would
+    // clobber the OSC-set title with a reset. Skipping the no-op call avoids it.
+    assert_eq!(terminal.title(), Some("my title".to_string()));
+    assert_eq!(history_size(&terminal), 500);
+}
+
+#[test]
+fn resizing_scrollback_preserves_an_app_set_title() {
+    let terminal = terminal_with(500);
+    terminal.process_output(b"\x1b]0;my title\x07");
+
+    // `Term::set_options` always re-emits a title event, which reaches our
+    // shared title through the listener. It replays the term's own title, so
+    // an OSC-set title must survive a real depth change too.
+    terminal.set_scrollback_lines(100);
+
+    assert_eq!(terminal.title(), Some("my title".to_string()));
+}
+
+#[test]
+fn shrinking_drops_prompt_marks_that_fell_out_of_history() {
+    let terminal = terminal_with(500);
+
+    // Emit a prompt mark, then push it deep into scrollback.
+    terminal.process_output(b"\x1b]133;A\x07prompt$ ");
+    feed_lines(&terminal, 300);
+    assert!(
+        !terminal.prompt_marks().is_empty(),
+        "expected the OSC 133 mark to be tracked while it is still in history"
+    );
+
+    terminal.set_scrollback_lines(10);
+
+    assert!(
+        terminal.prompt_marks().is_empty(),
+        "marks whose rows were freed must be dropped, not left pointing above the grid"
+    );
+}

--- a/crates/okena-terminal/src/terminal/tests/scrollback.rs
+++ b/crates/okena-terminal/src/terminal/tests/scrollback.rs
@@ -151,6 +151,29 @@ fn resizing_scrollback_preserves_an_app_set_title() {
 }
 
 #[test]
+fn shrinking_works_while_the_app_is_in_the_alternate_screen() {
+    let terminal = terminal_with(500);
+    feed_lines(&terminal, 1000);
+    assert_eq!(history_size(&terminal), 500);
+
+    // Enter the alternate screen, as a full-screen app (vim, less, a TUI) does.
+    // alacritty swaps the grids, so the primary — the one holding the history —
+    // becomes the *inactive* grid, which is what `set_options` then resizes.
+    // A long-running agent left in a TUI is exactly the terminal we most want
+    // to reclaim, so this must work without waiting for it to exit.
+    terminal.process_output(b"\x1b[?1049h");
+
+    terminal.set_scrollback_lines(0);
+
+    terminal.process_output(b"\x1b[?1049l");
+    assert_eq!(
+        history_size(&terminal),
+        0,
+        "history must be freed even when the shrink happened during alt-screen"
+    );
+}
+
+#[test]
 fn shrinking_drops_prompt_marks_that_fell_out_of_history() {
     let terminal = terminal_with(500);
 

--- a/crates/okena-terminal/src/terminal/transport.rs
+++ b/crates/okena-terminal/src/terminal/transport.rs
@@ -26,6 +26,18 @@ pub trait TerminalTransport: Send + Sync {
     fn answers_terminal_queries(&self) -> bool {
         true
     }
+    /// Whether this side reaches a system clipboard, and so should queue OSC 52
+    /// requests for someone to service.
+    ///
+    /// True only in a process with a UI. The daemon parses the same byte stream
+    /// into its own emulator but has no clipboard and no drain, so anything
+    /// queued there is never read and never freed — every `printf '\e]52;c;…'`
+    /// from nvim, tmux or a `pbcopy` shim would accumulate for the life of the
+    /// terminal. Kept separate from [`Self::answers_terminal_queries`], which
+    /// asks the opposite question (does this side own the PTY).
+    fn handles_clipboard(&self) -> bool {
+        true
+    }
     /// Load terminal modes retained by a transparent persistent session backend.
     fn load_terminal_modes(&self, _terminal_id: &str) -> Option<TerminalModeState> {
         None

--- a/crates/okena-terminal/src/terminal/types.rs
+++ b/crates/okena-terminal/src/terminal/types.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+
 /// Formatter for an OSC 52 clipboard *read* request.
 ///
 /// `alacritty_terminal` hands us this closure with the
@@ -26,6 +28,61 @@ impl Default for TerminalSize {
             cell_width: 8.0,
             cell_height: 16.0,
         }
+    }
+}
+
+/// Construction-time knobs for a [`super::Terminal`].
+///
+/// Currently just the scrollback depth, which is the single biggest lever on
+/// okena's memory use: alacritty stores 24 bytes per cell, so a 200-column
+/// terminal that fills the default 10 000-line history costs ~50 MB — once in
+/// the daemon that owns the PTY, and again in every client mirroring it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TerminalOptions {
+    /// Lines of scrollback to retain. Mirrors `AppSettings::scrollback_lines`,
+    /// which the settings layer clamps to 100..=100 000.
+    pub scrollback_lines: u32,
+}
+
+/// alacritty's own default, kept as ours so terminals built without settings
+/// in reach behave exactly as they did before this knob existed.
+pub const DEFAULT_SCROLLBACK_LINES: u32 = 10_000;
+
+/// Process-wide scrollback depth applied to terminals built without explicit
+/// options. Set at boot and on settings changes via
+/// [`set_process_scrollback_lines`], mirroring how the process palette reaches
+/// terminals that have no view to push one.
+///
+/// A global rather than a constructor argument because scrollback is one
+/// user-level setting shared by every terminal in the process, while terminals
+/// are constructed from a dozen places (hook runner, service manager, remote
+/// client, panes) that mostly have no route to `AppSettings`.
+static PROCESS_SCROLLBACK_LINES: AtomicU32 = AtomicU32::new(DEFAULT_SCROLLBACK_LINES);
+
+/// Set the process-wide default scrollback depth for terminals created from
+/// here on. Existing terminals are unaffected — call
+/// [`super::Terminal::set_scrollback_lines`] on them to resize a live grid.
+pub fn set_process_scrollback_lines(lines: u32) {
+    PROCESS_SCROLLBACK_LINES.store(lines, Ordering::Relaxed);
+}
+
+/// The current process-wide default scrollback depth.
+pub fn process_scrollback_lines() -> u32 {
+    PROCESS_SCROLLBACK_LINES.load(Ordering::Relaxed)
+}
+
+impl Default for TerminalOptions {
+    fn default() -> Self {
+        Self {
+            scrollback_lines: process_scrollback_lines(),
+        }
+    }
+}
+
+impl TerminalOptions {
+    /// Options with an explicit scrollback depth.
+    pub fn with_scrollback_lines(scrollback_lines: u32) -> Self {
+        Self { scrollback_lines }
     }
 }
 

--- a/crates/okena-transport/src/client/state.rs
+++ b/crates/okena-transport/src/client/state.rs
@@ -250,6 +250,7 @@ mod tests {
             hook_type: "on_worktree_create".to_string(),
             command: "echo hi".to_string(),
             cwd: "/tmp".to_string(),
+            finished_at: None,
         });
         let state = make_state(vec![proj]);
 

--- a/crates/okena-tui/src/main.rs
+++ b/crates/okena-tui/src/main.rs
@@ -96,6 +96,12 @@ impl TerminalTransport for TuiRemoteTransport {
     fn answers_terminal_queries(&self) -> bool {
         REMOTE_TERMINAL_ANSWERS_QUERIES
     }
+
+    /// The proof-of-concept TUI has no clipboard integration and never drains
+    /// the OSC 52 queues, so queueing there would only leak.
+    fn handles_clipboard(&self) -> bool {
+        false
+    }
 }
 
 struct TuiConnectionHandler {

--- a/crates/okena-workspace/src/actions/project.rs
+++ b/crates/okena-workspace/src/actions/project.rs
@@ -1489,6 +1489,7 @@ mod tests {
                 hook_type: "on_project_open".to_string(),
                 command: "echo old".to_string(),
                 cwd: "/tmp".to_string(),
+                finished_at: None,
             },
         );
         project
@@ -1530,6 +1531,7 @@ mod tests {
                 hook_type: "on_project_open".to_string(),
                 command: "echo old".to_string(),
                 cwd: "/tmp".to_string(),
+                finished_at: None,
             },
         );
 
@@ -3461,6 +3463,7 @@ mod gpui_tests {
                 hook_type: "project.on_open".to_string(),
                 command: "echo done".to_string(),
                 cwd: descendant_path.to_string_lossy().into_owned(),
+                finished_at: None,
             },
         );
         let mut data = make_workspace_data();

--- a/crates/okena-workspace/src/persistence.rs
+++ b/crates/okena-workspace/src/persistence.rs
@@ -2736,6 +2736,7 @@ mod tests {
                 hook_type: "on_project_open".to_string(),
                 command: "echo hook".to_string(),
                 cwd: "C:\\repo".to_string(),
+                finished_at: None,
             },
         );
         let mut data = make_workspace(

--- a/crates/okena-workspace/src/persistence.rs
+++ b/crates/okena-workspace/src/persistence.rs
@@ -1746,6 +1746,7 @@ mod tests {
                 hook_type: "on_project_open".to_string(),
                 command: "echo hello".to_string(),
                 cwd: "/tmp".to_string(),
+                finished_at: None,
             },
         );
 
@@ -2654,6 +2655,7 @@ mod tests {
                 hook_type: "on_project_open".to_string(),
                 command: "echo hook".to_string(),
                 cwd: "/tmp".to_string(),
+                finished_at: None,
             },
         );
 

--- a/crates/okena-workspace/src/remote_apply.rs
+++ b/crates/okena-workspace/src/remote_apply.rs
@@ -635,6 +635,7 @@ mod tests {
             hook_type: "on_project_open".into(),
             command: "make".into(),
             cwd: "/srv/a".into(),
+            finished_at: None,
         }];
         let snap = RemoteSnapshot {
             config: config("c1"),

--- a/crates/okena-workspace/src/settings.rs
+++ b/crates/okena-workspace/src/settings.rs
@@ -1042,6 +1042,16 @@ mod tests {
     }
 
     #[test]
+    fn recover_clamps_scrollback_up_to_the_floor() {
+        // The lower bound matters now that `scrollback_lines` actually sizes
+        // the alacritty grid: a tiny value would leave the user unable to
+        // scroll back at all, and 0 would be indistinguishable from the
+        // "hidden project" state the client uses to free a mirror's history.
+        let recovered = recover_settings_from_json(r#"{"scrollback_lines": 10}"#).unwrap();
+        assert_eq!(recovered.scrollback_lines, 100);
+    }
+
+    #[test]
     fn recover_all_garbage_fields_returns_defaults() {
         // Valid JSON object, but every value has the wrong type.
         let json = r#"{

--- a/crates/okena-workspace/src/state.rs
+++ b/crates/okena-workspace/src/state.rs
@@ -1895,6 +1895,22 @@ impl Workspace {
             .unwrap_or_default()
     }
 
+    /// Every terminal id belonging to a project: its layout tree plus its hook
+    /// terminals, which live outside the tree but are real terminals all the
+    /// same. In a client mirror these are the registry's own keys.
+    pub fn all_terminal_ids_for_project(&self, project_id: &str) -> Vec<String> {
+        let Some(project) = self.project(project_id) else {
+            return Vec::new();
+        };
+        let mut ids = project
+            .layout
+            .as_ref()
+            .map(|layout| layout.collect_terminal_ids())
+            .unwrap_or_default();
+        ids.extend(project.hook_terminals.keys().cloned());
+        ids
+    }
+
     /// Swap a hook terminal's ID (for rerun). Updates hook_terminals, layout tree, and terminal_names.
     /// Resets status back to Running.
     pub fn swap_hook_terminal_id(
@@ -4196,6 +4212,26 @@ mod gpui_tests {
         );
 
         assert!(stale.is_empty());
+    }
+
+    #[gpui::test]
+    fn project_terminal_ids_cover_the_layout_and_the_hooks(cx: &mut gpui::TestAppContext) {
+        // The client's hidden-project scrollback pass walks these ids, so a
+        // hook terminal missing here would keep a full grid while hidden.
+        // `make_project` gives p1 a layout holding one terminal, `term_p1`.
+        let data = make_workspace_data(vec![make_project("p1")], vec!["p1"]);
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            ws.register_hook_terminal("p1", "hook-1", make_hook_entry("on_project_open"), cx);
+        });
+
+        workspace.read_with(cx, |ws: &Workspace, _cx| {
+            let mut ids = ws.all_terminal_ids_for_project("p1");
+            ids.sort();
+            assert_eq!(ids, vec!["hook-1".to_string(), "term_p1".to_string()]);
+            assert!(ws.all_terminal_ids_for_project("missing").is_empty());
+        });
     }
 
     #[gpui::test]

--- a/crates/okena-workspace/src/state.rs
+++ b/crates/okena-workspace/src/state.rs
@@ -25,7 +25,7 @@ pub use okena_layout::{LayoutNode, SplitDirection};
 pub use okena_state::{
     DropZone, FocusedTerminalState, FolderData, HookTerminalEntry, HookTerminalStatus,
     PendingWorktreeClose, ProjectData, ProjectLayoutMode, WindowBounds, WindowId, WindowState,
-    WorkspaceData, WorktreeMetadata,
+    WorkspaceData, WorktreeMetadata, now_unix_seconds,
 };
 
 /// What a window is focused on, captured before a sync reshapes the layout.
@@ -1775,6 +1775,7 @@ impl Workspace {
                     hook_type: result.hook_type.to_string(),
                     command: result.command,
                     cwd: result.cwd,
+                    finished_at: None,
                 },
                 cx,
             );
@@ -1790,12 +1791,63 @@ impl Workspace {
         for project in &mut self.data.projects {
             if let Some(entry) = project.hook_terminals.get_mut(terminal_id) {
                 if entry.status != status {
+                    // Stamp when it stopped running, so the oldest finished
+                    // hooks can be evicted before they accumulate. Set only on
+                    // the transition, so a re-reported status keeps the
+                    // original time.
+                    entry.finished_at = match status {
+                        HookTerminalStatus::Running => None,
+                        _ => Some(crate::state::now_unix_seconds()),
+                    };
                     entry.status = status;
                     cx.notify();
                 }
                 return;
             }
         }
+    }
+
+    /// Finished hook terminals to retire, keeping the `keep` most recent.
+    ///
+    /// A hook terminal that completes on a normal path is kept forever: its
+    /// entry persists, and its `Arc<Terminal>` keeps a full scrollback grid in
+    /// the daemon plus one in every client mirroring it. Only a manual dismiss
+    /// ever removed one, so a project whose hooks run on every worktree
+    /// operation accumulates them for the life of the workspace.
+    ///
+    /// Running hooks are never candidates. Successes go before failures at the
+    /// same age, since a failure is the one the user still wants to read.
+    /// Entries with no `finished_at` (written before the field existed) sort
+    /// oldest.
+    pub fn finished_hook_terminals_to_evict(&self, project_id: &str, keep: usize) -> Vec<String> {
+        let Some(project) = self.project(project_id) else {
+            return Vec::new();
+        };
+        let mut finished: Vec<(&String, &HookTerminalEntry)> = project
+            .hook_terminals
+            .iter()
+            .filter(|(_, entry)| entry.status != HookTerminalStatus::Running)
+            .collect();
+        if finished.len() <= keep {
+            return Vec::new();
+        }
+        // Newest first, so the tail past `keep` is what goes.
+        finished.sort_by(|(a_id, a), (b_id, b)| {
+            let failed = |entry: &HookTerminalEntry| {
+                matches!(entry.status, HookTerminalStatus::Failed { .. })
+            };
+            failed(b)
+                .cmp(&failed(a))
+                .then(b.finished_at.cmp(&a.finished_at))
+                // Ids last, so the order is total and eviction is deterministic
+                // for entries that finished within the same second.
+                .then(b_id.cmp(a_id))
+        });
+        finished
+            .split_off(keep)
+            .into_iter()
+            .map(|(id, _)| id.clone())
+            .collect()
     }
 
     pub fn remove_hook_terminal(&mut self, terminal_id: &str, cx: &mut impl WorkspaceCx) {
@@ -2326,6 +2378,7 @@ mod workspace_tests {
                 hook_type: "before_worktree_remove".into(),
                 command: "true".into(),
                 cwd: "/tmp".into(),
+                finished_at: None,
             },
         );
         let mut workspace = Workspace::new(make_workspace_data(vec![project], vec!["wt1"]));
@@ -2405,6 +2458,7 @@ mod workspace_tests {
                 hook_type: "project.on_open".to_string(),
                 command: "echo hook".to_string(),
                 cwd: "/tmp/test".to_string(),
+                finished_at: None,
             },
         );
         project
@@ -2761,6 +2815,7 @@ mod workspace_tests {
                 hook_type: "project.on_open".to_string(),
                 command: "echo done".to_string(),
                 cwd: "/tmp/test".to_string(),
+                finished_at: None,
             },
         );
         project.hook_terminals.insert(
@@ -2771,6 +2826,7 @@ mod workspace_tests {
                 hook_type: "project.on_open".to_string(),
                 command: "sleep 10".to_string(),
                 cwd: "/tmp/test".to_string(),
+                finished_at: None,
             },
         );
         project
@@ -4026,7 +4082,147 @@ mod gpui_tests {
             hook_type: hook_type.to_string(),
             command: "echo test".to_string(),
             cwd: ".".to_string(),
+            finished_at: None,
         }
+    }
+
+    fn finished_hook_entry(status: HookTerminalStatus, finished_at: Option<u64>) -> HookTerminalEntry {
+        HookTerminalEntry {
+            status,
+            finished_at,
+            ..make_hook_entry("on_project_open")
+        }
+    }
+
+    /// Build a project holding the given `(terminal_id, entry)` hook terminals.
+    fn project_with_hooks(id: &str, hooks: Vec<(&str, HookTerminalEntry)>) -> ProjectData {
+        let mut project = make_project(id);
+        for (terminal_id, entry) in hooks {
+            project
+                .hook_terminals
+                .insert(terminal_id.to_string(), entry);
+        }
+        project
+    }
+
+    fn evict_from(project: ProjectData, keep: usize) -> Vec<String> {
+        let id = project.id.clone();
+        let ws = Workspace::new(make_workspace_data(vec![project], vec![&id]));
+        ws.finished_hook_terminals_to_evict(&id, keep)
+    }
+
+    #[test]
+    fn eviction_keeps_the_most_recent_finished_hooks() {
+        let stale = evict_from(
+            project_with_hooks(
+                "p1",
+                vec![
+                    ("old", finished_hook_entry(HookTerminalStatus::Succeeded, Some(100))),
+                    ("mid", finished_hook_entry(HookTerminalStatus::Succeeded, Some(200))),
+                    ("new", finished_hook_entry(HookTerminalStatus::Succeeded, Some(300))),
+                ],
+            ),
+            2,
+        );
+
+        assert_eq!(stale, vec!["old".to_string()]);
+    }
+
+    #[test]
+    fn eviction_never_touches_a_running_hook() {
+        // Two finished and one still running, keeping one: only a finished hook
+        // may go, and the running one must not count toward the budget.
+        let stale = evict_from(
+            project_with_hooks(
+                "p1",
+                vec![
+                    ("running", make_hook_entry("on_project_open")),
+                    ("old", finished_hook_entry(HookTerminalStatus::Succeeded, Some(100))),
+                    ("new", finished_hook_entry(HookTerminalStatus::Succeeded, Some(200))),
+                ],
+            ),
+            1,
+        );
+
+        assert_eq!(stale, vec!["old".to_string()]);
+    }
+
+    #[test]
+    fn eviction_prefers_dropping_successes_over_failures() {
+        // A failure is the one the user still wants to read, so it outranks a
+        // newer success when something has to go.
+        let stale = evict_from(
+            project_with_hooks(
+                "p1",
+                vec![
+                    (
+                        "failed",
+                        finished_hook_entry(HookTerminalStatus::Failed { exit_code: 1 }, Some(100)),
+                    ),
+                    ("succeeded", finished_hook_entry(HookTerminalStatus::Succeeded, Some(200))),
+                ],
+            ),
+            1,
+        );
+
+        assert_eq!(stale, vec!["succeeded".to_string()]);
+    }
+
+    #[test]
+    fn eviction_treats_entries_without_a_finish_time_as_oldest() {
+        // Written before `finished_at` existed, so they carry no timestamp.
+        let stale = evict_from(
+            project_with_hooks(
+                "p1",
+                vec![
+                    ("legacy", finished_hook_entry(HookTerminalStatus::Succeeded, None)),
+                    ("recent", finished_hook_entry(HookTerminalStatus::Succeeded, Some(200))),
+                ],
+            ),
+            1,
+        );
+
+        assert_eq!(stale, vec!["legacy".to_string()]);
+    }
+
+    #[test]
+    fn eviction_is_a_no_op_within_budget() {
+        let stale = evict_from(
+            project_with_hooks(
+                "p1",
+                vec![("only", finished_hook_entry(HookTerminalStatus::Succeeded, Some(100)))],
+            ),
+            5,
+        );
+
+        assert!(stale.is_empty());
+    }
+
+    #[gpui::test]
+    fn finishing_a_hook_stamps_when_it_stopped(cx: &mut gpui::TestAppContext) {
+        let data = make_workspace_data(vec![make_project("p1")], vec!["p1"]);
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        workspace.update(cx, |ws: &mut Workspace, cx| {
+            ws.register_hook_terminal("p1", "hook-1", make_hook_entry("on_project_open"), cx);
+            assert!(
+                ws.project("p1").unwrap().hook_terminals["hook-1"]
+                    .finished_at
+                    .is_none(),
+                "a running hook has no finish time"
+            );
+
+            ws.update_hook_terminal_status("hook-1", HookTerminalStatus::Succeeded, cx);
+        });
+
+        workspace.read_with(cx, |ws: &Workspace, _cx| {
+            assert!(
+                ws.project("p1").unwrap().hook_terminals["hook-1"]
+                    .finished_at
+                    .is_some(),
+                "finishing must stamp a time so eviction can order candidates"
+            );
+        });
     }
 
     #[gpui::test]
@@ -4133,6 +4329,7 @@ mod gpui_tests {
                     hook_type: "on_project_open".to_string(),
                     command: "echo test".to_string(),
                     cwd: ".".to_string(),
+                    finished_at: None,
                 },
                 cx,
             );

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -173,6 +173,8 @@ export interface ApiHookTerminalEntry {
   hook_type: string;
   command: string;
   cwd: string;
+  /** Unix seconds at which the hook finished; absent while it is running. */
+  finished_at?: number | null;
 }
 
 export interface ApiProjectHooks {


### PR DESCRIPTION
A long-running okena climbs to several GB. Most of it turned out to be
retained-by-design state with no eviction rather than a classic leak, plus
one genuine unbounded queue.

Measured on a 6-day-old instance: 942 MB in the GUI, 301 MB in the daemon,
48 terminals across 72 projects of which 35 were hidden. The Rust heap was
443 MB in the GUI and 289 MB in the daemon, most of it swapped out — the
signature of data nobody reads again.

## What was wrong

**Scrollback was hardcoded.** `Terminal::new` spread `..TermConfig::default()`,
so alacritty's 10 000-line history applied always and the `scrollback_lines`
setting — UI control, clamp, persistence and all — was read by nothing. The
grid is the dominant cost at 24 bytes per cell, and it is paid twice: once in
the daemon that owns the PTY, once in every client mirroring it.

**The daemon queued clipboard payloads it never read.** Both processes parse
the same PTY stream, so both queued every OSC 52 request, but only the UI
drains them. In the daemon it was pure leak: whole clipboard buffers, per
terminal, for the life of the terminal. Every yank in nvim or helix with
`clipboard=unnamedplus`, every tmux copy, every `pbcopy` shim over SSH.

**The client kept history for projects nobody was looking at.** It mirrors
every terminal so bells, notifications and titles from background projects
still reach the user. It does not need their scrollback — no pane can scroll
what is off screen.

**Finished hook terminals were kept forever**, each holding a grid in both
processes, until dismissed by hand.

**Docker pollers parked a thread each.** Every project polling status blocked
on the shared `docker ps` single-flight lock, up to a 3s timeout, every 5s.
The blocking pool retires idle threads between ticks, so they were respawned
each cycle — 1.28 million thread spawns in six days, all waiting to read a
value another thread was already fetching.

## Effect

Per terminal at 200 columns after 50 000 lines of output, measured against the
patched crate:

| Scrollback | Heap |
|---|---|
| 10 000 (the old hardcoded value) | 48.8 MB |
| 2 000 (a user-chosen value) | 11.7 MB |
| 0 (hidden project, client side) | 2.5 MB |

Hiding a project drops a filled terminal from 48.8 MB to 3.0 MB. Five hundred
undrained 60 KB clipboard copies now retain nothing in the daemon, and cap at
16 entries in the UI instead of growing without limit.

## Notes for review

The scrollback depth travels as a process-wide default rather than a
constructor argument, following how the terminal palette already reaches
terminals in the headless daemon — they are built from a dozen call sites,
most with no route to `AppSettings`. Live grids resize in place, so lowering
the setting frees memory immediately rather than only capping future growth.

`TerminalTransport::handles_clipboard` is deliberately separate from the
existing `answers_terminal_queries`, which asks the opposite question: the
daemon owns the PTY and has no clipboard. Clients still service OSC 52,
because what crosses the wire is raw PTY bytes, not the daemon's parse.

Scrollback recorded while a project is hidden is lost when it is shown again.
That is the trade the web client already makes — it unsubscribes on project
switch and drops the buffer outright.

`HookTerminalEntry` gains `finished_at` to order eviction. It is
`#[serde(default)]`, so existing workspaces load; entries written before it
sort oldest, which is what eviction wants anyway.

## Verification

`cargo build`, `cargo build --release`, and `cargo test --workspace` all pass
(1847 tests). Two suites, in `okena-files` and `okena-remote-client`, flake
under a loaded parallel run — a temp-directory name collision and a
nonblocking socket read. Both pass in isolation, both predate this branch, and
neither crate is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UeLJkqsTrf1Nx2F8VvPSY