### PR TITLE
test: automate seven runbook checks, and fix the two bugs they found

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,12 @@ jobs:
             pkg-config \
             cmake
 
+      # Test dependencies, not build ones: dtach backs the session-teardown
+      # tests, zsh and fish the dropped-path quoting round-trip. Without them
+      # those tests skip themselves and the job stays green having proved less.
+      - name: Install test dependencies
+        run: sudo apt-get install -y dtach zsh fish
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
@@ -75,6 +81,9 @@ jobs:
       # The workspace declares no `default-members`, so a bare `cargo test` would
       # run the root `okena` package alone and skip every member crate's tests.
       - name: Run tests
+        env:
+          # Turn a missing shell from a silent skip into a failure.
+          OKENA_REQUIRE_SHELLS: 1
         run: cargo test --workspace --no-fail-fast
 
   # Windows-only `cfg` branches never compile in the Linux `check` job above, so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,8 +82,9 @@ jobs:
       # run the root `okena` package alone and skip every member crate's tests.
       - name: Run tests
         env:
-          # Turn a missing shell from a silent skip into a failure.
+          # Turn a missing prerequisite from a silent skip into a failure.
           OKENA_REQUIRE_SHELLS: 1
+          OKENA_REQUIRE_TUI: 1
         run: cargo test --workspace --no-fail-fast
 
   # Windows-only `cfg` branches never compile in the Linux `check` job above, so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,12 @@ jobs:
             exit 1
           fi
 
+      # `cargo test` builds another package's bin target as a test harness, never
+      # as a plain binary, so the end-to-end tests that drive the TUI would skip
+      # themselves without this.
+      - name: Build the TUI binary the end-to-end tests drive
+        run: cargo build -p okena-tui
+
       # The workspace declares no `default-members`, so a bare `cargo test` would
       # run the root `okena` package alone and skip every member crate's tests.
       - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6010,6 +6010,7 @@ dependencies = [
  "okena-views-git",
  "okena-views-terminal",
  "okena-workspace",
+ "portable-pty",
  "rust-embed",
  "serde_json",
  "tikv-jemallocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,10 @@ strip = false
 [dev-dependencies]
 gpui = { git = "https://github.com/zed-industries/zed", package = "gpui", features = ["test-support"] }
 
+# The end-to-end tests drive the shipped binaries the way a user does: the TUI
+# needs a real terminal to enter raw mode at all.
+portable-pty = "0.9"
+
 # jemalloc is the default allocator on Unix (Linux + macOS). Kept Unix-only
 # because tikv-jemalloc-sys doesn't build under MSVC; Windows uses mimalloc.
 # Enabled by the `jemalloc` feature (in `default`); installed by src/main.rs.

--- a/crates/okena-daemon-core/src/command_loop.rs
+++ b/crates/okena-daemon-core/src/command_loop.rs
@@ -2212,6 +2212,7 @@ pub(crate) fn spawn_background_worktree_removal(
     plan: WorktreeRemovalPlan,
     operation_epoch: u64,
     did_stash: bool,
+    delete_branch: bool,
     extra_teardown_terminal_ids: &[String],
     global_hooks: &okena_workspace::persistence::HooksConfig,
     workspace: &Arc<Mutex<Workspace>>,
@@ -2298,6 +2299,12 @@ pub(crate) fn spawn_background_worktree_removal(
             } else {
                 plan.remove_fast().map_err(|error| error.to_string())
             };
+            if delete_branch && removal.is_ok() {
+                okena_workspace::actions::worktree::delete_closed_worktree_branch(
+                    &plan.main_repo_path,
+                    plan.branch(),
+                );
+            }
             (plan, removal, dirty_hook)
         })
         .await;
@@ -2499,6 +2506,7 @@ fn abort_background_worktree_close(
 fn resume_worktree_close_after_merge(
     project_id: &str,
     did_stash: bool,
+    delete_branch: bool,
     global_hooks: &okena_workspace::persistence::HooksConfig,
     workspace: &Arc<Mutex<Workspace>>,
     workspace_tick: &watch::Sender<u64>,
@@ -2521,7 +2529,7 @@ fn resume_worktree_close_after_merge(
             false,
             false,
             false,
-            false,
+            delete_branch,
             did_stash,
             global_hooks,
             &mut cx,
@@ -2633,12 +2641,11 @@ fn spawn_merge_worktree_close(
                 let is_dirty = okena_git::has_uncommitted_changes(Path::new(&project_path));
                 let merge_enabled =
                     (!is_dirty || stash) && !branch.is_empty() && !default_branch.is_empty();
-                if merge_enabled {
+                let outcome = if merge_enabled {
                     close_worktree_merge_git(
                         stash && is_dirty,
                         fetch,
                         push,
-                        delete_branch,
                         &blocking_project_id,
                         &project_name,
                         &project_path,
@@ -2653,7 +2660,8 @@ fn spawn_merge_worktree_close(
                     )
                 } else {
                     CloseWorktreeGitOutcome::Ok { did_stash: false }
-                }
+                };
+                (outcome, merge_enabled)
             })
             .await;
 
@@ -2662,7 +2670,7 @@ fn spawn_merge_worktree_close(
             return;
         }
 
-        let did_stash = match outcome {
+        let (did_stash, merged) = match outcome {
             Err(error) => {
                 abort_background_worktree_close(
                     &project_id,
@@ -2675,7 +2683,7 @@ fn spawn_merge_worktree_close(
                 );
                 return;
             }
-            Ok(CloseWorktreeGitOutcome::Err(error)) => {
+            Ok((CloseWorktreeGitOutcome::Err(error), _)) => {
                 abort_background_worktree_close(
                     &project_id,
                     operation_epoch,
@@ -2687,7 +2695,7 @@ fn spawn_merge_worktree_close(
                 );
                 return;
             }
-            Ok(CloseWorktreeGitOutcome::RebaseConflict { error, hook_plan }) => {
+            Ok((CloseWorktreeGitOutcome::RebaseConflict { error, hook_plan }, _)) => {
                 if let Some(hook_plan) = hook_plan {
                     let outcome = okena_hooks::execute_hook_action_plan(
                         hook_plan,
@@ -2725,7 +2733,7 @@ fn spawn_merge_worktree_close(
                 );
                 return;
             }
-            Ok(CloseWorktreeGitOutcome::Ok { did_stash }) => did_stash,
+            Ok((CloseWorktreeGitOutcome::Ok { did_stash }, merged)) => (did_stash, merged),
         };
 
         let plan = {
@@ -2749,6 +2757,7 @@ fn spawn_merge_worktree_close(
                         plan,
                         operation_epoch,
                         did_stash,
+                        delete_branch && merged,
                         &[],
                         &global_hooks,
                         &workspace,
@@ -2785,6 +2794,7 @@ fn spawn_merge_worktree_close(
         let result = resume_worktree_close_after_merge(
             &project_id,
             did_stash,
+            delete_branch && merged,
             &global_hooks,
             &workspace,
             &workspace_tick,
@@ -3862,6 +3872,7 @@ pub async fn daemon_command_loop(
                                     spawn_background_worktree_removal(
                                         plan,
                                         operation_epoch,
+                                        false,
                                         false,
                                         &[],
                                         &global_hooks,
@@ -9391,6 +9402,7 @@ mod tests {
         let result = resume_worktree_close_after_merge(
             "wt1",
             true,
+            false,
             &Default::default(),
             &workspace,
             &workspace_tick,
@@ -9515,6 +9527,7 @@ mod tests {
                 let result = spawn_background_worktree_removal(
                     plan,
                     operation_epoch,
+                    false,
                     false,
                     &[],
                     &Default::default(),
@@ -9686,6 +9699,7 @@ mod tests {
                 let result = spawn_background_worktree_removal(
                     plan,
                     operation_epoch,
+                    false,
                     false,
                     &[],
                     &global_hooks,

--- a/crates/okena-daemon-core/src/pty_loop.rs
+++ b/crates/okena-daemon-core/src/pty_loop.rs
@@ -417,6 +417,7 @@ fn resolve_osc_worktree_closes(
                         plan,
                         operation_epoch,
                         pending.did_stash,
+                        pending.delete_branch,
                         std::slice::from_ref(terminal_id),
                         &global_hooks,
                         &reactor.workspace,
@@ -762,6 +763,7 @@ fn handle_hook_terminal_exits(
                             plan,
                             operation_epoch,
                             pending.did_stash,
+                            pending.delete_branch,
                             std::slice::from_ref(&tid),
                             &global_hooks,
                             &context.reactor.workspace,
@@ -1116,6 +1118,7 @@ mod tests {
             branch: "feature".into(),
             main_repo_path: main_repo.to_string_lossy().into_owned(),
             did_stash,
+            delete_branch: false,
         });
         workspace
     }

--- a/crates/okena-daemon-core/src/worktree_close_watchdog.rs
+++ b/crates/okena-daemon-core/src/worktree_close_watchdog.rs
@@ -142,6 +142,7 @@ mod tests {
             branch: "feature".into(),
             main_repo_path: std::env::temp_dir().to_string_lossy().into_owned(),
             did_stash: false,
+            delete_branch: false,
         });
         workspace
     }
@@ -211,6 +212,7 @@ mod tests {
                 branch: "feature".into(),
                 main_repo_path: std::env::temp_dir().to_string_lossy().into_owned(),
                 did_stash: false,
+                delete_branch: false,
             });
         assert!(
             workspace.lock().is_project_closing("worktree"),

--- a/crates/okena-state/src/transient.rs
+++ b/crates/okena-state/src/transient.rs
@@ -28,4 +28,7 @@ pub struct PendingWorktreeClose {
     /// Whether an earlier phase of this close actually stashed. Drives the
     /// post-stash guard, which must refuse a checkout that turned dirty again.
     pub did_stash: bool,
+    /// Whether the merge phase was asked to delete the branch. Git refuses
+    /// while the checkout still holds it, so it happens after the removal.
+    pub delete_branch: bool,
 }

--- a/crates/okena-tui/src/main.rs
+++ b/crates/okena-tui/src/main.rs
@@ -534,8 +534,11 @@ fn handle_key(
         return Ok(LoopControl::Continue);
     }
 
+    // Ctrl+] is the byte 0x1D, which crossterm reports as Ctrl+'5' — the whole
+    // 0x1C..=0x1F range maps onto '4'..='7'. Matching only ']' left the TUI with
+    // no reachable way out at all.
     if key.modifiers.contains(CrosstermKeyModifiers::CONTROL)
-        && matches!(key.code, KeyCode::Char(']'))
+        && matches!(key.code, KeyCode::Char(']') | KeyCode::Char('5'))
     {
         return Ok(LoopControl::Quit);
     }

--- a/crates/okena-views-terminal/src/layout/terminal_pane/actions.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/actions.rs
@@ -868,4 +868,70 @@ mod tests {
         assert!(unquoted(r"C:\Users\me-1_2.txt", PathQuoting::Cmd));
         assert!(unquoted(r"C:\Users\me-1_2.txt", PathQuoting::PowerShell));
     }
+
+    /// Names a shell must hand back byte for byte. Control characters are
+    /// refused outright, so none appears here.
+    const ROUND_TRIP_PATHS: [&str; 13] = [
+        "/tmp/a b.txt",
+        "/tmp/it's.txt",
+        "/tmp/$HOME.txt",
+        "/tmp/back\\slash.txt",
+        "/tmp/semi;colon.txt",
+        "/tmp/amp&pipe|.txt",
+        "/tmp/star*.txt",
+        "/tmp/brack[et].txt",
+        "/tmp/qu\"ote.txt",
+        "/tmp/(paren).txt",
+        "/tmp/{brace}.txt",
+        "/tmp/back`tick.txt",
+        "/tmp/hacek ěščřž.txt",
+    ];
+
+    /// Asserting the quoted string only against another string proves nothing
+    /// about the shell that parses it — so parse it with the real one. A shell
+    /// that is not installed is skipped, unless `OKENA_REQUIRE_SHELLS` is set.
+    #[cfg(unix)]
+    fn round_trips_through(program: &str, args: &[&str], quoting: PathQuoting) {
+        let mut probe = std::process::Command::new(program);
+        if probe.args(args).arg("exit 0").output().is_err() {
+            assert!(
+                std::env::var_os("OKENA_REQUIRE_SHELLS").is_none(),
+                "{program} is not installed and OKENA_REQUIRE_SHELLS demands it"
+            );
+            return;
+        }
+        for path in ROUND_TRIP_PATHS {
+            let quoted =
+                quote(path, quoting).unwrap_or_else(|| panic!("{quoting:?} refused {path}"));
+            let output = std::process::Command::new(program)
+                .args(args)
+                .arg(format!("printf %s {quoted}"))
+                .output()
+                .unwrap_or_else(|error| panic!("{program} failed to run: {error}"));
+            assert!(
+                output.status.success(),
+                "{program} rejected `printf %s {quoted}`: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert_eq!(
+                String::from_utf8_lossy(&output.stdout),
+                path,
+                "{program} did not reconstruct the name from {quoted}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn posix_quoting_round_trips_through_the_posix_shells() {
+        round_trips_through("sh", &["-c"], PathQuoting::Posix);
+        round_trips_through("bash", &["--norc", "--noprofile", "-c"], PathQuoting::Posix);
+        round_trips_through("zsh", &["-f", "-c"], PathQuoting::Posix);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fish_quoting_round_trips_through_fish() {
+        round_trips_through("fish", &["--no-config", "-c"], PathQuoting::Fish);
+    }
 }

--- a/crates/okena-workspace/src/actions/project.rs
+++ b/crates/okena-workspace/src/actions/project.rs
@@ -1365,6 +1365,141 @@ impl Workspace {
 }
 
 #[cfg(test)]
+mod worktree_rename_tests {
+    use crate::settings::HooksConfig;
+    use crate::state::{Workspace, WorkspaceData};
+    use okena_core::theme::FolderColor;
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    struct TestRoot(PathBuf);
+
+    impl Drop for TestRoot {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn git(args: &[&str]) {
+        let output = Command::new("git").args(args).output().unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn path_str(path: &Path) -> &str {
+        path.to_str().expect("test path is utf-8")
+    }
+
+    fn project(id: &str, path: &Path) -> okena_state::ProjectData {
+        okena_state::ProjectData {
+            id: id.to_string(),
+            name: id.to_string(),
+            path: path.to_string_lossy().into_owned(),
+            layout: None,
+            terminal_names: HashMap::new(),
+            hidden_terminals: HashMap::new(),
+            worktree_info: None,
+            worktree_ids: Vec::new(),
+            folder_color: FolderColor::default(),
+            hooks: HooksConfig::default(),
+            connection_id: None,
+            service_terminals: HashMap::new(),
+            default_shell: None,
+            hook_terminals: HashMap::new(),
+            pinned: false,
+            last_activity_at: None,
+            is_creating: false,
+            is_closing: false,
+            creating_progress: None,
+        }
+    }
+
+    /// A plain project directory holding a linked worktree checkout, whose own
+    /// project row points at a package inside that checkout — the monorepo
+    /// shape, with the package missing because the branch no longer has it.
+    fn workspace_over_a_held_checkout(root: &Path, recorded_root: &str) -> Workspace {
+        let main_repo = root.join("main");
+        let holder = root.join("holder");
+        let checkout = holder.join("wt");
+        std::fs::create_dir_all(&holder).unwrap();
+        git(&["init", "-b", "main", path_str(&main_repo)]);
+        git(&[
+            "-C",
+            path_str(&main_repo),
+            "config",
+            "user.email",
+            "okena@example.invalid",
+        ]);
+        git(&[
+            "-C",
+            path_str(&main_repo),
+            "config",
+            "user.name",
+            "Okena Test",
+        ]);
+        std::fs::write(main_repo.join("base.txt"), "base\n").unwrap();
+        git(&["-C", path_str(&main_repo), "add", "base.txt"]);
+        git(&["-C", path_str(&main_repo), "commit", "-m", "base"]);
+        git(&[
+            "-C",
+            path_str(&main_repo),
+            "worktree",
+            "add",
+            "-b",
+            "feature",
+            path_str(&checkout),
+        ]);
+
+        let mut worktree_project = project("wt", &checkout.join("packages/app"));
+        worktree_project.worktree_info = Some(okena_state::WorktreeMetadata {
+            parent_project_id: "main".to_string(),
+            color_override: None,
+            main_repo_path: main_repo.to_string_lossy().into_owned(),
+            worktree_path: recorded_root.to_string(),
+            branch_name: "feature".to_string(),
+        });
+
+        let mut data = WorkspaceData::empty();
+        data.projects = vec![
+            project("main", &main_repo),
+            project("holder", &holder),
+            worktree_project,
+        ];
+        Workspace::new(data)
+    }
+
+    /// `worktree_path` is what makes the checkout visible here: the project row
+    /// points at a package that a branch switch removed, so nothing else in the
+    /// tree can say a worktree lives under the directory being renamed.
+    #[test]
+    fn renaming_a_directory_that_holds_a_recorded_worktree_root_is_refused() {
+        let root = TestRoot(
+            std::env::temp_dir().join(format!("okena-held-checkout-{}", uuid::Uuid::new_v4())),
+        );
+        let checkout = root.0.join("holder/wt");
+        let workspace = workspace_over_a_held_checkout(&root.0, path_str(&checkout));
+
+        let Err(error) = workspace.prepare_project_directory_rename(
+            "holder",
+            root.0.join("renamed").to_string_lossy().into_owned(),
+            "renamed".to_string(),
+        ) else {
+            panic!("a directory holding a checkout must not be renamed");
+        };
+
+        assert!(
+            error.contains("recorded worktree root"),
+            "the refusal must name what it is protecting: {error}"
+        );
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::{expand_tilde, pick_focus_replacement};
     use crate::context::WorkspaceCx;

--- a/crates/okena-workspace/src/actions/worktree.rs
+++ b/crates/okena-workspace/src/actions/worktree.rs
@@ -1610,6 +1610,126 @@ mod merge_pipeline_tests {
         assert!(history[0].terminal_id.is_none());
     }
 
+    /// The second destination check exists for this: the first one passed, and
+    /// the hook moved HEAD after it.
+    #[cfg(unix)]
+    #[test]
+    fn a_pre_merge_hook_that_moves_head_is_caught_before_the_merge() {
+        let fixture = TestRepo::new();
+        let (main_repo, worktree) = main_repo_with_feature_worktree(&fixture);
+        let main_before = rev_parse(&main_repo, "main");
+
+        // Dirty the checkout so the pipeline stashes: the refusal has to hand
+        // the work back, not strand it in the stash list.
+        std::fs::write(worktree.join("wip.txt"), "wip\n").unwrap();
+        git(&["-C", path_str(&worktree), "add", "wip.txt"]);
+
+        let hooks = HooksConfig {
+            worktree: WorktreeHooks {
+                pre_merge: Some(
+                    "git -C \"$OKENA_MAIN_REPO_PATH\" checkout -q -b develop".to_string(),
+                ),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let outcome = close_worktree_merge_git(
+            true,
+            false,
+            false,
+            false,
+            "p1",
+            "Project",
+            path_str(&worktree),
+            "feature",
+            "main",
+            path_str(&main_repo),
+            &hooks,
+            &HooksConfig::default(),
+            None,
+            None,
+            None,
+        );
+
+        let CloseWorktreeGitOutcome::Err(error) = outcome else {
+            panic!("a hook that moved HEAD must not reach the merge");
+        };
+        assert!(
+            error.contains("'develop'") && error.contains("'main'"),
+            "the refusal must name both branches: {error}"
+        );
+        assert_eq!(
+            rev_parse(&main_repo, "main"),
+            main_before,
+            "nothing may be merged into the branch the hook left behind"
+        );
+        assert_eq!(
+            rev_parse(&main_repo, "develop"),
+            main_before,
+            "nor into the branch the hook switched to"
+        );
+        assert!(
+            worktree.join("wip.txt").exists(),
+            "the stash must be popped back on the refusal"
+        );
+    }
+
+    /// The happy path with every toggle on — the regression control for the
+    /// destination checks above, and the only place `push` is exercised.
+    #[test]
+    fn a_close_with_every_toggle_on_merges_and_reaches_the_remote() {
+        let fixture = TestRepo::new();
+        let (main_repo, worktree) = main_repo_with_feature_worktree(&fixture);
+        let remote = fixture.root.join("remote.git");
+        git(&["init", "--bare", "-b", "main", path_str(&remote)]);
+        git(&[
+            "-C",
+            path_str(&main_repo),
+            "remote",
+            "add",
+            "origin",
+            path_str(&remote),
+        ]);
+        git(&["-C", path_str(&main_repo), "push", "-q", "origin", "main"]);
+        let feature_tip = rev_parse(&worktree, "HEAD");
+
+        let outcome = close_worktree_merge_git(
+            false,
+            true,
+            true,
+            true,
+            "p1",
+            "Project",
+            path_str(&worktree),
+            "feature",
+            "main",
+            path_str(&main_repo),
+            &HooksConfig::default(),
+            &HooksConfig::default(),
+            None,
+            None,
+            None,
+        );
+
+        assert!(matches!(
+            outcome,
+            CloseWorktreeGitOutcome::Ok { did_stash: false }
+        ));
+        let merged = rev_parse(&main_repo, "main");
+        assert_ne!(merged, feature_tip, "--no-ff must leave a merge commit");
+        assert_eq!(
+            rev_parse(&main_repo, "main^2"),
+            feature_tip,
+            "the feature tip must be the second parent of the merge"
+        );
+        assert_eq!(
+            rev_parse(&remote, "main"),
+            merged,
+            "push must carry the merge to the remote"
+        );
+    }
+
     #[test]
     fn removal_plan_finishes_close_hooks_while_checkout_exists() {
         let fixture = TestRepo::new();

--- a/crates/okena-workspace/src/actions/worktree.rs
+++ b/crates/okena-workspace/src/actions/worktree.rs
@@ -68,6 +68,11 @@ impl WorktreeRemovalPlan {
         &self.worktree_path
     }
 
+    /// The branch the removed checkout held.
+    pub fn branch(&self) -> &str {
+        &self.branch
+    }
+
     /// Whether this plan deletes a checkout Git no longer tracks.
     pub fn is_orphaned(&self) -> bool {
         matches!(self.target, WorktreeRemovalTarget::Orphaned(_))
@@ -212,8 +217,10 @@ fn verify_merge_destination(main_repo_path: &str, default_branch: &str) -> Resul
 }
 
 /// The worktree-close merge pipeline: stash → fetch → pre_merge hook → rebase →
-/// merge → post_merge hook → push → delete-branch, with stash-pop recovery on any
-/// failing step. PURE: only git subprocesses + headless hooks (monitor, no PTY
+/// merge → post_merge hook → push, with stash-pop recovery on any failing step.
+/// Deleting the branch is not part of it — see [`delete_closed_worktree_branch`].
+///
+/// PURE: only git subprocesses + headless hooks (monitor, no PTY
 /// runner), no `&mut Workspace` — so the daemon runs it on a blocking thread with
 /// no lock held. `on_rebase_conflict` is resolved into a deferred plan for the
 /// caller to execute and register on its reactor. Call only when merge is enabled.
@@ -222,7 +229,6 @@ pub fn close_worktree_merge_git(
     stash_enabled: bool,
     fetch_enabled: bool,
     push_enabled: bool,
-    delete_branch_enabled: bool,
     project_id: &str,
     project_name: &str,
     project_path: &str,
@@ -332,16 +338,23 @@ pub fn close_worktree_merge_git(
         log::warn!("Push failed (continuing): {}", e);
     }
 
-    if delete_branch_enabled {
-        if let Err(e) = okena_git::delete_local_branch(Path::new(main_repo_path), branch) {
-            log::warn!("Delete local branch failed (continuing): {}", e);
-        }
-        if let Err(e) = okena_git::delete_remote_branch(Path::new(main_repo_path), branch) {
-            log::warn!("Delete remote branch failed (continuing): {}", e);
-        }
-    }
-
     CloseWorktreeGitOutcome::Ok { did_stash }
+}
+
+/// Delete a closed worktree's branch, local and remote.
+///
+/// Only ever call this once the checkout is gone: `git branch -d` refuses a
+/// branch a worktree still holds, and the refusal is not worth surfacing — the
+/// close itself succeeded. A branch that survives is recoverable; the checkout
+/// this deletes it after is not.
+pub fn delete_closed_worktree_branch(main_repo_path: &str, branch: &str) {
+    let repo = std::path::Path::new(main_repo_path);
+    if let Err(e) = okena_git::delete_local_branch(repo, branch) {
+        log::warn!("Delete local branch failed (continuing): {}", e);
+    }
+    if let Err(e) = okena_git::delete_remote_branch(repo, branch) {
+        log::warn!("Delete remote branch failed (continuing): {}", e);
+    }
 }
 
 impl Workspace {
@@ -1286,7 +1299,10 @@ impl Workspace {
         let stash_enabled = stash && is_dirty;
         let fetch_enabled = fetch;
         let push_enabled = push;
-        let delete_branch_enabled = delete_branch;
+        // A branch may only be deleted once its work is merged and the checkout
+        // holding it is gone: either this call merges, or a caller resuming a
+        // merge it already ran comes in with `merge` off and vouches for it.
+        let delete_branch_enabled = delete_branch && (merge_enabled || !merge);
 
         let folder = self.folder_for_project_or_parent(project_id);
         let folder_id = folder.map(|f| f.id.clone());
@@ -1302,7 +1318,6 @@ impl Workspace {
                 stash_enabled,
                 fetch_enabled,
                 push_enabled,
-                delete_branch_enabled,
                 project_id,
                 &project_name,
                 &project_path,
@@ -1374,6 +1389,7 @@ impl Workspace {
                     branch: branch.clone(),
                     main_repo_path: main_repo_path.clone(),
                     did_stash,
+                    delete_branch: delete_branch_enabled,
                 });
                 Ok(())
             } else {
@@ -1422,13 +1438,24 @@ impl Workspace {
 
             // remove_worktree_project completes close hooks, removes the git
             // worktree, and deletes the project.
-            self.remove_worktree_project(focus_manager, project_id, force_remove, global_hooks, cx)
+            let removed = self.remove_worktree_project(
+                focus_manager,
+                project_id,
+                force_remove,
+                global_hooks,
+                cx,
+            );
+            if removed.is_ok() && delete_branch_enabled {
+                delete_closed_worktree_branch(&main_repo_path, &branch);
+            }
+            removed
         }
     }
 }
 
 #[cfg(test)]
 mod merge_pipeline_tests {
+    use super::delete_closed_worktree_branch;
     use super::{
         CloseWorktreeGitOutcome, WorktreeRemovalPlan, WorktreeRemovalTarget, close_dirty_state,
         close_worktree_merge_git,
@@ -1536,7 +1563,6 @@ mod merge_pipeline_tests {
             false,
             false,
             false,
-            false,
             "p1",
             "Project",
             path_str(&worktree),
@@ -1582,7 +1608,6 @@ mod merge_pipeline_tests {
         };
         let monitor = HookMonitor::new();
         let outcome = close_worktree_merge_git(
-            false,
             false,
             false,
             false,
@@ -1638,7 +1663,6 @@ mod merge_pipeline_tests {
             true,
             false,
             false,
-            false,
             "p1",
             "Project",
             path_str(&worktree),
@@ -1675,10 +1699,75 @@ mod merge_pipeline_tests {
         );
     }
 
-    /// The happy path with every toggle on — the regression control for the
-    /// destination checks above, and the only place `push` is exercised.
+    fn local_branches(repo: &Path) -> String {
+        let output = Command::new("git")
+            .args(["-C", path_str(repo), "branch", "--format=%(refname:short)"])
+            .output()
+            .unwrap();
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    }
+
+    /// The whole reason the deletion left the merge pipeline: Git refuses to
+    /// delete a branch a checkout still holds, and that refusal was only logged.
     #[test]
-    fn a_close_with_every_toggle_on_merges_and_reaches_the_remote() {
+    fn a_branch_is_deleted_only_once_its_checkout_is_gone() {
+        let fixture = TestRepo::new();
+        let (main_repo, worktree) = main_repo_with_feature_worktree(&fixture);
+        let remote = fixture.root.join("remote.git");
+        git(&["init", "--bare", "-b", "main", path_str(&remote)]);
+        git(&[
+            "-C",
+            path_str(&main_repo),
+            "remote",
+            "add",
+            "origin",
+            path_str(&remote),
+        ]);
+        git(&["-C", path_str(&main_repo), "push", "-q", "origin", "main"]);
+        git(&["-C", path_str(&worktree), "push", "-q", "origin", "feature"]);
+        // `git branch -d` also refuses an unmerged branch; the close deletes
+        // one it has just merged.
+        git(&[
+            "-C",
+            path_str(&main_repo),
+            "merge",
+            "--no-ff",
+            "-q",
+            "-m",
+            "merge",
+            "feature",
+        ]);
+
+        delete_closed_worktree_branch(path_str(&main_repo), "feature");
+        assert!(
+            local_branches(&main_repo).contains("feature"),
+            "git cannot delete a branch its worktree still holds"
+        );
+
+        git(&[
+            "-C",
+            path_str(&main_repo),
+            "worktree",
+            "remove",
+            "--force",
+            path_str(&worktree),
+        ]);
+        delete_closed_worktree_branch(path_str(&main_repo), "feature");
+
+        assert!(
+            !local_branches(&main_repo).contains("feature"),
+            "the local branch must be gone once its checkout is"
+        );
+        assert!(
+            !local_branches(&remote).contains("feature"),
+            "and so must the remote one"
+        );
+    }
+
+    /// The happy path with the remaining toggles on — the regression control for
+    /// the destination checks above, and the only place `push` is exercised.
+    #[test]
+    fn a_close_that_fetches_and_pushes_carries_the_merge_to_the_remote() {
         let fixture = TestRepo::new();
         let (main_repo, worktree) = main_repo_with_feature_worktree(&fixture);
         let remote = fixture.root.join("remote.git");
@@ -1696,7 +1785,6 @@ mod merge_pipeline_tests {
 
         let outcome = close_worktree_merge_git(
             false,
-            true,
             true,
             true,
             "p1",

--- a/crates/okena-workspace/src/lifecycle.rs
+++ b/crates/okena-workspace/src/lifecycle.rs
@@ -165,6 +165,7 @@ mod tests {
             branch: "main".to_string(),
             main_repo_path: "/tmp/repo".to_string(),
             did_stash: false,
+            delete_branch: false,
         }
     }
 

--- a/crates/okena-workspace/src/state.rs
+++ b/crates/okena-workspace/src/state.rs
@@ -2479,6 +2479,7 @@ mod workspace_tests {
             branch: "feature".into(),
             main_repo_path: "/tmp".into(),
             did_stash: false,
+            delete_branch: false,
         });
         assert!(workspace.is_project_closing("wt1"));
         assert!(workspace.project("wt1").unwrap().is_closing);

--- a/tests/cli_over_the_remote_api.rs
+++ b/tests/cli_over_the_remote_api.rs
@@ -203,9 +203,10 @@ fn a_null_puts_a_setting_back_to_its_default() {
     );
 }
 
-/// The TUI binary, built alongside this test by `cargo test --workspace`.
-/// `CARGO_BIN_EXE_` only covers this package's own binaries, so it is found
-/// next to the test executable instead.
+/// The TUI binary, found next to the test executable: `CARGO_BIN_EXE_` covers
+/// only this package's own binaries, and `cargo test` builds another package's
+/// bin target as a test harness, never as a plain binary. CI runs
+/// `cargo build -p okena-tui` for it; locally, so must you.
 fn tui_binary() -> Option<PathBuf> {
     let mut dir = std::env::current_exe().ok()?;
     dir.pop();
@@ -227,7 +228,7 @@ fn a_tui_that_cannot_connect_leaves_the_host_terminal_alone() {
             std::env::var_os("OKENA_REQUIRE_TUI").is_none(),
             "okena-tui is not built and OKENA_REQUIRE_TUI demands it"
         );
-        eprintln!("skipping: okena-tui is not built (run `cargo test --workspace`)");
+        eprintln!("skipping: run `cargo build -p okena-tui` to cover the tui");
         return;
     };
 
@@ -284,7 +285,7 @@ fn the_tui_hands_the_host_terminal_back_when_it_quits() {
             std::env::var_os("OKENA_REQUIRE_TUI").is_none(),
             "okena-tui is not built and OKENA_REQUIRE_TUI demands it"
         );
-        eprintln!("skipping: okena-tui is not built (run `cargo test --workspace`)");
+        eprintln!("skipping: run `cargo build -p okena-tui` to cover the tui");
         return;
     };
 

--- a/tests/cli_over_the_remote_api.rs
+++ b/tests/cli_over_the_remote_api.rs
@@ -1,0 +1,265 @@
+//! `okena <subcommand>` against a real headless daemon.
+//!
+//! Every other CLI test is a parser or a resolver over a canned state; nothing
+//! reached the HTTP API the subcommands actually speak. This one runs the
+//! shipped binary in both roles — `--headless` is the daemon, the same binary
+//! is the client — over an isolated config and runtime directory.
+
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+const BIN: &str = env!("CARGO_BIN_EXE_okena");
+
+/// A headless daemon with its own config, runtime and home directory. Runtime
+/// isolation is not optional: the dtach socket pool lives under
+/// `XDG_RUNTIME_DIR`, and a second instance sharing it reconciles — and kills —
+/// the sessions of the one already running.
+struct Daemon {
+    child: Child,
+    root: PathBuf,
+}
+
+impl Daemon {
+    fn start() -> Self {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock after the epoch")
+            .as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("okena-cli-e2e-{}-{unique}", std::process::id()));
+        for sub in ["cfg", "run", "home"] {
+            std::fs::create_dir_all(root.join(sub)).expect("scratch directory");
+        }
+
+        let child = Self::command(&root)
+            .arg("--headless")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn the headless daemon");
+
+        let daemon = Self { child, root };
+        daemon.wait_for_remote_json();
+        daemon
+    }
+
+    fn command(root: &Path) -> Command {
+        let mut command = Command::new(BIN);
+        command
+            .env("XDG_CONFIG_HOME", root.join("cfg"))
+            .env("XDG_RUNTIME_DIR", root.join("run"))
+            .env("HOME", root.join("home"))
+            .env_remove("OKENA_PROFILE");
+        command
+    }
+
+    /// The daemon publishes its port here, and the CLI discovers it from here.
+    fn wait_for_remote_json(&self) {
+        let published = self.root.join("cfg/okena/profiles/default/remote.json");
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while Instant::now() < deadline {
+            if published.exists() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        panic!("the daemon never published {}", published.display());
+    }
+
+    fn cli(&self, args: &[&str]) -> Output {
+        Self::command(&self.root)
+            .args(args)
+            .output()
+            .unwrap_or_else(|error| panic!("running `okena {}`: {error}", args.join(" ")))
+    }
+
+    fn ok(&self, args: &[&str]) -> String {
+        let output = self.cli(args);
+        assert!(
+            output.status.success(),
+            "`okena {}` failed: {}{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn overview(&self) -> serde_json::Value {
+        serde_json::from_str(&self.ok(&["ls", "--json"])).expect("`ls --json` emits JSON")
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        // dtach masters outlive the daemon by design; ours are addressed by a
+        // path no other process on the machine can match.
+        let _ = Command::new("pkill")
+            .arg("-f")
+            .arg(self.root.join("run").to_string_lossy().as_ref())
+            .status();
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+fn project_ids(overview: &serde_json::Value) -> Vec<String> {
+    overview["projects"]
+        .as_array()
+        .expect("projects array")
+        .iter()
+        .map(|project| project["id"].as_str().expect("project id").to_string())
+        .collect()
+}
+
+#[test]
+fn the_cli_sees_what_it_adds_to_a_running_daemon() {
+    let daemon = Daemon::start();
+    let workdir = daemon.root.join("home/a-project");
+    std::fs::create_dir_all(&workdir).unwrap();
+
+    let before = project_ids(&daemon.overview());
+    let project_id = daemon.ok(&["project", "add", workdir.to_str().unwrap()]);
+    assert!(!project_id.is_empty(), "`project add` prints the new id");
+
+    let overview = daemon.overview();
+    let after = project_ids(&overview);
+    assert!(
+        !before.contains(&project_id) && after.contains(&project_id),
+        "the added project must appear in `ls --json`: {after:?}"
+    );
+
+    let terminal_id = daemon.ok(&["term", "new", &project_id]);
+    let terminals = overview_terminals(&daemon.overview(), &project_id);
+    assert!(
+        terminals.contains(&terminal_id),
+        "`term new` printed {terminal_id}, which is not in {terminals:?}"
+    );
+}
+
+fn overview_terminals(overview: &serde_json::Value, project_id: &str) -> Vec<String> {
+    overview["projects"]
+        .as_array()
+        .expect("projects array")
+        .iter()
+        .find(|project| project["id"] == project_id)
+        .expect("the project we just added")["terminals"]
+        .as_array()
+        .expect("terminals array")
+        .iter()
+        .map(|id| id.as_str().expect("terminal id").to_string())
+        .collect()
+}
+
+#[test]
+fn a_null_puts_a_setting_back_to_its_default() {
+    let daemon = Daemon::start();
+    let default_font_size = daemon.ok(&["settings", "show", "font_size"]);
+    assert!(
+        !default_font_size.is_empty(),
+        "the daemon must answer with the current value"
+    );
+
+    daemon.ok(&["settings", "set", "font_size", "17"]);
+    assert_eq!(daemon.ok(&["settings", "show", "font_size"]), "17.0");
+    daemon.ok(&["settings", "set", "font_size", "null"]);
+    assert_eq!(
+        daemon.ok(&["settings", "show", "font_size"]),
+        default_font_size,
+        "null must restore the default, not store a literal null"
+    );
+
+    daemon.ok(&[
+        "settings",
+        "set",
+        "hooks.worktree.pre_merge",
+        "echo okena-e2e",
+    ]);
+    assert!(
+        daemon
+            .ok(&["settings", "show", "hooks"])
+            .contains("okena-e2e"),
+        "the hook must survive the round trip to the daemon"
+    );
+    daemon.ok(&["settings", "set", "hooks.worktree.pre_merge", "null"]);
+    assert!(
+        !daemon
+            .ok(&["settings", "show", "hooks"])
+            .contains("okena-e2e"),
+        "clearing one hook must reach the daemon"
+    );
+}
+
+/// The TUI binary, built alongside this test by `cargo test --workspace`.
+/// `CARGO_BIN_EXE_` only covers this package's own binaries, so it is found
+/// next to the test executable instead.
+fn tui_binary() -> Option<PathBuf> {
+    let mut dir = std::env::current_exe().ok()?;
+    dir.pop();
+    if dir.ends_with("deps") {
+        dir.pop();
+    }
+    let binary = dir.join("okena-tui");
+    binary.exists().then_some(binary)
+}
+
+/// `TerminalGuard` owns every host terminal mode the TUI changes, and it is
+/// entered only once a connection carries state. A TUI that cannot reach its
+/// daemon therefore owes the shell it was started from an untouched terminal —
+/// which only a real terminal can answer for.
+#[test]
+fn a_tui_that_cannot_connect_leaves_the_host_terminal_alone() {
+    let Some(tui) = tui_binary() else {
+        assert!(
+            std::env::var_os("OKENA_REQUIRE_TUI").is_none(),
+            "okena-tui is not built and OKENA_REQUIRE_TUI demands it"
+        );
+        eprintln!("skipping: okena-tui is not built (run `cargo test --workspace`)");
+        return;
+    };
+
+    let pty = portable_pty::native_pty_system()
+        .openpty(portable_pty::PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("open a pty");
+
+    // Port 1 is privileged and unbound: the connection fails before the guard.
+    let mut command = portable_pty::CommandBuilder::new(tui);
+    command.args(["--host", "127.0.0.1", "--port", "1"]);
+    command.env("TERM", "xterm-256color");
+    let mut child = pty.slave.spawn_command(command).expect("spawn the tui");
+    drop(pty.slave);
+
+    let mut reader = pty.master.try_clone_reader().expect("pty reader");
+    let pump = std::thread::spawn(move || {
+        let mut host = Vec::new();
+        let _ = std::io::Read::read_to_end(&mut reader, &mut host);
+        host
+    });
+
+    let status = child.wait().expect("the tui exits");
+    drop(pty.master);
+    let host = String::from_utf8_lossy(&pump.join().expect("reader thread")).into_owned();
+
+    assert!(!status.success(), "an unreachable daemon must not exit 0");
+    for (sequence, what) in [
+        ("\x1b[?1049h", "the alternate screen"),
+        ("\x1b[?25l", "cursor hiding"),
+        ("\x1b[?2004h", "bracketed paste"),
+        ("\x1b[?7l", "no-wrap"),
+    ] {
+        assert!(
+            !host.contains(sequence),
+            "{what} was switched on before the connection existed: {}",
+            host.escape_debug()
+        );
+    }
+}

--- a/tests/cli_over_the_remote_api.rs
+++ b/tests/cli_over_the_remote_api.rs
@@ -88,6 +88,15 @@ impl Daemon {
         String::from_utf8_lossy(&output.stdout).trim().to_string()
     }
 
+    /// The bearer token the first CLI call registered for this daemon.
+    fn cli_token(&self) -> String {
+        let path = self.root.join("cfg/okena/profiles/default/cli.json");
+        let config: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("cli.json"))
+                .expect("cli.json is JSON");
+        config["token"].as_str().expect("a token").to_string()
+    }
+
     fn overview(&self) -> serde_json::Value {
         serde_json::from_str(&self.ok(&["ls", "--json"])).expect("`ls --json` emits JSON")
     }
@@ -259,6 +268,106 @@ fn a_tui_that_cannot_connect_leaves_the_host_terminal_alone() {
         assert!(
             !host.contains(sequence),
             "{what} was switched on before the connection existed: {}",
+            host.escape_debug()
+        );
+    }
+}
+
+/// The other half of the guard's contract: what it turned on, it turns back off.
+/// `Drop` runs only when the event loop returns, so this also pins that the quit
+/// binding stays reachable — it was unreachable until the byte Ctrl+] actually
+/// sends was matched.
+#[test]
+fn the_tui_hands_the_host_terminal_back_when_it_quits() {
+    let Some(tui) = tui_binary() else {
+        assert!(
+            std::env::var_os("OKENA_REQUIRE_TUI").is_none(),
+            "okena-tui is not built and OKENA_REQUIRE_TUI demands it"
+        );
+        eprintln!("skipping: okena-tui is not built (run `cargo test --workspace`)");
+        return;
+    };
+
+    let daemon = Daemon::start();
+    // Registers the token this run reuses; the TUI does no pairing of its own.
+    daemon.ok(&["ls"]);
+
+    let pty = portable_pty::native_pty_system()
+        .openpty(portable_pty::PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("open a pty");
+
+    let mut command = portable_pty::CommandBuilder::new(tui);
+    command.env("XDG_CONFIG_HOME", daemon.root.join("cfg"));
+    command.env("XDG_RUNTIME_DIR", daemon.root.join("run"));
+    command.env("HOME", daemon.root.join("home"));
+    command.env("OKENA_TOKEN", daemon.cli_token());
+    command.env("TERM", "xterm-256color");
+    let mut child = pty.slave.spawn_command(command).expect("spawn the tui");
+    drop(pty.slave);
+
+    let mut reader = pty.master.try_clone_reader().expect("pty reader");
+    let collected = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let sink = collected.clone();
+    let pump = std::thread::spawn(move || {
+        let mut buffer = [0u8; 4096];
+        while let Ok(read) = std::io::Read::read(&mut reader, &mut buffer) {
+            if read == 0 {
+                break;
+            }
+            sink.lock()
+                .expect("sink")
+                .extend_from_slice(&buffer[..read]);
+        }
+    });
+    let host = || String::from_utf8_lossy(&collected.lock().expect("sink")).into_owned();
+
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while !host().contains("\x1b[?1049h") && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        host().contains("\x1b[?1049h"),
+        "the tui never reached the alternate screen: {}",
+        host().escape_debug()
+    );
+
+    let mut writer = pty.master.take_writer().expect("pty writer");
+    // The byte Ctrl+] sends. Anything the TUI does not recognise as quit goes
+    // to the remote terminal instead, and it would run until killed.
+    std::io::Write::write_all(&mut writer, b"\x1d").expect("send ctrl-]");
+    std::io::Write::flush(&mut writer).expect("flush ctrl-]");
+    drop(writer);
+
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let status = loop {
+        match child.try_wait().expect("poll the tui") {
+            Some(status) => break status,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                panic!("the tui did not quit on ctrl-]: {}", host().escape_debug());
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    };
+    drop(pty.master);
+    let _ = pump.join();
+
+    assert!(status.success(), "quitting must exit 0, got {status:?}");
+    let host = host();
+    for (sequence, what) in [
+        ("\x1b[?1049l", "the alternate screen"),
+        ("\x1b[?7h", "autowrap"),
+        ("\x1b[?25h", "the cursor"),
+        ("\x1b[?2004l", "bracketed paste"),
+    ] {
+        assert!(
+            host.contains(sequence),
+            "{what} was never restored: {}",
             host.escape_debug()
         );
     }


### PR DESCRIPTION
Last of five stacked PRs. Base is the review-fixes branch; merge that one first.

The review fixes came with a hand-verification runbook of 32 checks. Seven of
those turned out to be automatable, and closing them found two bugs.

## Tests

- **Real shells parse the quoted drop.** Every test for `quote_dropped_path`
  compared one string to another, which says nothing about the shell doing the
  parsing. `printf %s <quoted>` now runs through `sh`, `bash`, `zsh` and `fish`
  over thirteen names carrying spaces, quotes, `$`, backslashes, globs and
  brackets, and the bytes must come back unchanged.
- **The CLI drives a real daemon.** Every CLI test was a parser or a resolver
  over canned state; nothing reached the HTTP API the subcommands speak. The
  new end-to-end tests run `okena --headless` as the daemon and the same binary
  as the client, over an isolated config, runtime and home directory. Runtime
  isolation is not optional: the dtach socket pool lives under
  `XDG_RUNTIME_DIR`, and a second instance sharing it kills the sessions of the
  one already running.
- **The TUI runs under a real PTY**, both for a connection it cannot make and
  for a session it quits.
- **The second merge-destination check is reachable.** Only the first of the
  two had a test; the second is the one the guard exists for, and the refusal
  owes the user their stash back.
- **The rename refusal a recorded checkout root unlocks** had never fired,
  because the field it reads was dropped on every save.

## Silent skips

`dtach_teardown_reaps_the_real_child_process_tree` returns early when `dtach` is
missing, and CI never installed it — so it had been skipping itself on every
run while the job went green. CI now installs `dtach`, `zsh` and `fish`, and
`OKENA_REQUIRE_SHELLS` / `OKENA_REQUIRE_TUI` turn a missing prerequisite into a
failure instead of a skip. That guard immediately caught its own case:
`cargo test --workspace` does not build another package's binary, so both TUI
tests failed CI until the workflow built `okena-tui` explicitly.

## Two bugs the tests found

- **"Delete branch after merge — local + remote" only ever deleted the remote
  one.** `git branch -d` ran while the worktree still held the branch, which
  Git refuses, and the refusal was swallowed by a warning. Deletion now happens
  once the checkout is gone, so a failed removal keeps both.
- **The TUI could not be quit.** Its only binding matched `Ctrl+]`, but
  crossterm reports the byte that key sends as `Ctrl+'5'`. The key went to the
  remote terminal instead — it typed a `5` at the shell — and since
  `TerminalGuard::drop` runs only on a normal return, killing the TUI from
  outside left the host terminal in raw mode on the alternate screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSZhvCKhHXrWBAqLjCfTSr
