### PR TITLE
Fix terminal color queries for light and automatic themes

### DIFF
--- a/crates/okena-app-core/src/workspace/actions/execute/mod.rs
+++ b/crates/okena-app-core/src/workspace/actions/execute/mod.rs
@@ -653,6 +653,7 @@ pub fn execute_action(
         | ActionRequest::GetThemes
         | ActionRequest::GetTheme { .. }
         | ActionRequest::SetTheme { .. }
+        | ActionRequest::SetSystemAppearance { .. }
         | ActionRequest::SaveCustomTheme { .. }
         | ActionRequest::ListActions
         | ActionRequest::InvokeAction { .. } => {

--- a/crates/okena-app/src/action_dispatch.rs
+++ b/crates/okena-app/src/action_dispatch.rs
@@ -1276,6 +1276,7 @@ fn strip_remote_ids(action: ActionRequest, connection_id: &str) -> ActionRequest
         | ActionRequest::GetThemes
         | ActionRequest::GetTheme { .. }
         | ActionRequest::SetTheme { .. }
+        | ActionRequest::SetSystemAppearance { .. }
         | ActionRequest::SaveCustomTheme { .. }
         | ActionRequest::ListActions
         | ActionRequest::InvokeAction { .. }) => a,

--- a/crates/okena-app/src/app/mod.rs
+++ b/crates/okena-app/src/app/mod.rs
@@ -346,6 +346,22 @@ impl Okena {
         // Route clicked desktop notifications back to their originating pane.
         manager.start_notification_click_loop(notification_jump_rx, cx);
 
+        // Only the PTY-owning daemon answers OSC color queries. Share the
+        // resolved OS appearance with our local daemon so Auto matches the
+        // desktop, including OS appearance changes. Never persist this as a
+        // theme preference or send it to user-managed remote connections.
+        let theme = crate::theme::theme_entity(cx);
+        let mut last_is_dark = theme.read(cx).system_is_dark();
+        manager.sync_system_appearance(cx);
+        cx.observe(&theme, move |this, theme, cx| {
+            let is_dark = theme.read(cx).system_is_dark();
+            if is_dark != last_is_dark {
+                last_is_dark = is_dark;
+                this.sync_system_appearance(cx);
+            }
+        })
+        .detach();
+
         // Fire OS notifications for remote (daemon-served) terminals. Their PTY
         // output never reaches the local PTY event loop above — it arrives over
         // the WS and is only parsed by the remote activity pump, which drains
@@ -416,6 +432,9 @@ impl Okena {
                 this.recover_local_daemon(cx);
             }
             RemoteManagerEvent::SettingsChanged(settings) => {
+                // Initial/reconnected daemon snapshots also restore the
+                // transient appearance after a daemon restart.
+                this.sync_system_appearance(cx);
                 let settings = settings.as_ref().clone();
                 let mode = settings.theme_mode;
                 let custom_id = settings.custom_theme_id.clone();
@@ -951,6 +970,17 @@ impl Okena {
         // should hold just did — clear the memo so the sync actually runs.
         self.scrollback_visible_projects.lock().take();
         self.publish_visible_projects(cx);
+    }
+
+    fn sync_system_appearance(&self, cx: &mut Context<Self>) {
+        let is_dark = crate::theme::theme_entity(cx).read(cx).system_is_dark();
+        self.remote_manager.update(cx, |manager, cx| {
+            manager.send_action(
+                okena_transport::client::LOCAL_DAEMON_CONNECTION_ID,
+                okena_core::api::ActionRequest::SetSystemAppearance { is_dark },
+                cx,
+            );
+        });
     }
 
     fn recover_local_daemon(&mut self, cx: &mut Context<Self>) {

--- a/crates/okena-core/src/api.rs
+++ b/crates/okena-core/src/api.rs
@@ -1216,6 +1216,11 @@ pub enum ActionRequest {
     SetTheme {
         id: String,
     },
+    /// Report the local desktop's system appearance for Auto terminal colors.
+    /// Transient: does not change the persisted theme preference.
+    SetSystemAppearance {
+        is_dark: bool,
+    },
     /// Write a custom theme JSON file (a full `CustomThemeConfig`) and,
     /// when `activate`, switch to it.
     SaveCustomTheme {

--- a/crates/okena-daemon-core/src/command_loop.rs
+++ b/crates/okena-daemon-core/src/command_loop.rs
@@ -2732,6 +2732,9 @@ pub async fn daemon_command_loop(
                     }
                     ActionRequest::GetThemes => daemon_config.get_themes(),
                     ActionRequest::GetTheme { id } => daemon_config.get_theme(id),
+                    ActionRequest::SetSystemAppearance { is_dark } => {
+                        daemon_config.set_system_appearance(is_dark)
+                    }
                     ActionRequest::SetTheme { id } => {
                         let result = daemon_config.set_theme(id);
                         publish_config_change_after_success(&result, &state_version);

--- a/crates/okena-daemon-core/src/daemon_config.rs
+++ b/crates/okena-daemon-core/src/daemon_config.rs
@@ -10,8 +10,9 @@
 //! theme **preference** (the data — `theme_mode` + `custom_theme_id`, persisted
 //! to settings.json) and the custom-theme files on disk. It does NOT own an
 //! `AppTheme` entity, because applying colors to pixels is the client's job.
-//! So `apply_active_theme` is a no-op here and `active_theme_colors` derives the
-//! editable blob's colors straight from the persisted `theme_mode`.
+//! The daemon still publishes the palette used for terminal color queries.
+//! Auto uses the local desktop's reported appearance, with a dark fallback
+//! until a desktop connects. Appearance is transient, not a saved preference.
 //!
 //! State is shared through a single `Arc<parking_lot::Mutex<AppSettings>>`,
 //! loaded once at daemon startup via [`load_settings`]. [`DaemonConfig`] is the
@@ -39,6 +40,8 @@ type SettingsPersister = Arc<dyn Fn(&AppSettings) -> Result<(), String> + Send +
 pub struct DaemonConfig {
     settings: Arc<Mutex<AppSettings>>,
     persist_settings: SettingsPersister,
+    system_is_dark: bool,
+    publish_palette: Arc<dyn Fn(ThemeColors) + Send + Sync>,
 }
 
 impl DaemonConfig {
@@ -53,6 +56,8 @@ impl DaemonConfig {
             persist_settings: Arc::new(|settings| {
                 save_settings(settings).map_err(|error| error.to_string())
             }),
+            system_is_dark: true,
+            publish_palette: Arc::new(okena_terminal::terminal::set_process_palette),
         }
     }
 
@@ -64,7 +69,23 @@ impl DaemonConfig {
         Self {
             settings,
             persist_settings,
+            system_is_dark: true,
+            publish_palette: Arc::new(okena_terminal::terminal::set_process_palette),
         }
+    }
+
+    /// Update Auto's resolved appearance without changing the saved theme.
+    pub fn set_system_appearance(&mut self, is_dark: bool) -> CommandResult {
+        self.system_is_dark = is_dark;
+        self.refresh_palette();
+        CommandResult::Ok(None)
+    }
+
+    fn refresh_palette(&mut self) {
+        let settings = self.settings.lock().clone();
+        let colors =
+            self.active_theme_colors(settings.theme_mode, settings.custom_theme_id.as_deref());
+        (self.publish_palette)(colors);
     }
 
     /// Return the full current settings as JSON.
@@ -132,6 +153,7 @@ impl ConfigBackend for DaemonConfig {
         // save failure leaves the in-memory settings unchanged.
         (self.persist_settings)(new)?;
         *self.settings.lock() = new.clone();
+        self.refresh_palette();
         Ok(())
     }
 
@@ -143,14 +165,14 @@ impl ConfigBackend for DaemonConfig {
             Some(colors) => colors,
             None => self.active_theme_colors(mode, None),
         };
-        okena_terminal::terminal::set_process_palette(colors);
+        (self.publish_palette)(colors);
     }
 
     fn active_theme_colors(&mut self, mode: ThemeMode, custom_id: Option<&str>) -> ThemeColors {
-        // No AppTheme entity here: derive the editable blob's colors straight
-        // from the held `theme_mode`. The daemon has no windowing system to
-        // detect light/dark, so Auto defaults to dark for this editable blob.
+        // The desktop reports system appearance without adding a windowing
+        // dependency to the daemon. Explicit themes ignore that report.
         match mode {
+            ThemeMode::Auto if !self.system_is_dark => LIGHT_THEME,
             ThemeMode::Dark | ThemeMode::Auto => DARK_THEME,
             ThemeMode::Light => LIGHT_THEME,
             ThemeMode::PastelDark => PASTEL_DARK_THEME,
@@ -183,6 +205,66 @@ mod tests {
 
     fn config_with(settings: AppSettings) -> DaemonConfig {
         DaemonConfig::new(Arc::new(Mutex::new(settings)))
+    }
+
+    #[test]
+    fn terminal_palette_tracks_settings_and_transient_system_appearance() {
+        let settings = Arc::new(Mutex::new(default_settings()));
+        settings.lock().theme_mode = ThemeMode::Auto;
+        let mut cfg = DaemonConfig::with_persistence(settings.clone(), Arc::new(|_| Ok(())));
+        let published = Arc::new(Mutex::new(Vec::new()));
+        let captured = published.clone();
+        cfg.publish_palette = Arc::new(move |colors| {
+            captured
+                .lock()
+                .push((colors.term_foreground, colors.term_background));
+        });
+
+        // Headless fallback, then the light desktop's initial report.
+        cfg.refresh_palette();
+        cfg.set_system_appearance(false);
+        assert_eq!(settings.lock().theme_mode, ThemeMode::Auto);
+
+        // The GUI uses SetSettings, not SetTheme. Explicit themes must win
+        // over OS appearance, including an OS change while Dark is selected.
+        assert!(matches!(
+            cfg.set_settings(json!({"theme_mode": "dark"})),
+            CommandResult::Ok(_)
+        ));
+        cfg.set_system_appearance(true);
+        assert!(matches!(
+            cfg.set_settings(json!({"theme_mode": "light"})),
+            CommandResult::Ok(_)
+        ));
+        assert!(matches!(
+            cfg.set_settings(json!({"theme_mode": "auto"})),
+            CommandResult::Ok(_)
+        ));
+        cfg.set_system_appearance(false);
+
+        let dark = (DARK_THEME.term_foreground, DARK_THEME.term_background);
+        let light = (LIGHT_THEME.term_foreground, LIGHT_THEME.term_background);
+        assert_eq!(
+            *published.lock(),
+            vec![dark, light, dark, dark, light, dark, light]
+        );
+    }
+
+    #[test]
+    fn failed_settings_save_keeps_terminal_palette_and_preference() {
+        let mut settings = default_settings();
+        settings.theme_mode = ThemeMode::Dark;
+        let settings = Arc::new(Mutex::new(settings));
+        let mut cfg = DaemonConfig::with_persistence(
+            settings.clone(),
+            Arc::new(|_| Err("disk unavailable".into())),
+        );
+        cfg.publish_palette = Arc::new(|_| panic!("failed save must not publish a palette"));
+        assert!(matches!(
+            cfg.set_settings(json!({"theme_mode": "light"})),
+            CommandResult::Err(_)
+        ));
+        assert_eq!(settings.lock().theme_mode, ThemeMode::Dark);
     }
 
     #[test]

--- a/crates/okena-terminal/src/terminal/tests/osc.rs
+++ b/crates/okena-terminal/src/terminal/tests/osc.rs
@@ -1252,6 +1252,35 @@ fn test_process_palette_answers_color_query_without_per_terminal_palette() {
     );
 }
 
+#[test]
+fn test_color_queries_report_active_light_and_dark_palette() {
+    let transport = Arc::new(CapturingTransport::new());
+    let terminal = Terminal::new(
+        "theme-query".into(),
+        TerminalSize::default(),
+        transport.clone(),
+        "/tmp".into(),
+    );
+    for palette in [
+        okena_core::theme::LIGHT_THEME,
+        okena_core::theme::DARK_THEME,
+    ] {
+        terminal.set_palette(palette);
+        for (code, color) in [(10, palette.term_foreground), (11, palette.term_background)] {
+            terminal.process_output(format!("\x1b]{code};?\x07").as_bytes());
+            let writes = transport.writes();
+            let reply = String::from_utf8_lossy(writes.last().expect("color query reply"));
+            let r = ((color >> 16) & 255) * 257;
+            let g = ((color >> 8) & 255) * 257;
+            let b = (color & 255) * 257;
+            assert_eq!(
+                reply,
+                format!("\x1b]{code};rgb:{r:04x}/{g:04x}/{b:04x}\x07")
+            );
+        }
+    }
+}
+
 // ── OSC 52 queue bounds ────────────────────────────────────────────────────
 //
 // The daemon parses the same byte stream as the UI but has no clipboard and no

--- a/crates/okena-theme/src/app_theme.rs
+++ b/crates/okena-theme/src/app_theme.rs
@@ -60,6 +60,10 @@ impl AppTheme {
         }
     }
 
+    pub fn system_is_dark(&self) -> bool {
+        self.system_is_dark
+    }
+
     /// Set custom theme colors
     pub fn set_custom_colors(&mut self, colors: ThemeColors) {
         self.custom_colors = Some(colors);


### PR DESCRIPTION
On macOS with a light system appearance and Okena's Auto theme, the desktop renders a light terminal but the daemon answers OSC color queries using the dark palette. Codex can consequently draw a dark composer behind the terminal's dark default text. Switching to Light in the GUI also leaves the daemon's palette stale because the GUI uses SetSettings, which previously only persisted the preference.

Report the local desktop's resolved system appearance to its daemon at startup, on appearance changes, and after reconnecting. The report is transient and preserves the Auto preference; explicit themes still take precedence. Refresh the terminal palette after successfully storing settings, including GUI theme changes. The daemon remains the sole terminal-query responder, and the desktop does not send appearance reports to user-managed remote connections.

Validation on macOS:

- `cargo test -p okena-terminal color_ --lib`: 2 passed, including exact OSC 10/11 replies for light and dark palettes.
- `cargo test -p okena-daemon-core -p okena-app daemon_config::tests --lib`: 4 passed; also compiles the desktop integration. Covers Auto light/dark transitions, explicit theme precedence, SetSettings palette updates, and failed persistence.
- Built the embedded web client with `bun install --frozen-lockfile && bun run build`.
- `git diff --check` passed. The standalone daemon dependency graph still excludes GPUI.

The daemon-only test command is blocked by an existing unrelated compile error in `okena-files/src/history.rs`: `get_file_at_source` references the GUI-gated `file_viewer::FileSource` without a matching feature gate. Tests above use the desktop's feature unification; this PR does not change those dependencies.

Manual GUI/Codex verification remains: select Auto on a light macOS desktop (or explicitly select Light), then launch a fresh Codex process and check composer contrast. Already-running applications may need restarting to query the updated colors.
