### PR TITLE
Change Folder Path for projects, plus git badge legibility and agent-docs fixes

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,6 +1,9 @@
-# Commit
+---
+description: Commit staged and unstaged changes following Okena's message and splitting conventions.
+allowed-tools: Bash(git:*)
+---
 
-Commit staged and unstaged changes following the rules below.
+# Commit
 
 ## Commit message format
 
@@ -17,18 +20,9 @@ Types: `feat`, `fix`, `refactor`, `perf`, `chore`, `ci`, `docs`, `test`
 - Keep the first line under 72 characters
 - Add a blank line + body only if the "why" isn't obvious from the summary
 
-## Splitting into logical commits
+## Splitting and staging
 
-- If you have context about what work was done (e.g. you just finished implementing something), commit **only** that work. Don't bundle unrelated changes — leave other unstaged/untracked changes alone.
-- You MAY split your work into multiple logical commits if it makes sense (e.g. a refactor commit + a feature commit, or separating test changes from implementation).
-- If you have no prior context, read `git diff` and `git diff --cached` to understand all changes, then group them into reasonable logical commits by topic/purpose. If some changes appear unrelated to each other and you can't determine what belongs together, ask before committing.
-- Each commit should be self-contained and buildable on its own when possible.
-
-## Procedure
-
-1. Run `git status` and `git diff` (staged + unstaged) to see all changes.
-2. Review the changes and decide how to split them into commits (if needed).
-3. For each commit:
-   - Stage the relevant files with `git add <specific files>` (never `git add -A` or `git add .`)
-   - Create the commit
-4. Run `git status` after all commits to verify nothing was missed.
+Group unrelated changes into separate commits; each one should compile on its own
+(`cargo check`). Stage files explicitly — never `git add -A` or `git add .`, since
+this tree routinely carries worktree and cross-branch edits that are not yours to
+commit (see the Git Rules in the root `CLAUDE.md`).

--- a/.claude/skills/duplicate-detection/SKILL.md
+++ b/.claude/skills/duplicate-detection/SKILL.md
@@ -17,7 +17,7 @@ Use this skill to turn clone reports into small, safe refactors. Prefer removing
 2. Generate duplicate reports.
    - Use at least one structural or token-based detector.
    - Exclude generated output, vendored dependencies, build artifacts, lockfiles, snapshots, and large fixtures unless the user explicitly wants them included.
-   - Save reports under `/tmp` or another disposable path; do not commit report output unless asked.
+   - Save reports under `.mine/` at the repo root — it is git-ignored, so report output can never be committed, and it survives a reboot alongside the repo it describes.
 
 3. Triage the reports before editing.
    - Prioritize logic that can drift: policy checks, wire protocol construction, persistence, filesystem/process/network behavior, lifecycle transitions, cache invalidation, notifications, and cross-entrypoint behavior.
@@ -47,7 +47,7 @@ cargo dupes --path . \
   --min-lines 8 \
   --min-nodes 20 \
   --threshold 0.85 \
-  --format json report > /tmp/duplicate-detection-cargo-dupes.json
+  --format json report > .mine/duplicate-detection-cargo-dupes.json
 ```
 
 If it is missing and installing tools is acceptable in the environment:
@@ -64,7 +64,7 @@ jq -s '.[0] | {
   exact_lines: .exact_duplicate_lines,
   near_groups: .near_duplicate_groups,
   near_lines: .near_duplicate_lines
-}' /tmp/duplicate-detection-cargo-dupes.json
+}' .mine/duplicate-detection-cargo-dupes.json
 ```
 
 Run normal Rust quality gates for changed behavior:
@@ -86,7 +86,7 @@ npx --yes jscpd@5 . \
   --min-tokens 80 \
   --ignore "**/target/**,**/.git/**,**/node_modules/**,**/dist/**,**/build/**,**/coverage/**,**/Cargo.lock,**/package-lock.json,**/pnpm-lock.yaml,**/yarn.lock" \
   --reporters json,silent \
-  --output /tmp/duplicate-detection-jscpd
+  --output .mine/duplicate-detection-jscpd
 ```
 
 When the repo is mostly Rust, add `--format rust` to reduce noise. For mixed repos, let `jscpd` auto-detect formats or pass a comma-separated format list.
@@ -98,7 +98,7 @@ jq '.statistics.total | {
   clones: .clones,
   duplicated_lines: .duplicatedLines,
   duplicated_percentage: .percentage
-}' /tmp/duplicate-detection-jscpd/jscpd-report.json
+}' .mine/duplicate-detection-jscpd/jscpd-report.json
 ```
 
 ## Review Heuristics

--- a/.claude/skills/ui-screenshot/SKILL.md
+++ b/.claude/skills/ui-screenshot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-screenshot
-description: Look at Okena's UI by taking a real screenshot of the running app, headlessly — nothing appears on the user's desktop and their live Okena instance is untouched. Use whenever a change is visual (layout, spacing, colors, a new widget, "make it prettier") and you need to see the result, or when a GPUI element renders nothing and you need to find out why. Triggers on "screenshot the app", "how does it look", "is it visible", "verify the UI", "the element doesn't render".
+description: Look at Okena's UI by taking a real screenshot of the running app, headlessly — nothing appears on the user's desktop and their live Okena instance is untouched. Linux/GNOME hosts only: the capture harness needs gnome-shell >= 45, and there is no macOS or Windows path. Use whenever a change is visual (layout, spacing, colors, a new widget, "make it prettier") and you need to see the result, or when a GPUI element renders nothing and you need to find out why. Triggers on "screenshot the app", "how does it look", "is it visible", "verify the UI", "the element doesn't render".
 ---
 
 # Seeing Okena's UI
@@ -10,6 +10,12 @@ GPUI will happily lay an element out at the wrong coordinates and clip every
 quad you paint. Take a screenshot.
 
 ## Run it
+
+Linux with GNOME only. `command -v gnome-shell` first: the harness nests a real
+`gnome-shell --headless`, and there is no macOS or Windows equivalent here. On
+those hosts say the screenshot is unavailable rather than reaching for a
+substitute — a debug build on the real display is the thing this skill exists to
+avoid.
 
 ```bash
 cargo build

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ Thumbs.db
 .ralph-tui/
 settings.local.json
 
+# Agent/human scratch: analysis notes, tool reports, draft comments.
+# Checked-in skills point here (see .claude/skills/duplicate-detection/SKILL.md),
+# so the ignore has to live in the repo, not in a personal excludes file.
+.mine/
+
 dist
 
 # Mobile (React Native)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6596,6 +6596,7 @@ dependencies = [
 name = "okena-views-sidebar"
 version = "0.1.0"
 dependencies = [
+ "dirs 5.0.1",
  "gpui",
  "gpui-component",
  "log",

--- a/crates/okena-app-core/src/workspace/actions/execute/mod.rs
+++ b/crates/okena-app-core/src/workspace/actions/execute/mod.rs
@@ -520,6 +520,10 @@ pub fn execute_action(
             project_id,
             new_name,
         } => project::rename_project_directory(ws, project_id, new_name, cx),
+        ActionRequest::ChangeProjectPath {
+            project_id,
+            new_path,
+        } => project::change_project_path(ws, project_id, new_path, cx),
         ActionRequest::DeleteProject { project_id } => {
             project::delete_project(ws, focus_manager, project_id, settings, cx)
         }

--- a/crates/okena-app-core/src/workspace/actions/execute/project.rs
+++ b/crates/okena-app-core/src/workspace/actions/execute/project.rs
@@ -215,6 +215,20 @@ pub(super) fn rename_project_directory(
     }
 }
 
+pub(super) fn change_project_path(
+    ws: &mut Workspace,
+    project_id: String,
+    new_path: String,
+    cx: &mut impl WorkspaceCx,
+) -> ActionResult {
+    // Every check this needs — existence, directory-ness, collisions, missing
+    // project — belongs to the workspace, which owns the path invariants.
+    match ws.change_project_path(&project_id, new_path, cx) {
+        Ok(()) => ActionResult::Ok(None),
+        Err(error) => ActionResult::Err(error),
+    }
+}
+
 pub(super) fn delete_project(
     ws: &mut Workspace,
     focus_manager: &mut FocusManager,

--- a/crates/okena-app/src/action_dispatch.rs
+++ b/crates/okena-app/src/action_dispatch.rs
@@ -1162,6 +1162,13 @@ fn strip_remote_ids(action: ActionRequest, connection_id: &str) -> ActionRequest
             project_id: s(&project_id),
             new_name,
         },
+        ActionRequest::ChangeProjectPath {
+            project_id,
+            new_path,
+        } => ActionRequest::ChangeProjectPath {
+            project_id: s(&project_id),
+            new_path,
+        },
         ActionRequest::DeleteProject { project_id } => ActionRequest::DeleteProject {
             project_id: s(&project_id),
         },

--- a/crates/okena-app/src/keybindings/mod.rs
+++ b/crates/okena-app/src/keybindings/mod.rs
@@ -187,6 +187,11 @@ pub fn reload_keybindings(cx: &mut App) {
             okena_views_sidebar::Cancel,
             Some("RenameDirectoryDialog"),
         ),
+        KeyBinding::new(
+            "escape",
+            okena_views_sidebar::Cancel,
+            Some("ChangePathDialog"),
+        ),
         KeyBinding::new("escape", okena_views_sidebar::Cancel, Some("HookLog")),
         KeyBinding::new(
             "escape",
@@ -319,6 +324,11 @@ pub fn register_keybindings(cx: &mut App) {
             "escape",
             okena_views_sidebar::Cancel,
             Some("RenameDirectoryDialog"),
+        ),
+        KeyBinding::new(
+            "escape",
+            okena_views_sidebar::Cancel,
+            Some("ChangePathDialog"),
         ),
         KeyBinding::new("escape", okena_views_sidebar::Cancel, Some("HookLog")),
         // okena-views-terminal crate Cancel for shell selector + send composer

--- a/crates/okena-app/src/views/overlay_manager.rs
+++ b/crates/okena-app/src/views/overlay_manager.rs
@@ -9,6 +9,7 @@ use crate::remote_client::manager::RemoteConnectionManager;
 use crate::terminal::shell_config::ShellType;
 use crate::views::overlays::about::{AboutModal, AboutModalEvent};
 use crate::views::overlays::add_project_dialog::{AddProjectDialog, AddProjectDialogEvent};
+use crate::views::overlays::change_path_dialog::{ChangePathDialog, ChangePathDialogEvent};
 use crate::views::overlays::close_worktree_dialog::{
     CloseWorktreeDialog, CloseWorktreeDialogEvent,
 };
@@ -172,6 +173,23 @@ pub enum OverlayManagerEvent {
     RenameDirectoryConfirmed {
         project_id: String,
         new_name: String,
+    },
+
+    /// Context menu: point the project at a different existing directory
+    ChangeProjectPath {
+        project_id: String,
+        project_path: String,
+        /// Whether that directory is on this machine, so the dialog knows
+        /// whether it may check the typed path itself.
+        shares_local_filesystem: bool,
+    },
+
+    /// Change-path dialog confirmed: the host dispatches
+    /// `ActionRequest::ChangeProjectPath`; the daemon rewrites the record —
+    /// nothing on disk moves — and mirrors the new path back.
+    ChangeProjectPathConfirmed {
+        project_id: String,
+        new_path: String,
     },
 
     /// Context menu: Close worktree project (opens the confirm dialog)
@@ -1031,6 +1049,39 @@ impl OverlayManager {
     }
 
     // ========================================================================
+    // Change path dialog (parametric)
+    // ========================================================================
+
+    /// Show the change-folder-path dialog for a project.
+    pub fn show_change_path_dialog(
+        &mut self,
+        project_id: String,
+        project_path: String,
+        shares_local_filesystem: bool,
+        cx: &mut Context<Self>,
+    ) {
+        let entity = cx
+            .new(|cx| ChangePathDialog::new(project_id, project_path, shares_local_filesystem, cx));
+        cx.subscribe(&entity, |this, _, event: &ChangePathDialogEvent, cx| {
+            if let ChangePathDialogEvent::Confirmed {
+                project_id,
+                new_path,
+            } = event
+            {
+                cx.emit(OverlayManagerEvent::ChangeProjectPathConfirmed {
+                    project_id: project_id.clone(),
+                    new_path: new_path.clone(),
+                });
+            }
+            if event.is_close() {
+                this.close_modal(cx);
+            }
+        })
+        .detach();
+        self.open_modal(entity, cx);
+    }
+
+    // ========================================================================
     // Context menu (parametric - remains as separate OverlaySlot)
     // ========================================================================
 
@@ -1078,6 +1129,18 @@ impl OverlayManager {
                     cx.emit(OverlayManagerEvent::RenameDirectory {
                         project_id: project_id.clone(),
                         project_path: project_path.clone(),
+                    });
+                }
+                ContextMenuEvent::ChangeProjectPath {
+                    project_id,
+                    project_path,
+                    shares_local_filesystem,
+                } => {
+                    this.hide_context_menu(cx);
+                    cx.emit(OverlayManagerEvent::ChangeProjectPath {
+                        project_id: project_id.clone(),
+                        project_path: project_path.clone(),
+                        shares_local_filesystem: *shares_local_filesystem,
                     });
                 }
                 ContextMenuEvent::CloseWorktree { project_id } => {

--- a/crates/okena-app/src/views/overlays/change_path_dialog.rs
+++ b/crates/okena-app/src/views/overlays/change_path_dialog.rs
@@ -1,0 +1,1 @@
+pub use okena_views_sidebar::change_path_dialog::*;

--- a/crates/okena-app/src/views/overlays/mod.rs
+++ b/crates/okena-app/src/views/overlays/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod about;
 pub mod add_project_dialog;
+pub mod change_path_dialog;
 pub mod close_worktree_dialog;
 pub mod command_palette;
 pub mod content_search;

--- a/crates/okena-app/src/views/window/handlers.rs
+++ b/crates/okena-app/src/views/window/handlers.rs
@@ -569,6 +569,20 @@ impl WindowView {
                     om.show_rename_directory_dialog(project_id.clone(), project_path.clone(), cx);
                 });
             }
+            OverlayManagerEvent::ChangeProjectPath {
+                project_id,
+                project_path,
+                shares_local_filesystem,
+            } => {
+                self.overlay_manager.update(cx, |om, cx| {
+                    om.show_change_path_dialog(
+                        project_id.clone(),
+                        project_path.clone(),
+                        *shares_local_filesystem,
+                        cx,
+                    );
+                });
+            }
             OverlayManagerEvent::CloseWorktree { project_id } => {
                 let params = self
                     .workspace
@@ -645,6 +659,20 @@ impl WindowView {
                         ActionRequest::RenameProjectDirectory {
                             project_id: project_id.clone(),
                             new_name: new_name.clone(),
+                        },
+                        cx,
+                    );
+                }
+            }
+            OverlayManagerEvent::ChangeProjectPathConfirmed {
+                project_id,
+                new_path,
+            } => {
+                if let Some(dispatcher) = self.dispatcher_for_project(project_id, cx) {
+                    dispatcher.dispatch(
+                        ActionRequest::ChangeProjectPath {
+                            project_id: project_id.clone(),
+                            new_path: new_path.clone(),
                         },
                         cx,
                     );

--- a/crates/okena-core/src/api.rs
+++ b/crates/okena-core/src/api.rs
@@ -1064,6 +1064,15 @@ pub enum ActionRequest {
         project_id: String,
         new_name: String,
     },
+    /// Repoint a project at a directory that already exists on disk, without
+    /// moving anything. Unlike `RenameProjectDirectory` — which renames the
+    /// folder in place and therefore requires the target *not* to exist — this
+    /// adopts an existing directory, for when the folder was moved outside
+    /// okena and the recorded path went stale.
+    ChangeProjectPath {
+        project_id: String,
+        new_path: String,
+    },
     DeleteProject {
         project_id: String,
     },
@@ -1792,6 +1801,10 @@ mod tests {
             ActionRequest::RenameProjectDirectory {
                 project_id: "p1".into(),
                 new_name: "new-dir".into(),
+            },
+            ActionRequest::ChangeProjectPath {
+                project_id: "p1".into(),
+                new_path: "/tmp/moved".into(),
             },
             ActionRequest::DeleteProject {
                 project_id: "p1".into(),

--- a/crates/okena-views-git/src/git_header/status_pill.rs
+++ b/crates/okena-views-git/src/git_header/status_pill.rs
@@ -145,10 +145,13 @@ impl GitHeader {
                                 this.toggle_commit_log(cx);
                             }))
                             .child(
+                                // Matches the PR badge: at `text_muted` this
+                                // 10px glyph was near-invisible on the darker
+                                // themes.
                                 svg()
                                     .path("icons/git-commit.svg")
                                     .size(px(10.0))
-                                    .text_color(rgb(t.text_muted)),
+                                    .text_color(rgb(t.text_secondary)),
                             )
                             .child(
                                 canvas(

--- a/crates/okena-views-git/src/project_header/branch_status.rs
+++ b/crates/okena-views-git/src/project_header/branch_status.rs
@@ -126,7 +126,13 @@ pub fn render_branch_status(
     // typically wired to open the PR URL on GitHub.
     let pr_badge = pr_number.map(|num| {
         let pr_clickable = on_pr_click.is_some();
-        let badge_color = pr_state_color.unwrap_or(t.text_muted);
+        // `text_secondary`, not `text_muted`: at muted the badge sat around
+        // 3:1 against the header background on the darker themes, which is
+        // below the readable floor for something carrying an identifier you
+        // are meant to read. Secondary is the "quieter than body text but
+        // still legible" token in every theme — including light, where it is
+        // *darker* than muted rather than lighter.
+        let badge_color = pr_state_color.unwrap_or(t.text_secondary);
         let mut el = h_flex()
             .id("pr-badge")
             .gap(px(3.0))
@@ -145,7 +151,11 @@ pub fn render_branch_status(
                     .size(px(10.0))
                     .text_color(rgb(badge_color)),
             )
-            .child(div().text_color(rgb(t.text_muted)).child(format!("#{num}")));
+            .child(
+                div()
+                    .text_color(rgb(t.text_secondary))
+                    .child(format!("#{num}")),
+            );
         if let Some(cb) = on_pr_click {
             el = el.on_click(move |_, window, cx| {
                 cb(window, cx);

--- a/crates/okena-views-sidebar/Cargo.toml
+++ b/crates/okena-views-sidebar/Cargo.toml
@@ -20,3 +20,4 @@ gpui-component = { git = "https://github.com/longbridge/gpui-component", package
 smol = "2.0"
 log = "0.4"
 serde_json = "1.0"
+dirs = "5.0"

--- a/crates/okena-views-sidebar/src/change_path_dialog.rs
+++ b/crates/okena-views-sidebar/src/change_path_dialog.rs
@@ -1,0 +1,360 @@
+//! Dialog for repointing a project at a directory that already exists on disk.
+//!
+//! The sibling `rename_directory_dialog` renames a folder *in place* and so
+//! takes a bare name. This one takes a whole path, because the case it serves
+//! is the folder having moved somewhere else entirely — usually leaving the
+//! project's recorded path dangling.
+
+use crate::Cancel;
+use gpui::prelude::*;
+use gpui::*;
+use gpui_component::h_flex;
+use okena_ui::button::{button, button_primary};
+use okena_ui::input::input_container;
+use okena_ui::modal::{modal_backdrop, modal_content};
+use okena_ui::simple_input::{SimpleInput, SimpleInputState};
+use okena_ui::theme::theme;
+use okena_ui::tokens::{ui_text, ui_text_md, ui_text_ms, ui_text_xl};
+use std::path::{Path, PathBuf};
+
+/// Events emitted by the change path dialog
+#[derive(Clone)]
+pub enum ChangePathDialogEvent {
+    /// Dialog closed (cancelled or confirmed)
+    Close,
+    /// A new path was confirmed: the host dispatches
+    /// `ActionRequest::ChangeProjectPath`; the daemon rewrites the record and
+    /// mirrors the new path back.
+    Confirmed {
+        project_id: String,
+        new_path: String,
+    },
+}
+
+impl okena_ui::overlay::CloseEvent for ChangePathDialogEvent {
+    fn is_close(&self) -> bool {
+        matches!(self, Self::Close | Self::Confirmed { .. })
+    }
+}
+
+impl EventEmitter<ChangePathDialogEvent> for ChangePathDialog {}
+
+/// Dialog for pointing a project at a different existing directory.
+pub struct ChangePathDialog {
+    project_id: String,
+    project_path: String,
+    /// Whether the project's directory is on this machine. When it isn't, the
+    /// owning daemon is the only thing that can judge the typed path, so the
+    /// local pre-checks below stand down and it validates instead.
+    shares_local_filesystem: bool,
+    path_input: Entity<SimpleInputState>,
+    error_message: Option<String>,
+    focus_handle: FocusHandle,
+    initialized: bool,
+}
+
+impl ChangePathDialog {
+    pub fn new(
+        project_id: String,
+        project_path: String,
+        shares_local_filesystem: bool,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let path_input = cx.new(|cx| {
+            let mut input = SimpleInputState::new(cx).placeholder("/path/to/project...");
+            input.set_value(&project_path, cx);
+            input
+        });
+
+        Self {
+            project_id,
+            project_path,
+            shares_local_filesystem,
+            path_input,
+            error_message: None,
+            focus_handle: cx.focus_handle(),
+            initialized: false,
+        }
+    }
+
+    fn close(&mut self, cx: &mut Context<Self>) {
+        cx.emit(ChangePathDialogEvent::Close);
+    }
+
+    /// Expand a leading `~` so typed and pasted paths both work.
+    fn expand_home(raw: &str) -> String {
+        let Some(rest) = raw.strip_prefix('~') else {
+            return raw.to_string();
+        };
+        if !(rest.is_empty() || rest.starts_with('/') || rest.starts_with('\\')) {
+            // `~other-user/...` is not ours to resolve.
+            return raw.to_string();
+        }
+        let Some(home) = dirs::home_dir() else {
+            return raw.to_string();
+        };
+        let trimmed = rest.trim_start_matches(['/', '\\']);
+        if trimmed.is_empty() {
+            home.to_string_lossy().into_owned()
+        } else {
+            home.join(trimmed).to_string_lossy().into_owned()
+        }
+    }
+
+    fn confirm(&mut self, cx: &mut Context<Self>) {
+        let raw = self.path_input.read(cx).value().trim().to_string();
+
+        if raw.is_empty() {
+            self.error_message = Some("Path cannot be empty".to_string());
+            cx.notify();
+            return;
+        }
+
+        // `~` and every filesystem check below describe *this* machine. For a
+        // project served by a remote daemon none of them apply — its home
+        // directory is not ours, and its paths need not even use this
+        // platform's shape (a Windows `C:\...` reads as relative here). So the
+        // owning daemon validates those, and its error arrives as a toast.
+        let new_path = if self.shares_local_filesystem {
+            Self::expand_home(&raw)
+        } else {
+            raw
+        };
+
+        if new_path == self.project_path {
+            self.error_message = Some("Path is the same as the current one".to_string());
+            cx.notify();
+            return;
+        }
+
+        if self.shares_local_filesystem {
+            let candidate = PathBuf::from(&new_path);
+            if !candidate.is_absolute() {
+                self.error_message = Some("Path must be absolute".to_string());
+                cx.notify();
+                return;
+            }
+            // The daemon checks these too and is the authority — repeating them
+            // here only turns a toast fired after the dialog closes into an
+            // inline message the user can act on without reopening anything.
+            if !candidate.exists() {
+                self.error_message = Some(format!("'{new_path}' does not exist"));
+                cx.notify();
+                return;
+            }
+            if !candidate.is_dir() {
+                self.error_message = Some(format!("'{new_path}' is not a directory"));
+                cx.notify();
+                return;
+            }
+            if candidate.as_path() == Path::new(&self.project_path) {
+                self.error_message = Some("Path is the same as the current one".to_string());
+                cx.notify();
+                return;
+            }
+        }
+
+        cx.emit(ChangePathDialogEvent::Confirmed {
+            project_id: self.project_id.clone(),
+            new_path,
+        });
+    }
+}
+
+okena_ui::impl_focusable!(ChangePathDialog);
+
+impl Render for ChangePathDialog {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let t = theme(cx);
+        let focus_handle = self.focus_handle.clone();
+
+        if !self.initialized {
+            self.initialized = true;
+            self.path_input.update(cx, |input, cx| {
+                input.focus(window, cx);
+            });
+        }
+
+        let path_input = self.path_input.clone();
+        let input_focused = self.path_input.read(cx).focus_handle(cx).is_focused(window);
+        let error_msg = self.error_message.clone();
+        // Only meaningful for a path on this disk; a remote project's directory
+        // is not ours to stat, and calling it missing would be a lie.
+        let current_missing =
+            self.shares_local_filesystem && !Path::new(&self.project_path).exists();
+        let current_label = if current_missing {
+            format!("{} (missing)", self.project_path)
+        } else {
+            self.project_path.clone()
+        };
+        let caption = if self.shares_local_filesystem {
+            "Nothing is moved on disk — only the folder this project points at."
+        } else {
+            "Nothing is moved on disk. The path is on the remote host and is checked there."
+        };
+
+        modal_backdrop("change-path-dialog-backdrop", &t)
+            .track_focus(&focus_handle)
+            .key_context("ChangePathDialog")
+            .items_center()
+            .on_action(cx.listener(|this, _: &Cancel, _, cx| {
+                this.close(cx);
+            }))
+            .on_key_down(cx.listener(|this, event: &KeyDownEvent, _, cx| {
+                if event.keystroke.key.as_str() == "enter" {
+                    this.confirm(cx);
+                }
+            }))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, _, cx| {
+                    this.close(cx);
+                }),
+            )
+            .child(
+                modal_content("change-path-dialog", &t)
+                    .w(px(520.0))
+                    .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                        cx.stop_propagation();
+                    })
+                    .child(
+                        div()
+                            .px(px(16.0))
+                            .py(px(12.0))
+                            .flex()
+                            .items_center()
+                            .justify_between()
+                            .border_b_1()
+                            .border_color(rgb(t.border))
+                            .child(
+                                h_flex()
+                                    .gap(px(8.0))
+                                    .child(
+                                        svg()
+                                            .path("icons/folder.svg")
+                                            .size(px(16.0))
+                                            .text_color(rgb(t.border_active)),
+                                    )
+                                    .child(
+                                        div()
+                                            .text_size(ui_text_xl(cx))
+                                            .font_weight(FontWeight::SEMIBOLD)
+                                            .text_color(rgb(t.text_primary))
+                                            .child("Change Folder Path"),
+                                    ),
+                            )
+                            .child(
+                                div()
+                                    .id("close-change-path-btn")
+                                    .cursor_pointer()
+                                    .w(px(24.0))
+                                    .h(px(24.0))
+                                    .flex()
+                                    .items_center()
+                                    .justify_center()
+                                    .rounded(px(4.0))
+                                    .hover(|s| s.bg(rgb(t.bg_hover)))
+                                    .child(
+                                        svg()
+                                            .path("icons/close.svg")
+                                            .size(px(14.0))
+                                            .text_color(rgb(t.text_secondary)),
+                                    )
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.close(cx);
+                                    })),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .px(px(16.0))
+                            .py(px(12.0))
+                            .flex()
+                            .flex_col()
+                            .gap(px(8.0))
+                            .child(
+                                div()
+                                    .text_size(ui_text_ms(cx))
+                                    .text_color(rgb(if current_missing {
+                                        t.error
+                                    } else {
+                                        t.text_muted
+                                    }))
+                                    .overflow_x_hidden()
+                                    .whitespace_nowrap()
+                                    .child(current_label),
+                            )
+                            .child(
+                                input_container(&t, Some(input_focused)).child(
+                                    SimpleInput::new(&path_input).text_size(ui_text(13.0, cx)),
+                                ),
+                            )
+                            .child(
+                                div()
+                                    .text_size(ui_text_ms(cx))
+                                    .text_color(rgb(t.text_muted))
+                                    .child(caption),
+                            ),
+                    )
+                    .when_some(error_msg, |d, msg| {
+                        d.child(
+                            div()
+                                .px(px(16.0))
+                                .py(px(8.0))
+                                .bg(rgba(0xff00001a))
+                                .text_size(ui_text_md(cx))
+                                .text_color(rgb(t.error))
+                                .child(msg),
+                        )
+                    })
+                    .child(
+                        div()
+                            .px(px(16.0))
+                            .py(px(12.0))
+                            .flex()
+                            .justify_end()
+                            .gap(px(8.0))
+                            .border_t_1()
+                            .border_color(rgb(t.border))
+                            .child(
+                                button("cancel-change-path-btn", "Cancel", &t)
+                                    .px(px(16.0))
+                                    .py(px(8.0))
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.close(cx);
+                                    })),
+                            )
+                            .child(
+                                button_primary("confirm-change-path-btn", "Change Path", &t)
+                                    .px(px(16.0))
+                                    .py(px(8.0))
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.confirm(cx);
+                                    })),
+                            ),
+                    ),
+            )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ChangePathDialog;
+
+    #[test]
+    fn expand_home_rewrites_only_our_own_tilde() {
+        let home = dirs::home_dir().expect("home dir");
+        assert_eq!(
+            ChangePathDialog::expand_home("~/Developer/x"),
+            home.join("Developer/x").to_string_lossy()
+        );
+        assert_eq!(
+            ChangePathDialog::expand_home("~"),
+            home.to_string_lossy().into_owned()
+        );
+        // Another user's home is not ours to resolve, and a bare path is
+        // already what it claims to be.
+        assert_eq!(ChangePathDialog::expand_home("~someone/x"), "~someone/x");
+        assert_eq!(ChangePathDialog::expand_home("/abs/x"), "/abs/x");
+    }
+}

--- a/crates/okena-views-sidebar/src/context_menu.rs
+++ b/crates/okena-views-sidebar/src/context_menu.rs
@@ -82,6 +82,13 @@ pub enum ContextMenuEvent {
         project_id: String,
         project_path: String,
     },
+    ChangeProjectPath {
+        project_id: String,
+        project_path: String,
+        /// Whether the project's path is on this machine's disk, so the dialog
+        /// knows if it may check the typed path itself.
+        shares_local_filesystem: bool,
+    },
     CloseWorktree {
         project_id: String,
     },
@@ -179,6 +186,19 @@ impl ContextMenu {
         cx.emit(ContextMenuEvent::RenameDirectory {
             project_id: self.request.project_id.clone(),
             project_path,
+        });
+    }
+
+    fn change_project_path(
+        &self,
+        project_path: String,
+        shares_local_filesystem: bool,
+        cx: &mut Context<Self>,
+    ) {
+        cx.emit(ContextMenuEvent::ChangeProjectPath {
+            project_id: self.request.project_id.clone(),
+            project_path,
+            shares_local_filesystem,
         });
     }
 
@@ -288,7 +308,21 @@ impl Render for ContextMenu {
             .remote_snapshot(&self.request.project_id)
             .and_then(|s| s.git_status.as_ref())
             .is_some();
+        // Not `is_remote`: every project mirrored from a daemon connection
+        // carries that, including the local daemon a `--daemon-client` desktop
+        // talks to — i.e. most projects on a normal setup. What the change-path
+        // dialog needs to know is whether the project's path lives on *this*
+        // disk, so it can pre-validate against it. That is the connection,
+        // mirroring `ActionDispatcher::shares_local_filesystem`.
+        let shares_local_filesystem = project
+            .map(|p| {
+                p.connection_id
+                    .as_deref()
+                    .is_none_or(|id| id == okena_transport::client::LOCAL_DAEMON_CONNECTION_ID)
+            })
+            .unwrap_or(false);
         let project_path_for_rename_dir = project_path.clone();
+        let project_path_for_change_path = project_path.clone();
         let project_name_for_rename = project_name.clone();
         let extras_exist = !ws.data().extra_windows.is_empty();
         let is_hidden_in_window = ws
@@ -505,6 +539,28 @@ impl Render for ContextMenu {
                                 let project_path = project_path_for_rename_dir.clone();
                                 move |this, _, _window, cx| {
                                     this.rename_directory(project_path.clone(), cx);
+                                }
+                            })),
+                        )
+                        // Change Folder Path option. Offered for remote projects
+                        // too — the daemon that owns one validates the target
+                        // against its own disk. Only this dialog's *local*
+                        // pre-checks have to stand down, hence the flag.
+                        .child(
+                            menu_item(
+                                "context-menu-change-path",
+                                "icons/folder.svg",
+                                "Change Folder Path...",
+                                &t,
+                            )
+                            .on_click(cx.listener({
+                                let project_path = project_path_for_change_path.clone();
+                                move |this, _, _window, cx| {
+                                    this.change_project_path(
+                                        project_path.clone(),
+                                        shares_local_filesystem,
+                                        cx,
+                                    );
                                 }
                             })),
                         )

--- a/crates/okena-views-sidebar/src/lib.rs
+++ b/crates/okena-views-sidebar/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod activity_order;
+pub mod change_path_dialog;
 pub mod color_picker;
 pub mod context_menu;
 pub mod drag;
@@ -27,6 +28,7 @@ pub use sidebar::{
 };
 
 // Re-export context menu types
+pub use change_path_dialog::{ChangePathDialog, ChangePathDialogEvent};
 pub use context_menu::{ContextMenu, ContextMenuEvent};
 pub use folder_context_menu::{FolderContextMenu, FolderContextMenuEvent};
 pub use hook_log::{HookLog, HookLogEvent};

--- a/crates/okena-workspace/src/actions/project.rs
+++ b/crates/okena-workspace/src/actions/project.rs
@@ -639,13 +639,16 @@ impl Workspace {
         }
         self.ensure_project_path_mutation_allowed(project_id, &new_path_buf)?;
 
-        let (is_remote, old_path) = {
+        let (is_mirror, old_path) = {
             let project = self
                 .project(project_id)
                 .ok_or_else(|| "Project not found".to_string())?;
-            (project.is_remote, std::path::PathBuf::from(&project.path))
+            (
+                project.connection_id.is_some(),
+                std::path::PathBuf::from(&project.path),
+            )
         };
-        if is_remote {
+        if is_mirror {
             // Not a refusal of remote projects as such — a client routes this
             // action to the daemon that owns the project, and there it is
             // local. Reaching here means someone asked a workspace to repoint
@@ -660,7 +663,7 @@ impl Workspace {
         if let Some(claimant) = self
             .projects()
             .iter()
-            .filter(|other| !other.is_remote && other.id != project_id)
+            .filter(|other| other.id != project_id)
             .find(|other| {
                 Self::physical_path_identity(std::path::Path::new(&other.path)) == new_identity
             })
@@ -906,7 +909,7 @@ impl Workspace {
         let old_identity = Self::physical_path_identity(old_root);
         let old_lexical = Self::lexical_absolute(old_root);
         let mut translated_paths = Vec::new();
-        for descendant in self.projects().iter().filter(|project| !project.is_remote) {
+        for descendant in self.projects() {
             let descendant_path = std::path::Path::new(&descendant.path);
             if !Self::physical_path_identity(descendant_path).starts_with(&old_identity) {
                 continue;

--- a/crates/okena-workspace/src/actions/project.rs
+++ b/crates/okena-workspace/src/actions/project.rs
@@ -610,6 +610,83 @@ impl Workspace {
         });
     }
 
+    /// Repoint a project at a directory that already exists on disk.
+    ///
+    /// The filesystem is left untouched — this only rewrites the recorded
+    /// paths, for when a folder was moved or flattened outside okena and the
+    /// project's path went stale. Nested projects under the old root are
+    /// translated by suffix, the same way a directory rename translates them.
+    ///
+    /// Deliberately *not* built on `rename_project_directory`: that one moves
+    /// the directory and so requires the target to be absent, and its
+    /// translation canonicalizes the old root — which fails outright when that
+    /// root no longer exists, i.e. exactly the case this exists to repair.
+    pub fn change_project_path(
+        &mut self,
+        project_id: &str,
+        new_path: String,
+        cx: &mut impl WorkspaceCx,
+    ) -> Result<(), String> {
+        let new_path_buf = std::path::PathBuf::from(&new_path);
+        if !new_path_buf.is_absolute() {
+            return Err("path must be absolute".to_string());
+        }
+        if !new_path_buf.exists() {
+            return Err(format!("'{new_path}' does not exist"));
+        }
+        if !new_path_buf.is_dir() {
+            return Err(format!("'{new_path}' is not a directory"));
+        }
+        self.ensure_project_path_mutation_allowed(project_id, &new_path_buf)?;
+
+        let (is_remote, old_path) = {
+            let project = self
+                .project(project_id)
+                .ok_or_else(|| "Project not found".to_string())?;
+            (project.is_remote, std::path::PathBuf::from(&project.path))
+        };
+        if is_remote {
+            // Not a refusal of remote projects as such — a client routes this
+            // action to the daemon that owns the project, and there it is
+            // local. Reaching here means someone asked a workspace to repoint
+            // its own *mirror* of a project, whose path that workspace does not
+            // own and whose disk it cannot see.
+            return Err("project is owned by another daemon".to_string());
+        }
+        let new_identity = Self::physical_path_identity(&new_path_buf);
+        if Self::physical_path_identity(&old_path) == new_identity {
+            return Err("project already points at this directory".to_string());
+        }
+        if let Some(claimant) = self
+            .projects()
+            .iter()
+            .filter(|other| !other.is_remote && other.id != project_id)
+            .find(|other| {
+                Self::physical_path_identity(std::path::Path::new(&other.path)) == new_identity
+            })
+        {
+            return Err(format!("'{}' already uses this directory", claimant.name));
+        }
+
+        let translated_paths = self.translate_project_paths_onto(&old_path, &new_path_buf)?;
+        self.apply_translated_project_paths(translated_paths);
+        // `worktree_path` is deprecated and mirrors `project.path`; keep the
+        // in-memory copy consistent for anything still reading it.
+        if let Some(project) = self
+            .data
+            .projects
+            .iter_mut()
+            .find(|project| project.id == project_id)
+        {
+            let path = project.path.clone();
+            if let Some(metadata) = &mut project.worktree_info {
+                metadata.worktree_path = path;
+            }
+        }
+        self.notify_data(cx);
+        Ok(())
+    }
+
     /// Rename a project's directory path and update the project name to match
     pub fn rename_project_directory(
         &mut self,
@@ -809,6 +886,74 @@ impl Workspace {
             });
         }
         Ok(translated_paths)
+    }
+
+    /// Translate a project and its nested projects from `old_root` onto
+    /// `new_root` by path suffix, without touching the filesystem.
+    ///
+    /// The sibling `translate_local_project_paths` canonicalizes both ends,
+    /// which a repoint cannot do: the old root is usually already gone by the
+    /// time anyone reaches for this. Suffixes are therefore taken lexically,
+    /// using the same normalization `physical_path_identity` applies before it
+    /// compares. A descendant whose recorded path reaches the old root through
+    /// a symlink matches on identity but has no lexical suffix; that is
+    /// reported rather than guessed at.
+    fn translate_project_paths_onto(
+        &self,
+        old_root: &std::path::Path,
+        new_root: &std::path::Path,
+    ) -> Result<Vec<ProjectPathTranslation>, String> {
+        let old_identity = Self::physical_path_identity(old_root);
+        let old_lexical = Self::lexical_absolute(old_root);
+        let mut translated_paths = Vec::new();
+        for descendant in self.projects().iter().filter(|project| !project.is_remote) {
+            let descendant_path = std::path::Path::new(&descendant.path);
+            if !Self::physical_path_identity(descendant_path).starts_with(&old_identity) {
+                continue;
+            }
+            let suffix = Self::lexical_absolute(descendant_path)
+                .strip_prefix(&old_lexical)
+                .map_err(|_| {
+                    format!(
+                        "Failed to translate nested project '{}' into the new directory",
+                        descendant.name
+                    )
+                })?
+                .to_path_buf();
+            let translated_path = if suffix.as_os_str().is_empty() {
+                new_root.to_path_buf()
+            } else {
+                new_root.join(suffix)
+            };
+            let translated_hook_terminal_ids = descendant
+                .hook_terminals
+                .iter()
+                .filter(|(_, entry)| {
+                    Self::physical_path_identity(std::path::Path::new(&entry.cwd))
+                        == Self::physical_path_identity(descendant_path)
+                })
+                .map(|(terminal_id, _)| terminal_id.clone())
+                .collect();
+            translated_paths.push(ProjectPathTranslation {
+                project_id: descendant.id.clone(),
+                old_path: descendant.path.clone(),
+                new_path: translated_path.to_string_lossy().into_owned(),
+                translated_hook_terminal_ids,
+            });
+        }
+        Ok(translated_paths)
+    }
+
+    /// Absolute, `.`/`..`-free form of `path`, without requiring it to exist.
+    fn lexical_absolute(path: &std::path::Path) -> std::path::PathBuf {
+        let absolute = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map(|cwd| cwd.join(path))
+                .unwrap_or_else(|_| path.to_path_buf())
+        };
+        okena_git::repository::normalize_path(&absolute)
     }
 
     fn apply_translated_project_paths(&mut self, translated_paths: Vec<ProjectPathTranslation>) {
@@ -3913,5 +4058,158 @@ mod gpui_tests {
             result.is_err(),
             "clone target inside an in-flight worktree must be rejected"
         );
+    }
+
+    /// Fixture for the case this action exists for: the project's recorded
+    /// directory is gone and the real one lives somewhere else.
+    fn moved_project_fixture(name: &str) -> (std::path::PathBuf, std::path::PathBuf) {
+        let fixture = std::env::temp_dir().join(format!("okena-{name}-{}", uuid::Uuid::new_v4()));
+        let missing = fixture.join("old/nested");
+        let moved = fixture.join("moved");
+        std::fs::create_dir_all(&moved).expect("create moved dir");
+        (missing, moved)
+    }
+
+    #[gpui::test]
+    fn change_project_path_repoints_a_project_whose_folder_moved(cx: &mut gpui::TestAppContext) {
+        let (missing, moved) = moved_project_fixture("repoint");
+        let mut project = make_project("p1");
+        project.path = path_str(&missing).to_string();
+        let mut data = make_workspace_data();
+        data.projects = vec![project];
+        data.project_order = vec!["p1".to_string()];
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        let result = workspace.update(cx, |ws: &mut Workspace, cx| {
+            ws.change_project_path("p1", path_str(&moved).to_string(), cx)
+        });
+
+        assert_eq!(result, Ok(()));
+        workspace.read_with(cx, |ws: &Workspace, _cx| {
+            assert_eq!(ws.project("p1").unwrap().path, path_str(&moved));
+        });
+        // Nothing was moved on disk: the old path is still absent.
+        assert!(!missing.exists());
+        std::fs::remove_dir_all(moved.parent().unwrap()).ok();
+    }
+
+    #[gpui::test]
+    fn change_project_path_translates_nested_projects(cx: &mut gpui::TestAppContext) {
+        let (missing, moved) = moved_project_fixture("repoint-nested");
+        let mut root = make_project("root");
+        root.path = path_str(&missing).to_string();
+        let mut nested = make_project("nested");
+        nested.path = path_str(&missing.join("packages/app")).to_string();
+        let mut data = make_workspace_data();
+        data.projects = vec![root, nested];
+        data.project_order = vec!["root".to_string(), "nested".to_string()];
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        let result = workspace.update(cx, |ws: &mut Workspace, cx| {
+            ws.change_project_path("root", path_str(&moved).to_string(), cx)
+        });
+
+        assert_eq!(result, Ok(()));
+        workspace.read_with(cx, |ws: &Workspace, _cx| {
+            assert_eq!(ws.project("root").unwrap().path, path_str(&moved));
+            assert_eq!(
+                ws.project("nested").unwrap().path,
+                path_str(&moved.join("packages/app"))
+            );
+        });
+        std::fs::remove_dir_all(moved.parent().unwrap()).ok();
+    }
+
+    #[gpui::test]
+    fn change_project_path_rejects_a_directory_another_project_uses(cx: &mut gpui::TestAppContext) {
+        let (missing, moved) = moved_project_fixture("repoint-claimed");
+        let mut project = make_project("p1");
+        project.path = path_str(&missing).to_string();
+        let mut claimant = make_project("p2");
+        claimant.name = "Other".to_string();
+        claimant.path = path_str(&moved).to_string();
+        let mut data = make_workspace_data();
+        data.projects = vec![project, claimant];
+        data.project_order = vec!["p1".to_string(), "p2".to_string()];
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        let err = workspace.update(cx, |ws: &mut Workspace, cx| {
+            ws.change_project_path("p1", path_str(&moved).to_string(), cx)
+                .err()
+        });
+
+        assert_eq!(err.as_deref(), Some("'Other' already uses this directory"));
+        workspace.read_with(cx, |ws: &Workspace, _cx| {
+            assert_eq!(ws.project("p1").unwrap().path, path_str(&missing));
+        });
+        std::fs::remove_dir_all(moved.parent().unwrap()).ok();
+    }
+
+    #[gpui::test]
+    fn change_project_path_rejects_targets_that_are_not_usable_directories(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let (missing, moved) = moved_project_fixture("repoint-invalid");
+        let file = moved.join("a-file");
+        std::fs::write(&file, b"x").expect("write file");
+        let mut project = make_project("p1");
+        project.path = path_str(&missing).to_string();
+        let mut data = make_workspace_data();
+        data.projects = vec![project];
+        data.project_order = vec!["p1".to_string()];
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        let absent = moved.join("not-there");
+        let errors = workspace.update(cx, |ws: &mut Workspace, cx| {
+            (
+                ws.change_project_path("p1", "relative/path".to_string(), cx)
+                    .err(),
+                ws.change_project_path("p1", path_str(&absent).to_string(), cx)
+                    .err(),
+                ws.change_project_path("p1", path_str(&file).to_string(), cx)
+                    .err(),
+                ws.change_project_path("p1", path_str(&missing).to_string(), cx)
+                    .err(),
+            )
+        });
+
+        assert_eq!(errors.0.as_deref(), Some("path must be absolute"));
+        assert_eq!(
+            errors.1.as_deref(),
+            Some(format!("'{}' does not exist", path_str(&absent)).as_str())
+        );
+        assert_eq!(
+            errors.2.as_deref(),
+            Some(format!("'{}' is not a directory", path_str(&file)).as_str())
+        );
+        // The current path is rejected before the "does not exist" check would
+        // fire, so a stale project cannot be pointed at its own dead path.
+        assert_eq!(
+            errors.3.as_deref(),
+            Some(format!("'{}' does not exist", path_str(&missing)).as_str())
+        );
+        std::fs::remove_dir_all(moved.parent().unwrap()).ok();
+    }
+
+    #[gpui::test]
+    fn change_project_path_rejects_the_path_it_already_has(cx: &mut gpui::TestAppContext) {
+        let (_missing, moved) = moved_project_fixture("repoint-same");
+        let mut project = make_project("p1");
+        project.path = path_str(&moved).to_string();
+        let mut data = make_workspace_data();
+        data.projects = vec![project];
+        data.project_order = vec!["p1".to_string()];
+        let workspace = cx.new(|_cx| Workspace::new(data));
+
+        let err = workspace.update(cx, |ws: &mut Workspace, cx| {
+            ws.change_project_path("p1", path_str(&moved).to_string(), cx)
+                .err()
+        });
+
+        assert_eq!(
+            err.as_deref(),
+            Some("project already points at this directory")
+        );
+        std::fs::remove_dir_all(moved.parent().unwrap()).ok();
     }
 }


### PR DESCRIPTION
Six commits: one feature, one readability fix, three agent-docs corrections,
and a build repair.

## Change Folder Path

A folder moved or flattened outside okena leaves the project pointing at a
path that no longer exists. The only way back was removing the project and
adding it again, losing its layout, hooks and order.

Deliberately separate from `RenameProjectDirectory` rather than a flag on it.
That one moves the directory, so it requires the target to be absent, and it
canonicalizes the old root — which fails outright when that root is gone,
which is exactly the case this repairs. Nothing on disk is touched here; only
the recorded paths are rewritten, with nested projects translated by lexical
suffix.

Offered for remote projects too, since the daemon that owns a project
validates against its own disk. Only the dialog's local pre-checks stand down,
which is what `shares_local_filesystem` gates.

## PR badge and commit icon legibility

Both sat at `text_muted`, which on the darker themes lands around 3:1 against
the header background — below the readable floor for a 10px glyph and for an
identifier you are meant to read. `text_secondary` is the "quieter than body
text but still legible" token in every theme, including light, where it is
darker than muted rather than lighter.

## Agent docs

- The `ui-screenshot` skill promised its capability unconditionally and
  triggered on broad phrases, while the harness it invokes hard-requires
  gnome-shell >= 45 with no darwin branch. On a macOS checkout every trigger
  loaded a skill whose first command fails, and the fallback it warns against
  is what an agent reaches for next.
- Duplicate-detection reports now go to `.mine/` per the repo's own scratch
  convention, with the `.gitignore` entry in the same change — the skill is
  checked in and read by every contributor's agent, so "it is git-ignored" has
  to be true from the repo alone.
- The commit command is trimmed to the rules only this repo knows: the
  semantic type list, the summary format, and why staging must be explicit.
  The rest duplicated a same-named user-level skill that shadows it, and
  disagreed with it on whether to stop for approval.

## Build repair

The branch has not compiled since "add a Change Folder Path action for
projects": it reads `project.is_remote` after "retire ProjectData::is_remote"
had removed the field, and four commits landed on top without a build.

The fix follows the two commits that retired the field. The two
`!project.is_remote` filters scan sibling projects for a path collision; path
mutations execute in the daemon's workspace, where every project is locally
owned, so the filters could never exclude anything — the same reasoning and
the same edit as "delete the is_remote checks that cannot fire", which removed
a structurally identical filter. The refusal guard keeps its intent instead,
now expressed through `connection_id`, the field the retiring commit named as
carrying it. That stays a no-op in the daemon, where `connection_id` is `None`.

Worth a look during review, since it changes a guard on a path-mutating
action.

## Note on the branch

`fix/close-terminal-focus` is reused — the focus work it was named for shipped
in #169, and #178 shipped from it after that. These six commits are unrelated
to both.

## Verification

`cargo build` and `cargo test --workspace` pass (1823 tests). One suite in
`okena-files` flakes under a loaded parallel run on a temp-directory name
collision; it passes in isolation and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UeLJkqsTrf1Nx2F8VvPSY