### PR TITLE
feat(status-bar): minimal style + CPU/MEM history graphs

### DIFF
--- a/crates/okena-app-core/src/settings.rs
+++ b/crates/okena-app-core/src/settings.rs
@@ -119,6 +119,22 @@ impl SettingsState {
         self.save_and_notify(cx);
     }
 
+    /// Set the status bar style (Detailed, Minimal)
+    pub fn set_status_bar_style(
+        &mut self,
+        value: crate::workspace::settings::StatusBarStyle,
+        cx: &mut Context<Self>,
+    ) {
+        self.settings.status_bar.style = value;
+        self.save_and_notify(cx);
+    }
+
+    /// Toggle the CPU/MEM history graph in the status bar.
+    pub fn set_status_bar_metrics_graph(&mut self, value: bool, cx: &mut Context<Self>) {
+        self.settings.status_bar.metrics_graph = value;
+        self.save_and_notify(cx);
+    }
+
     setting_setter!(set_cursor_blink, cursor_blink, bool);
     setting_setter!(set_scrollback_lines, scrollback_lines, u32, 100, 100000);
     setting_setter!(

--- a/crates/okena-app/src/ui/metrics.rs
+++ b/crates/okena-app/src/ui/metrics.rs
@@ -1,0 +1,3 @@
+//! Status-bar metric primitives — re-exported from okena-ui.
+
+pub use okena_ui::metrics::*;

--- a/crates/okena-app/src/ui/mod.rs
+++ b/crates/okena-app/src/ui/mod.rs
@@ -3,6 +3,7 @@
 //! This module contains shared utilities that can be used across
 //! different views in the application.
 
+pub mod metrics;
 pub mod tokens;
 
 pub use okena_ui::color_utils::tint_color;

--- a/crates/okena-app/src/views/overlays/settings_panel/render_general.rs
+++ b/crates/okena-app/src/views/overlays/settings_panel/render_general.rs
@@ -2,7 +2,7 @@ use crate::settings::settings_entity;
 use crate::theme::theme;
 use crate::ui::tokens::{ui_text_md, ui_text_sm};
 use crate::views::components::simple_input::SimpleInput;
-use crate::workspace::settings::HeaderDensity;
+use crate::workspace::settings::{HeaderDensity, StatusBarStyle};
 use gpui::prelude::*;
 use gpui::*;
 use okena_transport::client::tls::format_fingerprint;
@@ -25,6 +25,11 @@ impl SettingsPanel {
                 |state, val, cx| state.set_color_tinted_background(val, cx), cx,
             ))
             .child(self.render_header_density_row(s.header_density, cx))
+            .child(self.render_status_bar_style_row(s.status_bar.style, cx))
+            .child(self.render_toggle(
+                "status-bar-graphs", "Status Bar CPU/Memory Graph", s.status_bar.metrics_graph, true,
+                |state, val, cx| state.set_status_bar_metrics_graph(val, cx), cx,
+            ))
             .child(self.render_toggle(
                 "detached-by-default", "Detached Overlays by Default", s.detached_overlays_by_default, true,
                 |state, val, cx| state.set_detached_overlays_by_default(val, cx), cx,
@@ -148,6 +153,35 @@ impl SettingsPanel {
                 |state, val, cx| state.set_allow_clipboard_read(val, cx),
                 cx,
             )))
+    }
+
+    /// Detailed vs. minimal status bar. Minimal drops the numbers next to the
+    /// CPU/MEM graphs and usage bars and the "OK" next to each service name;
+    /// the exact figures stay one hover away.
+    fn render_status_bar_style_row(
+        &self,
+        current: StatusBarStyle,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let t = theme(cx);
+        let variants = StatusBarStyle::all_variants();
+        let segments: Vec<Segment<'_>> = variants
+            .iter()
+            .map(|style| Segment {
+                id: format!("{:?}", style).into(),
+                label: style.display_name(),
+                selected: *style == current,
+            })
+            .collect();
+
+        settings_row("status-bar-style".to_string(), "Status Bar", &t, cx, true).child(
+            segmented_control("status-bar-style", &segments, &t, cx, move |i, _, cx| {
+                let style = variants[i];
+                settings_entity(cx).update(cx, |state, cx| {
+                    state.set_status_bar_style(style, cx);
+                });
+            }),
+        )
     }
 
     fn render_header_density_row(

--- a/crates/okena-app/src/views/panels/status_bar.rs
+++ b/crates/okena-app/src/views/panels/status_bar.rs
@@ -2,6 +2,7 @@ use crate::keybindings::ToggleSidebar;
 use crate::remote_client::manager::RemoteConnectionManager;
 use crate::settings::settings_entity;
 use crate::theme::theme;
+use crate::ui::metrics::{SparklineStyle, StatusBarStyle, metric_bar, sparkline};
 use crate::ui::tokens::{ui_text_ms, ui_text_sm, ui_text_xl};
 use crate::workspace::state::Workspace;
 use gpui::prelude::FluentBuilder;
@@ -21,12 +22,33 @@ use time::OffsetDateTime;
 /// Refresh interval for system stats
 const REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 
+/// How many samples of CPU/MEM history the graphs keep. At [`REFRESH_INTERVAL`]
+/// this is a little under a minute — enough to see a spike come and go.
+const HISTORY_LEN: usize = 24;
+
 /// Cached system stats
 #[derive(Clone, Default)]
 struct SystemStats {
     cpu_usage: f32,
     memory_used_gb: f32,
     memory_total_gb: f32,
+    /// Recent CPU load, oldest first, each 0.0..=1.0.
+    cpu_history: Vec<f32>,
+    /// Recent memory pressure, oldest first, each 0.0..=1.0.
+    memory_history: Vec<f32>,
+}
+
+/// Everything the status bar needs to draw one system metric (CPU or MEM).
+struct SystemMetric {
+    id: &'static str,
+    label: &'static str,
+    value_text: String,
+    tooltip: String,
+    /// Current value as 0.0..=1.0, for the bar.
+    fraction: f32,
+    /// Recent values as 0.0..=1.0, oldest first, for the graph.
+    history: Vec<f32>,
+    color: u32,
 }
 
 #[derive(Clone)]
@@ -76,17 +98,37 @@ impl SystemInfoCache {
 
         let memory_used = self.system.used_memory() as f64 / 1_073_741_824.0; // bytes to GB
         let memory_total = self.system.total_memory() as f64 / 1_073_741_824.0;
+        let memory_fraction = if memory_total > 0.0 {
+            (memory_used / memory_total) as f32
+        } else {
+            0.0
+        };
+
+        let mut cpu_history = std::mem::take(&mut self.stats.cpu_history);
+        let mut memory_history = std::mem::take(&mut self.stats.memory_history);
+        push_sample(&mut cpu_history, cpu_usage / 100.0);
+        push_sample(&mut memory_history, memory_fraction);
 
         self.stats = SystemStats {
             cpu_usage,
             memory_used_gb: memory_used as f32,
             memory_total_gb: memory_total as f32,
+            cpu_history,
+            memory_history,
         };
     }
 
     fn stats(&self) -> SystemStats {
         self.stats.clone()
     }
+}
+
+/// Append a sample to a history buffer, dropping the oldest past [`HISTORY_LEN`].
+fn push_sample(history: &mut Vec<f32>, value: f32) {
+    if history.len() >= HISTORY_LEN {
+        history.remove(0);
+    }
+    history.push(value.clamp(0.0, 1.0));
 }
 
 /// Status bar component showing system info and time
@@ -404,6 +446,67 @@ impl StatusBar {
         t.text_muted
     }
 
+    /// One system metric (CPU or MEM) as the status bar draws it.
+    fn render_system_metric(
+        metric: SystemMetric,
+        style: StatusBarStyle,
+        graph: bool,
+        t: &okena_core::theme::ThemeColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let SystemMetric {
+            id,
+            label,
+            value_text,
+            tooltip,
+            fraction,
+            history,
+            color,
+        } = metric;
+
+        let label_el = div().text_color(rgb(t.text_muted)).child(label);
+
+        let body = if style.is_minimal() {
+            // No number — the graph (or bar) carries the value, the tooltip
+            // carries the exact figure.
+            h_flex()
+                .gap(px(4.0))
+                .text_size(ui_text_sm(cx))
+                .child(label_el)
+                .child(if graph {
+                    sparkline(&history, SparklineStyle::tall(), color, t).into_any_element()
+                } else {
+                    div()
+                        .w(px(34.0))
+                        .child(metric_bar(fraction, color, t))
+                        .into_any_element()
+                })
+                .into_any_element()
+        } else {
+            v_flex()
+                .gap(px(1.0))
+                .child(
+                    h_flex()
+                        .gap(px(3.0))
+                        .text_size(ui_text_sm(cx))
+                        .child(label_el)
+                        .child(div().text_color(rgb(color)).child(value_text)),
+                )
+                .child(if graph {
+                    sparkline(&history, SparklineStyle::compact(), color, t).into_any_element()
+                } else {
+                    metric_bar(fraction, color, t).into_any_element()
+                })
+                .into_any_element()
+        };
+
+        div()
+            .id(id)
+            .child(body)
+            .tooltip(move |window, cx| Tooltip::new(tooltip.clone()).build(window, cx))
+            .into_any_element()
+    }
+
     fn render_remote_status_popover(
         &self,
         snapshots: &[RemoteStatusSnapshot],
@@ -620,23 +723,32 @@ impl Render for StatusBar {
             0
         };
 
-        let cpu_color = if stats.cpu_usage > 80.0 {
-            t.metric_critical
-        } else if stats.cpu_usage > 50.0 {
-            t.metric_warning
-        } else {
-            t.metric_normal
-        };
+        // Same thresholds as the remote rows in the popover.
+        let cpu_color = Self::cpu_metric_color(stats.cpu_usage, &t);
+        let mem_color = Self::memory_metric_color(memory_percent as u64, &t);
 
-        let mem_color = if memory_percent > 80 {
-            t.metric_critical
-        } else if memory_percent > 60 {
-            t.metric_warning
-        } else {
-            t.metric_normal
+        let status_bar = settings_entity(cx).read(cx).settings.status_bar.clone();
+        let bar_style = status_bar.style;
+        let graphs = status_bar.metrics_graph;
+
+        let cpu_metric = SystemMetric {
+            id: "cpu-status-metric",
+            label: "CPU",
+            value_text: format!("{:02.0}%", stats.cpu_usage),
+            tooltip: format!("CPU {:.0}%", stats.cpu_usage),
+            fraction: (stats.cpu_usage / 100.0).clamp(0.0, 1.0),
+            history: stats.cpu_history.clone(),
+            color: cpu_color,
         };
-        let mut metric_track_color = rgb(t.text_muted);
-        metric_track_color.a = 0.55;
+        let memory_metric = SystemMetric {
+            id: "memory-status-metric",
+            label: "MEM",
+            value_text: format!("{memory_percent}%"),
+            tooltip: format!("MEM {memory_percent}% — {memory_detail}"),
+            fraction: memory_percent.min(100) as f32 / 100.0,
+            history: stats.memory_history.clone(),
+            color: mem_color,
+        };
 
         // Collect widgets in stable registry order from active extensions
         let left_widgets: Vec<&Vec<AnyView>> = self
@@ -691,70 +803,16 @@ impl Render for StatusBar {
                                 }),
                         )
                     })
-                    // CPU
-                    .child(
-                        v_flex()
-                            .gap(px(1.0))
-                            .child(
-                                h_flex()
-                                    .gap(px(3.0))
-                                    .text_size(ui_text_sm(cx))
-                                    .child(div().text_color(rgb(t.text_muted)).child("CPU"))
-                                    .child(
-                                        div()
-                                            .text_color(rgb(cpu_color))
-                                            .child(format!("{:02.0}%", stats.cpu_usage)),
-                                    ),
-                            )
-                            .child(
-                                div()
-                                    .h(px(2.0))
-                                    .w_full()
-                                    .rounded_full()
-                                    .bg(metric_track_color)
-                                    .child(
-                                        div()
-                                            .h_full()
-                                            .w(relative((stats.cpu_usage / 100.0).clamp(0.0, 1.0)))
-                                            .rounded_full()
-                                            .bg(rgb(cpu_color)),
-                                    ),
-                            ),
-                    )
-                    // Memory
-                    .child(
-                        v_flex()
-                            .id("memory-status-metric")
-                            .gap(px(1.0))
-                            .child(
-                                h_flex()
-                                    .gap(px(3.0))
-                                    .text_size(ui_text_sm(cx))
-                                    .child(div().text_color(rgb(t.text_muted)).child("MEM"))
-                                    .child(
-                                        div()
-                                            .text_color(rgb(mem_color))
-                                            .child(format!("{memory_percent}%")),
-                                    ),
-                            )
-                            .child(
-                                div()
-                                    .h(px(2.0))
-                                    .w_full()
-                                    .rounded_full()
-                                    .bg(metric_track_color)
-                                    .child(
-                                        div()
-                                            .h_full()
-                                            .w(relative(memory_percent.min(100) as f32 / 100.0))
-                                            .rounded_full()
-                                            .bg(rgb(mem_color)),
-                                    ),
-                            )
-                            .tooltip(move |window, cx| {
-                                Tooltip::new(memory_detail.clone()).build(window, cx)
-                            }),
-                    );
+                    .child(Self::render_system_metric(
+                        cpu_metric, bar_style, graphs, &t, cx,
+                    ))
+                    .child(Self::render_system_metric(
+                        memory_metric,
+                        bar_style,
+                        graphs,
+                        &t,
+                        cx,
+                    ));
 
                 // Left-side extension widgets
                 for widgets in &left_widgets {

--- a/crates/okena-core/src/types.rs
+++ b/crates/okena-core/src/types.rs
@@ -35,6 +35,38 @@ impl DiffViewMode {
     }
 }
 
+/// How much text the status bar spells out.
+///
+/// `Detailed` (default) is the labelled bar: `CPU 13%`, `Claude Code OK`,
+/// `5h 20%`. `Minimal` keeps the same widgets but drops the redundant numbers
+/// and "OK" labels, leaving the graphs and bars to carry the value — the exact
+/// figures move into tooltips. Anything abnormal (a degraded service) still
+/// prints its label in both modes.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StatusBarStyle {
+    #[default]
+    Detailed,
+    Minimal,
+}
+
+impl StatusBarStyle {
+    pub fn display_name(self) -> &'static str {
+        match self {
+            StatusBarStyle::Detailed => "Detailed",
+            StatusBarStyle::Minimal => "Minimal",
+        }
+    }
+
+    pub fn all_variants() -> &'static [StatusBarStyle] {
+        &[StatusBarStyle::Detailed, StatusBarStyle::Minimal]
+    }
+
+    pub fn is_minimal(self) -> bool {
+        matches!(self, StatusBarStyle::Minimal)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DiffMode {

--- a/crates/okena-ext-claude/src/status.rs
+++ b/crates/okena-ext-claude/src/status.rs
@@ -3,6 +3,7 @@ use gpui::prelude::FluentBuilder;
 use gpui::*;
 use gpui_component::{h_flex, v_flex};
 use okena_extensions::ThemeColors;
+use okena_ui::metrics::service_status_items;
 use okena_ui::tokens::{ui_text_md, ui_text_ms, ui_text_sm};
 use parking_lot::Mutex;
 use std::sync::Arc;
@@ -372,6 +373,7 @@ impl Render for ClaudeStatus {
             Some(_) => ("Unknown", t.text_muted),
             None => ("...", t.text_muted),
         };
+        let healthy = label == "OK";
         let has_incidents = data
             .as_ref()
             .map(|d| !d.incidents.is_empty())
@@ -390,8 +392,9 @@ impl Render for ClaudeStatus {
                     .py(px(1.0))
                     .rounded(px(3.0))
                     .hover(|s| s.bg(rgb(t.bg_hover)))
-                    .child(div().text_color(rgb(t.text_muted)).child("Claude Code"))
-                    .child(div().text_color(rgb(color)).child(label))
+                    .children(service_status_items(
+                        "Claude Code", label, color, healthy, &t, cx,
+                    ))
                     .child(
                         canvas(
                             move |bounds, _window, app| {

--- a/crates/okena-ext-codex/src/status.rs
+++ b/crates/okena-ext-codex/src/status.rs
@@ -3,6 +3,7 @@ use gpui::prelude::FluentBuilder;
 use gpui::*;
 use gpui_component::{h_flex, v_flex};
 use okena_extensions::ThemeColors;
+use okena_ui::metrics::service_status_items;
 use okena_ui::tokens::{ui_text_md, ui_text_ms, ui_text_sm};
 use parking_lot::Mutex;
 use std::sync::Arc;
@@ -375,6 +376,7 @@ impl Render for CodexStatus {
             Some(_) => ("Unknown", t.text_muted),
             None => ("...", t.text_muted),
         };
+        let healthy = label == "OK";
         let has_incidents = data
             .as_ref()
             .map(|d| !d.incidents.is_empty())
@@ -393,8 +395,9 @@ impl Render for CodexStatus {
                     .py(px(1.0))
                     .rounded(px(3.0))
                     .hover(|s| s.bg(rgb(t.bg_hover)))
-                    .child(div().text_color(rgb(t.text_muted)).child("Codex"))
-                    .child(div().text_color(rgb(color)).child(label))
+                    .children(service_status_items(
+                        "Codex", label, color, healthy, &t, cx,
+                    ))
                     .child(
                         canvas(
                             move |bounds, _window, app| {

--- a/crates/okena-ext-github/src/status.rs
+++ b/crates/okena-ext-github/src/status.rs
@@ -3,6 +3,7 @@ use gpui::prelude::FluentBuilder;
 use gpui::*;
 use gpui_component::{h_flex, v_flex};
 use okena_extensions::ThemeColors;
+use okena_ui::metrics::service_status_items;
 use okena_ui::tokens::{ui_text_md, ui_text_ms, ui_text_sm};
 use parking_lot::Mutex;
 use std::sync::Arc;
@@ -361,6 +362,7 @@ impl Render for GitHubStatus {
             Some(_) => ("Unknown", t.text_muted),
             None => ("...", t.text_muted),
         };
+        let healthy = label == "OK";
         let has_incidents = data
             .as_ref()
             .map(|d| !d.incidents.is_empty())
@@ -379,8 +381,9 @@ impl Render for GitHubStatus {
                     .py(px(1.0))
                     .rounded(px(3.0))
                     .hover(|s| s.bg(rgb(t.bg_hover)))
-                    .child(div().text_color(rgb(t.text_muted)).child("GitHub"))
-                    .child(div().text_color(rgb(color)).child(label))
+                    .children(service_status_items(
+                        "GitHub", label, color, healthy, &t, cx,
+                    ))
                     .child(
                         canvas(
                             move |bounds, _window, app| {

--- a/crates/okena-ui/src/lib.rs
+++ b/crates/okena-ui/src/lib.rs
@@ -25,6 +25,7 @@ pub mod icon_button;
 pub mod input;
 pub mod list_row;
 pub mod menu;
+pub mod metrics;
 pub mod modal;
 pub mod overlay;
 pub mod popover;

--- a/crates/okena-ui/src/metrics.rs
+++ b/crates/okena-ui/src/metrics.rs
@@ -1,0 +1,215 @@
+//! Status-bar metric primitives.
+//!
+//! Three things live here because the status bar is assembled from widgets
+//! that ship in different crates (system stats in `okena-app`, usage bars in
+//! `okena-usage`, service status in the `okena-ext-*` crates) and they all
+//! have to agree on how a metric looks:
+//!
+//! - [`metric_bar`] — the thin capacity bar drawn under a value,
+//! - [`sparkline`] — a short history graph for a value sampled over time,
+//! - [`status_bar_style`] — the host-registered reader for the user's
+//!   Detailed/Minimal preference, so a widget in any crate can decide whether
+//!   to spell its number out.
+
+use crate::theme::ThemeColors;
+use gpui::*;
+
+pub use okena_core::types::StatusBarStyle;
+
+// =============================================================================
+// Global status bar style provider
+// =============================================================================
+
+/// Global function pointer that reads the current status bar style from the
+/// host app's settings. The host registers this at startup; widgets in any
+/// crate call [`status_bar_style`]. Unregistered (tests, headless) falls back
+/// to [`StatusBarStyle::Detailed`].
+pub struct GlobalStatusBarStyle(pub fn(&App) -> StatusBarStyle);
+
+impl Global for GlobalStatusBarStyle {}
+
+pub fn status_bar_style(cx: &App) -> StatusBarStyle {
+    cx.try_global::<GlobalStatusBarStyle>()
+        .map(|g| (g.0)(cx))
+        .unwrap_or_default()
+}
+
+// =============================================================================
+// Bars and graphs
+// =============================================================================
+
+/// Muted track drawn behind a metric bar or under a sparkline.
+pub fn metric_track_color(t: &ThemeColors) -> Rgba {
+    let mut color = rgb(t.text_muted);
+    color.a = 0.55;
+    color
+}
+
+/// Thin capacity bar. `fraction` is 0.0..=1.0 of the parent's width; the
+/// caller sizes the width (usually `w_full` under a label).
+pub fn metric_bar(fraction: f32, color: u32, t: &ThemeColors) -> Div {
+    div()
+        .h(px(2.0))
+        .w_full()
+        .rounded_full()
+        .bg(metric_track_color(t))
+        .child(
+            div()
+                .h_full()
+                .w(relative(fraction.clamp(0.0, 1.0)))
+                .rounded_full()
+                .bg(rgb(color)),
+        )
+}
+
+/// Geometry of a [`sparkline`]. `slots` is how many samples are drawn; a
+/// shorter history is padded on the left so the graph never changes width
+/// while it fills up.
+#[derive(Clone, Copy, Debug)]
+pub struct SparklineStyle {
+    pub slots: usize,
+    pub height: Pixels,
+    pub bar_width: Pixels,
+    pub gap: Pixels,
+}
+
+impl SparklineStyle {
+    /// Compact graph that fits under a label in the detailed status bar.
+    pub fn compact() -> Self {
+        Self {
+            slots: 14,
+            height: px(6.0),
+            bar_width: px(2.0),
+            gap: px(1.0),
+        }
+    }
+
+    /// Taller graph for the minimal status bar, where the graph replaces the
+    /// number instead of sitting under it.
+    pub fn tall() -> Self {
+        Self {
+            slots: 16,
+            height: px(11.0),
+            bar_width: px(2.0),
+            gap: px(1.0),
+        }
+    }
+
+    pub fn width(self) -> Pixels {
+        self.bar_width * self.slots as f32 + self.gap * self.slots.saturating_sub(1) as f32
+    }
+}
+
+/// A short history graph. `values` are 0.0..=1.0, oldest first; only the last
+/// `style.slots` are drawn, so the newest sample is always at the right edge.
+pub fn sparkline(values: &[f32], style: SparklineStyle, color: u32, t: &ThemeColors) -> Div {
+    let track = metric_track_color(t);
+    let shown = &values[values.len().saturating_sub(style.slots)..];
+    let missing = style.slots.saturating_sub(shown.len());
+
+    let mut row = div()
+        .flex()
+        .items_end()
+        .gap(style.gap)
+        .h(style.height)
+        .w(style.width());
+
+    // Empty slots keep the graph a fixed width while the history fills up.
+    for _ in 0..missing {
+        row = row.child(div().w(style.bar_width).h(px(1.0)).bg(track));
+    }
+    let full_height: f32 = style.height.into();
+    for value in shown {
+        // Never zero — an idle sample still reads as a baseline tick.
+        let filled = px(f32::max(1.0, full_height * value.clamp(0.0, 1.0)));
+        row = row.child(
+            div()
+                .w(style.bar_width)
+                .h(style.height)
+                .flex()
+                .flex_col()
+                .justify_end()
+                .child(div().w_full().h(filled).bg(rgb(color))),
+        );
+    }
+
+    row
+}
+
+// =============================================================================
+// Service status trigger
+// =============================================================================
+
+/// Trigger content for a service-status widget (Claude Code, Codex, GitHub):
+/// the service name plus its status word.
+///
+/// In the minimal status bar an all-clear status is reduced to a colored dot —
+/// "OK" next to three service names is the most redundant text in the bar.
+/// Anything abnormal keeps its label in both styles, so a problem never hides.
+pub fn service_status_items(
+    name: impl Into<SharedString>,
+    label: impl Into<SharedString>,
+    color: u32,
+    healthy: bool,
+    t: &ThemeColors,
+    cx: &App,
+) -> Vec<AnyElement> {
+    let name_el = div()
+        .text_color(rgb(t.text_muted))
+        .child(name.into())
+        .into_any_element();
+    let label_el = div()
+        .text_color(rgb(color))
+        .child(label.into())
+        .into_any_element();
+
+    if !status_bar_style(cx).is_minimal() {
+        return vec![name_el, label_el];
+    }
+
+    let dot = div()
+        .flex_shrink_0()
+        .w(px(6.0))
+        .h(px(6.0))
+        .rounded_full()
+        .bg(rgb(color))
+        .into_any_element();
+
+    if healthy {
+        vec![dot, name_el]
+    } else {
+        vec![dot, name_el, label_el]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Import specific items rather than `use super::*` — the latter pulls in
+    // gpui's `test` proc-macro (re-exported via `use gpui::*`), which shadows
+    // the std `#[test]` attribute and blows the macro recursion limit.
+    use super::SparklineStyle;
+    use gpui::px;
+
+    #[test]
+    fn compact_width_counts_gaps_between_bars() {
+        let style = SparklineStyle {
+            slots: 4,
+            height: px(6.0),
+            bar_width: px(2.0),
+            gap: px(1.0),
+        };
+        // 4 bars * 2px + 3 gaps * 1px
+        assert_eq!(style.width(), px(11.0));
+    }
+
+    #[test]
+    fn single_slot_has_no_gap() {
+        let style = SparklineStyle {
+            slots: 1,
+            height: px(6.0),
+            bar_width: px(2.0),
+            gap: px(1.0),
+        };
+        assert_eq!(style.width(), px(2.0));
+    }
+}

--- a/crates/okena-usage/src/lib.rs
+++ b/crates/okena-usage/src/lib.rs
@@ -13,6 +13,7 @@ use gpui::*;
 use gpui_component::tooltip::Tooltip;
 use gpui_component::{h_flex, v_flex};
 use okena_extensions::ExtensionSettingsStore;
+use okena_ui::metrics::{metric_bar, status_bar_style};
 use okena_ui::settings::{section_container, section_header, section_note};
 use okena_ui::theme::ThemeColors;
 use okena_ui::tokens::{ui_text_md, ui_text_ms, ui_text_sm, ui_text_xs};
@@ -849,40 +850,51 @@ pub fn usage_kv_row(
 /// time-elapsed value (so the color matches the popover headline exactly).
 pub type TriggerItem = (SharedString, f64, Option<f64>);
 
+/// Bar width for one trigger item in the minimal status bar, where the bar
+/// stands on its own instead of sitting under a `label + %` row.
+const MINIMAL_TRIGGER_BAR_WIDTH: Pixels = px(28.0);
+
 /// Build the inner content of the status-bar trigger with a bar below each value.
 /// The caller wraps these in a hoverable, bounds-tracking container.
+///
+/// In the minimal status bar the percentage is dropped and the label sits next
+/// to the bar — the exact figures are one hover away in the popover.
 pub fn usage_trigger_items(t: &ThemeColors, cx: &App, items: &[TriggerItem]) -> Vec<AnyElement> {
-    let mut track_color = rgb(t.text_muted);
-    track_color.a = 0.55;
+    let minimal = status_bar_style(cx).is_minimal();
 
     items
         .iter()
         .map(|(label, pct, time_pct)| {
             let color = headline_color(t, *pct, *time_pct);
-            v_flex()
-                .gap(px(1.0))
-                .child(
-                    h_flex()
-                        .gap(px(3.0))
-                        .text_size(ui_text_sm(cx))
-                        .child(div().text_color(rgb(t.text_muted)).child(label.clone()))
-                        .child(div().text_color(rgb(color)).child(format!("{:.0}%", pct))),
-                )
-                .child(
-                    div()
-                        .h(px(2.0))
-                        .w_full()
-                        .rounded_full()
-                        .bg(track_color)
-                        .child(
-                            div()
-                                .h_full()
-                                .w(relative(pct.clamp(0.0, 100.0) as f32 / 100.0))
-                                .rounded_full()
-                                .bg(rgb(color)),
-                        ),
-                )
-                .into_any_element()
+            let fraction = pct.clamp(0.0, 100.0) as f32 / 100.0;
+            let label_el = div()
+                .text_size(ui_text_sm(cx))
+                .text_color(rgb(t.text_muted))
+                .child(label.clone());
+
+            if minimal {
+                h_flex()
+                    .gap(px(4.0))
+                    .child(label_el)
+                    .child(
+                        div()
+                            .w(MINIMAL_TRIGGER_BAR_WIDTH)
+                            .child(metric_bar(fraction, color, t)),
+                    )
+                    .into_any_element()
+            } else {
+                v_flex()
+                    .gap(px(1.0))
+                    .child(
+                        h_flex()
+                            .gap(px(3.0))
+                            .text_size(ui_text_sm(cx))
+                            .child(label_el)
+                            .child(div().text_color(rgb(color)).child(format!("{:.0}%", pct))),
+                    )
+                    .child(metric_bar(fraction, color, t))
+                    .into_any_element()
+            }
         })
         .collect()
 }

--- a/crates/okena-workspace/src/settings.rs
+++ b/crates/okena-workspace/src/settings.rs
@@ -1,5 +1,5 @@
 use okena_core::theme::ThemeMode;
-pub use okena_core::types::DiffViewMode;
+pub use okena_core::types::{DiffViewMode, StatusBarStyle};
 use okena_terminal::session_backend::SessionBackend;
 use okena_terminal::shell_config::ShellType;
 use okena_transport::client::RemoteConnectionConfig;
@@ -212,6 +212,30 @@ impl Default for SidebarSettings {
     }
 }
 
+/// Status bar appearance.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StatusBarSettings {
+    /// How much text the bar spells out — see [`StatusBarStyle`].
+    #[serde(default)]
+    pub style: StatusBarStyle,
+    /// Draw CPU/MEM as a short history graph instead of a single-value bar.
+    #[serde(default = "default_status_bar_metrics_graph")]
+    pub metrics_graph: bool,
+}
+
+impl Default for StatusBarSettings {
+    fn default() -> Self {
+        Self {
+            style: StatusBarStyle::default(),
+            metrics_graph: default_status_bar_metrics_graph(),
+        }
+    }
+}
+
+fn default_status_bar_metrics_graph() -> bool {
+    true
+}
+
 /// Current settings schema version - increment when making breaking changes
 pub const SETTINGS_VERSION: u32 = 3;
 
@@ -416,6 +440,11 @@ pub struct AppSettings {
     #[serde(default)]
     pub header_density: HeaderDensity,
 
+    /// Status bar appearance: how verbose it is, and whether CPU/MEM render
+    /// as a history graph.
+    #[serde(default)]
+    pub status_bar: StatusBarSettings,
+
     /// Native desktop notifications for background-terminal activity
     /// (OSC 9/777 alerts and the bell). Opt-in — see [`NotificationSettings`].
     #[serde(default)]
@@ -480,6 +509,7 @@ impl Default for AppSettings {
             terminal_double_click_selects_in_mouse_mode: false,
             file_finder: FileFinderSettings::default(),
             header_density: HeaderDensity::default(),
+            status_bar: StatusBarSettings::default(),
             notifications: NotificationSettings::default(),
             allow_clipboard_read: false,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -679,6 +679,12 @@ fn main() {
             settings::settings_entity(cx).read(cx).settings.ui_font_size
         }));
 
+        // Status bar verbosity, read by the status-bar widgets that live in
+        // other crates (usage bars, extension status pills).
+        cx.set_global(okena_ui::metrics::GlobalStatusBarStyle(|cx| {
+            settings::settings_entity(cx).read(cx).settings.status_bar.style
+        }));
+
         // NOTE: Terminal and git view settings are now served through
         // ExtensionSettingsStore (registered above) — no separate globals needed.
 


### PR DESCRIPTION
## What

A **Detailed / Minimal** switch for the status bar, plus CPU/MEM drawn as history graphs. Both live under Settings → General → Appearance.

**Minimal** drops the text that only repeats what a bar already shows:

- CPU / MEM — label + graph, no `%` (exact figures move to a tooltip)
- usage (`5h`, `7d`) — label + bar, no `%`; the numbers are already one hover away in the popover
- Claude Code / Codex / GitHub — a colored dot + name instead of `Claude Code OK`

Anything abnormal (`Degraded`, `Major Outage`) keeps its word in **both** styles, so choosing minimal never hides a problem.

**Graphs** replace the single-value bar for CPU/MEM: the last 24 samples (~50s at the 2s refresh) as a sparkline, on by default. A one-value bar reports the instant only — a spike is over before you look at it.

## Dedup that came with it

The status bar is assembled from widgets shipped by four different crates, which agreed on what a metric looks like by copy: the 2px capacity bar existed twice, and the `name + status word` trigger three times, once per extension. Both now go through `okena-ui::metrics` (`metric_bar`, `sparkline`, `service_status_items`).

`GlobalStatusBarStyle` follows the existing `GlobalUiFontSize` provider pattern, so a widget in any crate can read the preference without depending on `okena-app-core`.

## Notes

- `StatusBarStyle` lives in `okena-core`: `AppSettings` has to serialize it and `okena-workspace` must stay gpui-free. `cargo tree -i gpui -p okena-daemon` still comes back empty.
- `StatusBarSettings` carries serde defaults, so existing `settings.json` files load unchanged.

## Testing

- `cargo check` passes at **each** of the four commits — the history bisects cleanly, it doesn't just end in a working state
- `cargo test` green for the touched crates; `cargo clippy` clean
- No screenshot: the `ui-screenshot` harness is Linux/GNOME only and this was authored on macOS. Worth a look on a real window before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhHu7ad5BeaettLreDgEs5