### PR TITLE
fix: fifteen medium findings from the codebase review

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
   # crates/okena-mobile-ffi to an Android NDK .so / iOS xcframework, then
   # `react-native run-*`) needs the mobile toolchain and is NOT yet wired into
   # CI — see mobile/rn/README.md for the device-side steps. Until then CI
-  # type-checks and lints the RN/TS sources; the Rust FFI crate itself is
+  # type-checks, lints and Jest-tests the RN/TS sources; the Rust FFI crate is
   # already covered by the `check` job's workspace build + clippy + tests.
   mobile-rn:
     if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
@@ -158,6 +158,9 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+      - name: Test
+        run: npm test
 
   # Full multi-platform build: tags + manual trigger
   build:
@@ -358,6 +361,16 @@ jobs:
 
           exit "$failed"
 
+      # The in-app updater looks for an asset named exactly `SHA256SUMS` and
+      # silently skips verification when it is absent (checker.rs:204).
+      - name: Generate SHA256SUMS
+        run: |
+          shopt -s nullglob
+          assets=(*.tar.gz *.zip *.dmg *.apk)
+          [[ ${#assets[@]} -gt 0 ]] || { echo "no release assets to checksum"; exit 1; }
+          sha256sum "${assets[@]}" > SHA256SUMS
+          cat SHA256SUMS
+
       # The cask is the stable channel — a prerelease must not overwrite it.
       - name: Generate ContemberBot token
         id: app-token
@@ -407,4 +420,5 @@ jobs:
             *.zip
             *.dmg
             *.apk
+            SHA256SUMS
           generate_release_notes: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6088,7 +6088,7 @@ dependencies = [
 
 [[package]]
 name = "okena-cli"
-version = "0.1.0"
+version = "0.31.0"
 dependencies = [
  "base64",
  "clap",

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The install script includes built-in auto-update support. On macOS and Linux, Ok
 
 ## Building
 
-Requires Rust toolchain (edition 2021).
+Requires Rust toolchain (edition 2024).
 
 ```bash
 cargo build --release

--- a/crates/okena-app/src/action_dispatch.rs
+++ b/crates/okena-app/src/action_dispatch.rs
@@ -548,19 +548,42 @@ impl okena_views_terminal::ActionDispatch for ActionDispatcher {
             (config.clone(), config.effective_auth_token()?)
         };
         let action = okena_core::api::ActionRequest::ExportBuffer {
-            terminal_id: remote_terminal_id,
+            terminal_id: remote_terminal_id.clone(),
         };
         let value = okena_transport::remote_action::RemoteActionClient::new(config, token)
             .post_action(action)
             .ok()??;
         let content = value.get("content").and_then(|v| v.as_str())?;
-        // Write the client-side copy (same naming as the in-process capture).
-        let short: String = terminal_id.chars().take(8).collect();
         let mut path = std::env::temp_dir();
-        path.push(format!("terminal-{}.txt", short));
+        path.push(format!(
+            "{}.txt",
+            export_file_stem(connection_id, &remote_terminal_id)
+        ));
         std::fs::write(&path, content).ok()?;
         Some(path)
     }
+}
+
+/// Filename stem for an exported terminal buffer. Both ids are needed: a prefix
+/// of the display id is `remote:l` for every local-daemon terminal, and the
+/// colon it contains is not a portable path character.
+fn export_file_stem(connection_id: &str, terminal_id: &str) -> String {
+    fn sanitize(s: &str) -> String {
+        s.chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                    c
+                } else {
+                    '-'
+                }
+            })
+            .collect()
+    }
+    format!(
+        "terminal-{}-{}",
+        sanitize(connection_id),
+        sanitize(terminal_id)
+    )
 }
 
 /// Strip the `remote:{connection_id}:` prefix from terminal and project IDs before sending to server.
@@ -1306,6 +1329,28 @@ fn strip_remote_ids(action: ActionRequest, connection_id: &str) -> ActionRequest
 mod tests {
     use super::*;
     use crate::workspace::state::SplitDirection;
+
+    #[test]
+    fn export_stems_are_distinct_per_terminal_and_connection() {
+        let a = export_file_stem("local-daemon", "1111aaaa");
+        let b = export_file_stem("local-daemon", "2222bbbb");
+        let c = export_file_stem("box.lan:8443", "1111aaaa");
+
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_eq!(a, "terminal-local-daemon-1111aaaa");
+    }
+
+    #[test]
+    fn export_stems_contain_only_portable_characters() {
+        let stem = export_file_stem("box.lan:8443", "remote/id with space");
+
+        assert!(
+            stem.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+            "not portable: {stem}"
+        );
+    }
 
     #[test]
     fn rows_map_visual_split_axis_back_to_canonical_axis() {

--- a/crates/okena-app/src/keybindings/mod.rs
+++ b/crates/okena-app/src/keybindings/mod.rs
@@ -25,8 +25,6 @@ actions!(
         ClearFocus,
         CloseWindow,
         FocusActiveProject,
-        ScrollUp,
-        ScrollDown,
         ShowKeybindings,
         ShowSessionManager,
         ShowThemeSelector,
@@ -63,9 +61,9 @@ pub use okena_views_terminal::actions::{
     AddTab, CloseSearch, CloseTerminal, Copy, DetachTerminal, ExportTerminalBuffer, FocusDown,
     FocusLeft, FocusNextTerminal, FocusPrevTerminal, FocusRight, FocusUp, FullscreenNextTerminal,
     FullscreenPrevTerminal, JumpToNextFailedCommand, JumpToNextPrompt, JumpToPreviousFailedCommand,
-    JumpToPreviousPrompt, MinimizeTerminal, Paste, ResetZoom, Search, SearchNext, SearchPrev,
-    SendBacktab, SendEscape, SendTab, SplitHorizontal, SplitVertical, ToggleFullscreen,
-    ToggleUnread, ZoomIn, ZoomOut,
+    JumpToPreviousPrompt, MinimizeTerminal, Paste, ResetZoom, ScrollDown, ScrollUp, Search,
+    SearchNext, SearchPrev, SendBacktab, SendEscape, SendTab, SplitHorizontal, SplitVertical,
+    ToggleFullscreen, ToggleUnread, ZoomIn, ZoomOut,
 };
 
 // Sidebar-specific actions (defined in okena-views-sidebar crate)

--- a/crates/okena-cli/Cargo.toml
+++ b/crates/okena-cli/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "okena-cli"
-version = "0.1.0"
+# Workspace version so `okena -V` reports the shipped app version.
+version.workspace = true
 edition = "2024"
 license = "MIT"
 

--- a/crates/okena-cli/src/parser.rs
+++ b/crates/okena-cli/src/parser.rs
@@ -10,6 +10,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(
     name = "okena",
+    version,
     about = "Control a running Okena instance",
     disable_help_subcommand = false,
     // The binary also launches the GUI; only the subcommands below are CLI.
@@ -512,6 +513,26 @@ pub fn subcommand_names() -> &'static [&'static str] {
 mod tests {
     use super::*;
     use clap::CommandFactory as _;
+
+    #[test]
+    fn both_advertised_version_forms_report_the_app_version() {
+        let version = Cli::command()
+            .get_version()
+            .expect("clap needs version metadata or `-V` is an unknown argument")
+            .to_string();
+        assert_eq!(version, env!("CARGO_PKG_VERSION"));
+        // The workspace version is the shipped app version; a per-crate 0.1.0
+        // here would report a version no release ever had.
+        assert_ne!(version, "0.1.0");
+
+        for form in ["-V", "--version"] {
+            let kind = Cli::try_parse_from(["okena", form])
+                .err()
+                .map(|e| e.kind())
+                .expect("version exits via an error");
+            assert_eq!(kind, clap::error::ErrorKind::DisplayVersion, "{form}");
+        }
+    }
 
     #[test]
     fn command_tree_is_well_formed() {

--- a/crates/okena-daemon-core/src/command_loop.rs
+++ b/crates/okena-daemon-core/src/command_loop.rs
@@ -2279,6 +2279,7 @@ pub(crate) fn spawn_background_worktree_removal(
                     plan,
                     Err("terminal teardown did not release the worktree in time; checkout preserved".to_string()),
                     None,
+                    None,
                 );
             }
             let worktree_path = plan.worktree_path.clone();
@@ -2299,21 +2300,34 @@ pub(crate) fn spawn_background_worktree_removal(
             } else {
                 plan.remove_fast().map_err(|error| error.to_string())
             };
-            if delete_branch && removal.is_ok() {
+            let surviving_branch = if delete_branch && removal.is_ok() {
                 okena_workspace::actions::worktree::delete_closed_worktree_branch(
                     &plan.main_repo_path,
                     plan.branch(),
-                );
-            }
-            (plan, removal, dirty_hook)
+                )
+                .err()
+                .map(|error| (plan.branch().to_string(), error))
+            } else {
+                None
+            };
+            (plan, removal, dirty_hook, surviving_branch)
         })
         .await;
         match outcome {
-            Ok((plan, removal, dirty_hook)) => {
+            Ok((plan, removal, dirty_hook, surviving_branch)) => {
                 if let Some(Err(error)) = dirty_hook {
                     log::error!(
                         "worktree-close: dirty-close hook failed for {}: {error}",
                         plan.project_id
+                    );
+                }
+                if let Some((branch, error)) = surviving_branch
+                    && let Some(hm) = &hook_monitor
+                {
+                    hm.push_toast(
+                        okena_workspace::actions::worktree::surviving_branch_toast(
+                            &branch, &error,
+                        ),
                     );
                 }
                 match removal {

--- a/crates/okena-ext-claude/src/usage.rs
+++ b/crates/okena-ext-claude/src/usage.rs
@@ -636,7 +636,7 @@ impl ClaudeUsageData {
                             log::info!(
                                 "[claude-usage] HTTP {} body={}",
                                 status,
-                                &body[..body.len().min(500)]
+                                &body[..body.floor_char_boundary(500)]
                             );
                             if !resp.is_success() {
                                 return (None, None);

--- a/crates/okena-git/src/diff.rs
+++ b/crates/okena-git/src/diff.rs
@@ -264,14 +264,14 @@ pub fn parse_unified_diff(output: &str) -> DiffResult {
             .strip_prefix("rename from ")
             .or_else(|| line.strip_prefix("copy from "))
         {
-            file.old_path = Some(old.to_string());
+            file.old_path = decode_git_path(old);
             continue;
         }
         if let Some(new) = line
             .strip_prefix("rename to ")
             .or_else(|| line.strip_prefix("copy to "))
         {
-            file.new_path = Some(new.to_string());
+            file.new_path = decode_git_path(new);
             continue;
         }
 
@@ -287,28 +287,14 @@ pub fn parse_unified_diff(output: &str) -> DiffResult {
         // Parse old file path. These lines are authoritative and override the
         // `diff --git` header fallback (e.g. /dev/null clears the path for an
         // added file even though the header carried a fake `a/<new>`).
-        if line.starts_with("--- ") {
-            let path = line.strip_prefix("--- ").unwrap_or("");
-            if path == "/dev/null" {
-                file.old_path = None;
-            } else {
-                // Strip "a/" prefix if present
-                let path = path.strip_prefix("a/").unwrap_or(path);
-                file.old_path = Some(path.to_string());
-            }
+        if let Some(raw) = line.strip_prefix("--- ") {
+            file.old_path = parse_diff_path_line(raw, "a/");
             continue;
         }
 
         // Parse new file path
-        if line.starts_with("+++ ") {
-            let path = line.strip_prefix("+++ ").unwrap_or("");
-            if path == "/dev/null" {
-                file.new_path = None;
-            } else {
-                // Strip "b/" prefix if present
-                let path = path.strip_prefix("b/").unwrap_or(path);
-                file.new_path = Some(path.to_string());
-            }
+        if let Some(raw) = line.strip_prefix("+++ ") {
+            file.new_path = parse_diff_path_line(raw, "b/");
             continue;
         }
 
@@ -365,39 +351,122 @@ pub fn parse_unified_diff(output: &str) -> DiffResult {
 /// authoritative paths come from `rename from`/`rename to` or `---`/`+++`
 /// lines when present, which override this.
 ///
-/// Caveat: when paths contain spaces the `a/… b/…` form is ambiguous and git
-/// quotes them or relies on the explicit headers instead, so this helper only
-/// reliably handles unquoted, space-free paths. Returns `(None, None)` if the
-/// header can't be split unambiguously.
+/// Caveat: git quotes each side independently, so both forms can share one
+/// header. Two unquoted paths stay ambiguous when the old one contains " b/";
+/// returns `(None, None)` if the header can't be split unambiguously.
 fn parse_diff_git_header(line: &str) -> (Option<String>, Option<String>) {
-    let rest = match line.strip_prefix("diff --git ") {
-        Some(r) => r,
-        None => return (None, None),
+    let Some(rest) = line.strip_prefix("diff --git ") else {
+        return (None, None);
+    };
+    let Some((old, new)) = split_diff_git_paths(rest) else {
+        return (None, None);
     };
 
-    // Quoted paths (contain spaces / special chars) are not handled here; defer
-    // to the explicit rename/`---`/`+++` headers.
+    match (
+        decode_git_path(old).and_then(|path| strip_path_prefix(&path, "a/")),
+        decode_git_path(new).and_then(|path| strip_path_prefix(&path, "b/")),
+    ) {
+        (Some(old), Some(new)) => (Some(old), Some(new)),
+        _ => (None, None),
+    }
+}
+
+/// The path a `---`/`+++` line names, or `None` for `/dev/null`.
+///
+/// Git terminates the name with a tab whenever it contains a space, so the
+/// token ends at the closing quote or at the first tab — never at end of line.
+fn parse_diff_path_line(raw: &str, prefix: &str) -> Option<String> {
+    let token = if raw.starts_with('"') {
+        raw.get(..quoted_token_end(raw)?)?
+    } else {
+        raw.split('\t').next()?
+    };
+
+    let path = decode_git_path(token)?;
+    if path == "/dev/null" {
+        return None;
+    }
+    Some(path.strip_prefix(prefix).unwrap_or(&path).to_string())
+}
+
+/// Split a `diff --git` header's two path tokens, each possibly C-quoted.
+fn split_diff_git_paths(rest: &str) -> Option<(&str, &str)> {
     if rest.starts_with('"') {
-        return (None, None);
+        let (old, tail) = rest.split_at(quoted_token_end(rest)?);
+        return Some((old, tail.strip_prefix(' ')?));
     }
 
-    let a = match rest.strip_prefix("a/") {
-        Some(a) => a,
-        None => return (None, None),
+    // An unquoted old path cannot contain `"`, so a trailing one means the new
+    // side is quoted; otherwise the last " b/" is the least-bad guess.
+    let at = if rest.ends_with('"') {
+        rest.rfind(" \"")?
+    } else {
+        rest.rfind(" b/")?
+    };
+    Some((&rest[..at], &rest[at + 1..]))
+}
+
+/// Byte index just past the closing `"` of the quoted token starting at 0.
+fn quoted_token_end(token: &str) -> Option<usize> {
+    let bytes = token.as_bytes();
+    let mut index = 1;
+    while let Some(&byte) = bytes.get(index) {
+        match byte {
+            b'\\' => index += 2,
+            b'"' => return Some(index + 1),
+            _ => index += 1,
+        }
+    }
+    None
+}
+
+/// Strip a `a/`-style diff prefix, rejecting a path that is nothing but it.
+fn strip_path_prefix(path: &str, prefix: &str) -> Option<String> {
+    let stripped = path.strip_prefix(prefix)?;
+    (!stripped.is_empty()).then(|| stripped.to_string())
+}
+
+/// Decode git's C-quoting (`core.quotePath`): `\NNN` escapes are *bytes*, so
+/// they decode into a byte buffer before the UTF-8 check. A malformed escape
+/// or a non-UTF-8 result yields `None` — a lossy name is a wrong identity.
+fn decode_git_path(raw: &str) -> Option<String> {
+    let Some(inner) = raw
+        .strip_prefix('"')
+        .and_then(|rest| rest.strip_suffix('"'))
+    else {
+        return Some(raw.to_string());
     };
 
-    // Split on the " b/" that separates the two paths. Use the last occurrence
-    // so directory components named "b" earlier in the old path don't trip us.
-    let (old, new) = match a.rsplit_once(" b/") {
-        Some(pair) => pair,
-        None => return (None, None),
-    };
-
-    if old.is_empty() || new.is_empty() {
-        return (None, None);
+    let mut decoded = Vec::with_capacity(inner.len());
+    let mut rest = inner.bytes();
+    while let Some(byte) = rest.next() {
+        if byte != b'\\' {
+            decoded.push(byte);
+            continue;
+        }
+        decoded.push(match rest.next()? {
+            b'a' => 0x07,
+            b'b' => 0x08,
+            b'f' => 0x0c,
+            b'n' => b'\n',
+            b'r' => b'\r',
+            b't' => b'\t',
+            b'v' => 0x0b,
+            verbatim @ (b'"' | b'\\') => verbatim,
+            first @ b'0'..=b'7' => {
+                // Git always writes three octal digits, and never above \377.
+                let mut value = u32::from(first - b'0');
+                for _ in 0..2 {
+                    let digit = rest.next().filter(|d| (b'0'..=b'7').contains(d))?;
+                    value = value * 8 + u32::from(digit - b'0');
+                }
+                u8::try_from(value).ok()?
+            }
+            _ => return None,
+        });
     }
 
-    (Some(old.to_string()), Some(new.to_string()))
+    String::from_utf8(decoded).ok()
 }
 
 /// Parse a hunk header into `(old_start, old_count, new_start, new_count)`.
@@ -1374,13 +1443,179 @@ rename to src/new.rs
             parse_diff_git_header("diff --git a/old.rs b/new.rs"),
             (Some("old.rs".to_string()), Some("new.rs".to_string()))
         );
-        // Quoted (special-char) paths are deferred to explicit headers.
+        // Quoted (special-char) paths are decoded, both sides independently.
         assert_eq!(
             parse_diff_git_header("diff --git \"a/has space.rs\" \"b/has space.rs\""),
-            (None, None)
+            (
+                Some("has space.rs".to_string()),
+                Some("has space.rs".to_string())
+            )
+        );
+        assert_eq!(
+            parse_diff_git_header(r#"diff --git a/plain.rs "b/p\303\251.rs""#),
+            (Some("plain.rs".to_string()), Some("pé.rs".to_string()))
+        );
+        assert_eq!(
+            parse_diff_git_header(r#"diff --git "a/p\303\251.rs" b/plain.rs"#),
+            (Some("pé.rs".to_string()), Some("plain.rs".to_string()))
         );
         // Non-header input.
         assert_eq!(parse_diff_git_header("@@ -1 +1 @@"), (None, None));
+    }
+
+    #[test]
+    fn decode_git_path_follows_gits_byte_escapes() {
+        // Octal escapes are bytes, so `\305\231` is the single char `ř`.
+        assert_eq!(
+            decode_git_path(r#""sekce/p\305\231ehled.md""#).as_deref(),
+            Some("sekce/přehled.md")
+        );
+        assert_eq!(
+            decode_git_path(r#""a\tb.txt""#).as_deref(),
+            Some("a\tb.txt")
+        );
+        assert_eq!(
+            decode_git_path(r#""q\"uote.txt""#).as_deref(),
+            Some("q\"uote.txt")
+        );
+        assert_eq!(
+            decode_git_path(r#""back\\slash.txt""#).as_deref(),
+            Some(r"back\slash.txt")
+        );
+        assert_eq!(
+            decode_git_path(r#""nl\n.txt""#).as_deref(),
+            Some("nl\n.txt")
+        );
+        assert_eq!(
+            decode_git_path(r#""bell\a.txt""#).as_deref(),
+            Some("bell\u{7}.txt")
+        );
+
+        // Only a fully double-quoted string is quoted; the rest passes through.
+        assert_eq!(
+            decode_git_path("src/main.rs").as_deref(),
+            Some("src/main.rs")
+        );
+        assert_eq!(decode_git_path(r"a\303b").as_deref(), Some(r"a\303b"));
+        assert_eq!(decode_git_path("\"").as_deref(), Some("\""));
+
+        // Bytes that are not UTF-8, and malformed escapes, have no path form.
+        assert_eq!(decode_git_path(r#""\377.txt""#), None);
+        assert_eq!(decode_git_path(r#""\q""#), None);
+        assert_eq!(decode_git_path(r#""\30""#), None);
+    }
+
+    #[test]
+    fn quoted_paths_decode_across_the_whole_file_section() {
+        let diff = "diff --git \"a/sekce/p\\305\\231ehled.md\" \"b/sekce/p\\305\\231ehled.md\"\n\
+                    --- \"a/sekce/p\\305\\231ehled.md\"\n\
+                    +++ \"b/sekce/p\\305\\231ehled.md\"\n\
+                    @@ -1,1 +1,1 @@\n\
+                    -a\n\
+                    +b\n";
+        let result = parse_unified_diff(diff);
+
+        assert_eq!(result.files.len(), 1);
+        assert_eq!(
+            result.files[0].old_path.as_deref(),
+            Some("sekce/přehled.md")
+        );
+        assert_eq!(
+            result.files[0].new_path.as_deref(),
+            Some("sekce/přehled.md")
+        );
+        // display_name feeds content loading, stage and discard.
+        assert_eq!(result.files[0].display_name(), "sekce/přehled.md");
+    }
+
+    #[test]
+    fn quoted_rename_decodes_both_sides() {
+        let diff = "diff --git \"a/st\\303\\241r\\303\\251.md\" \"b/nov\\303\\251 \\\"one\\\".md\"\n\
+                    similarity index 100%\n\
+                    rename from \"st\\303\\241r\\303\\251.md\"\n\
+                    rename to \"nov\\303\\251 \\\"one\\\".md\"\n";
+        let result = parse_unified_diff(diff);
+
+        assert_eq!(result.files.len(), 1);
+        assert_eq!(result.files[0].old_path.as_deref(), Some("stáré.md"));
+        assert_eq!(result.files[0].new_path.as_deref(), Some("nové \"one\".md"));
+    }
+
+    #[test]
+    fn tabs_and_backslashes_in_a_new_file_path_decode() {
+        let diff = "diff --git \"a/od\\\\tud\\there.md\" \"b/od\\\\tud\\there.md\"\n\
+                    new file mode 100644\n\
+                    --- /dev/null\n\
+                    +++ \"b/od\\\\tud\\there.md\"\n\
+                    @@ -0,0 +1,1 @@\n\
+                    +x\n";
+        let result = parse_unified_diff(diff);
+
+        assert_eq!(result.files.len(), 1);
+        assert_eq!(result.files[0].old_path, None);
+        assert_eq!(
+            result.files[0].new_path.as_deref(),
+            Some("od\\tud\there.md")
+        );
+    }
+
+    #[test]
+    fn a_name_with_a_space_drops_gits_tab_terminator() {
+        // git ends a `---`/`+++` name containing a space with a tab, quoted or
+        // not — keeping it would put the tab in the file identity.
+        let diff = "diff --git a/has space.md b/has space.md\n\
+                    --- a/has space.md\t\n\
+                    +++ b/has space.md\t\n\
+                    @@ -1,1 +1,1 @@\n\
+                    -a\n\
+                    +b\n";
+        let result = parse_unified_diff(diff);
+        assert_eq!(result.files[0].old_path.as_deref(), Some("has space.md"));
+        assert_eq!(result.files[0].new_path.as_deref(), Some("has space.md"));
+
+        let quoted = "diff --git \"a/sekce/nov\\303\\251 jm\\303\\251no.md\" \"b/sekce/nov\\303\\251 jm\\303\\251no.md\"\n\
+                      --- \"a/sekce/nov\\303\\251 jm\\303\\251no.md\"\t\n\
+                      +++ \"b/sekce/nov\\303\\251 jm\\303\\251no.md\"\t\n\
+                      @@ -1,1 +1,1 @@\n\
+                      -a\n\
+                      +b\n";
+        let result = parse_unified_diff(quoted);
+        assert_eq!(
+            result.files[0].old_path.as_deref(),
+            Some("sekce/nové jméno.md")
+        );
+        assert_eq!(result.files[0].display_name(), "sekce/nové jméno.md");
+    }
+
+    #[test]
+    fn an_accented_path_survives_a_real_git_diff() {
+        use crate::repository::test_support::{git_in, init_temp_repo};
+
+        // Accent (quoting) plus a space (tab terminator) in one real name.
+        let (_tmp, repo) = init_temp_repo();
+        let name = "sekce/nové jméno.md";
+        std::fs::create_dir_all(repo.join("sekce")).unwrap();
+        std::fs::write(repo.join(name), "a\n").unwrap();
+        git_in(&repo, &["add", "."]);
+        git_in(
+            &repo,
+            &["-c", "commit.gpgsign=false", "commit", "-m", "accented"],
+        );
+        std::fs::write(repo.join(name), "b\n").unwrap();
+
+        let result = get_diff_with_options(&repo, DiffMode::WorkingTree, false)
+            .expect("diff an accented path");
+        let names: Vec<&str> = result.files.iter().map(|f| f.display_name()).collect();
+        assert_eq!(names, vec![name]);
+        // The name is a file identity, not just a label: it has to resolve.
+        assert_eq!(
+            get_file_from_working_tree(&repo, result.files[0].display_name()).as_deref(),
+            Some("b\n")
+        );
+        assert_eq!(
+            get_file_from_git(&repo, "HEAD", result.files[0].display_name()).as_deref(),
+            Some("a\n")
+        );
     }
 
     #[test]

--- a/crates/okena-git/src/repository/worktree.rs
+++ b/crates/okena-git/src/repository/worktree.rs
@@ -377,6 +377,69 @@ fn require_absent_worktree_target(target_path: &Path) -> GitResult<()> {
     Ok(())
 }
 
+/// An existing ref to start a new branch from: the pushed copy when there is
+/// one, else the local branch. `None` when the repository has neither — a
+/// local-only repository never has `origin/<branch>` to base anything on.
+fn resolve_start_ref(repo_path: &Path, branch: &str) -> Option<String> {
+    let repo = crate::gix_helpers::open(repo_path)?;
+    if repo
+        .find_reference(&format!("refs/remotes/origin/{branch}"))
+        .is_ok()
+    {
+        return Some(format!("origin/{branch}"));
+    }
+    repo.find_reference(&format!("refs/heads/{branch}"))
+        .is_ok()
+        .then(|| branch.to_string())
+}
+
+/// Freshen the default branch, then resolve what a new branch starts from.
+fn fetch_and_resolve_start_ref(repo_path: &Path, repo_str: &str) -> Option<String> {
+    let default_branch = get_default_branch(repo_path)?;
+    let _ =
+        safe_output(network_command().args(["-C", repo_str, "fetch", "origin", &default_branch]));
+    resolve_start_ref(repo_path, &default_branch)
+}
+
+/// How `git worktree add` attaches the new checkout.
+enum BranchAttachment {
+    /// Create `-b <branch>`, optionally from a resolved start ref.
+    NewBranch(Option<String>),
+    /// Check out an existing branch by name.
+    Existing(String),
+    /// Create a local branch tracking a remote-only selection.
+    TrackRemote { local: String, remote: String },
+}
+
+/// Resolve a branch picked from a list that mixes local names with
+/// remote-prefixed ones (`origin/feature`). Handing the remote ref straight to
+/// `git worktree add` detaches HEAD, so it becomes a local tracking branch
+/// instead; an existing local branch of that name wins, as it does in
+/// `checkout_remote_branch`. Anything that is neither goes to git unchanged so
+/// its own diagnostic reaches the user.
+fn resolve_existing_branch(repo_path: &Path, branch: &str) -> GitResult<BranchAttachment> {
+    let Some(repo) = crate::gix_helpers::open(repo_path) else {
+        return Ok(BranchAttachment::Existing(branch.to_string()));
+    };
+    let is_ref = |full: String| repo.find_reference(&full).is_ok();
+    if is_ref(format!("refs/heads/{branch}")) || !is_ref(format!("refs/remotes/{branch}")) {
+        return Ok(BranchAttachment::Existing(branch.to_string()));
+    }
+
+    let local = branch.split_once('/').map_or("", |(_, rest)| rest);
+    if local.is_empty() {
+        return Err(GitError::InvalidRef(branch.to_string()));
+    }
+    crate::validate_git_ref(local)?;
+    if is_ref(format!("refs/heads/{local}")) {
+        return Ok(BranchAttachment::Existing(local.to_string()));
+    }
+    Ok(BranchAttachment::TrackRemote {
+        local: local.to_string(),
+        remote: branch.to_string(),
+    })
+}
+
 /// Create a new worktree.
 pub fn create_worktree(
     repo_path: &Path,
@@ -390,30 +453,33 @@ pub fn create_worktree(
     let repo_str = path_str(repo_path)?;
     let target_str = path_str(target_path)?;
 
-    let mut args = vec!["-C", repo_str, "worktree", "add"];
-
-    // When creating a new branch, fetch the remote default branch first,
-    // then base the worktree on origin/{default} so it starts from the
-    // latest remote state instead of a potentially stale local ref.
-    let start_point;
-    if create_branch {
-        args.push("-b");
-        args.push(branch);
-        args.push(target_str);
-        if let Some(default_branch) = get_default_branch(repo_path) {
-            let _ = safe_output(network_command().args([
-                "-C",
-                repo_str,
-                "fetch",
-                "origin",
-                &default_branch,
-            ]));
-            start_point = format!("origin/{}", default_branch);
-            args.push(&start_point);
-        }
+    let attachment = if create_branch {
+        BranchAttachment::NewBranch(fetch_and_resolve_start_ref(repo_path, repo_str))
     } else {
-        args.push(target_str);
-        args.push(branch);
+        resolve_existing_branch(repo_path, branch)?
+    };
+
+    let mut args = vec!["-C", repo_str, "worktree", "add"];
+    match &attachment {
+        BranchAttachment::NewBranch(start_point) => {
+            args.push("-b");
+            args.push(branch);
+            args.push(target_str);
+            if let Some(start_point) = start_point {
+                args.push(start_point);
+            }
+        }
+        BranchAttachment::Existing(name) => {
+            args.push(target_str);
+            args.push(name);
+        }
+        BranchAttachment::TrackRemote { local, remote } => {
+            args.push("--track");
+            args.push("-b");
+            args.push(local);
+            args.push(target_str);
+            args.push(remote);
+        }
     }
 
     let output = safe_output(command("git").args(&args))?;
@@ -421,8 +487,9 @@ pub fn create_worktree(
 }
 
 /// Create a new worktree with an optional pre-fetched start point.
-/// If `start_branch` is Some, creates `-b <branch> <target> origin/<start_branch>`
-/// without re-fetching (caller is expected to have fetched already).
+/// If `start_branch` is Some, creates `-b <branch> <target> <resolved start>`
+/// without re-fetching (caller is expected to have fetched already); the start
+/// ref resolves to `origin/<start_branch>` or, failing that, the local branch.
 pub fn create_worktree_with_start_point(
     repo_path: &Path,
     branch: &str,
@@ -440,10 +507,9 @@ pub fn create_worktree_with_start_point(
 
     let mut args = vec!["-C", repo_str, "worktree", "add", "-b", branch, target_str];
 
-    let start_point;
-    if let Some(sb) = start_branch {
-        start_point = format!("origin/{}", sb);
-        args.push(&start_point);
+    let start_point = start_branch.and_then(|sb| resolve_start_ref(repo_path, sb));
+    if let Some(start_point) = &start_point {
+        args.push(start_point);
     }
 
     let output = safe_output(command("git").args(&args))?;
@@ -1036,6 +1102,154 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(sentinel).expect("existing data survives"),
             "user data"
+        );
+    }
+
+    /// Read-only git, returning trimmed stdout.
+    fn git_out(repo: &Path, args: &[&str]) -> String {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("git command failed");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn commit_in(repo: &Path, name: &str) {
+        std::fs::write(repo.join(name), name).expect("write file");
+        git_in(repo, &["add", "."]);
+        git_in(repo, &["-c", "commit.gpgsign=false", "commit", "-m", name]);
+    }
+
+    /// A repo whose `main` is pushed to a bare `origin`. The second tempdir owns
+    /// the remote and must stay alive for the repo's lifetime.
+    fn repo_with_origin() -> (tempfile::TempDir, PathBuf, tempfile::TempDir) {
+        let (tmp, repo) = init_temp_repo();
+        let remote_tmp = tempfile::tempdir().expect("create remote tempdir");
+        let remote = remote_tmp.path().join("remote.git");
+        let remote_str = remote.to_str().expect("remote path is utf-8");
+        git_in(&repo, &["init", "--bare", "-b", "main", remote_str]);
+        git_in(&repo, &["remote", "add", "origin", remote_str]);
+        git_in(&repo, &["push", "-q", "origin", "main"]);
+        (tmp, repo, remote_tmp)
+    }
+
+    /// Push `feature` and drop the local copy, leaving only `origin/feature` —
+    /// the shape a remote-only entry in the branch picker has.
+    fn push_and_forget_feature(repo: &Path) {
+        git_in(repo, &["branch", "feature"]);
+        git_in(repo, &["push", "-q", "origin", "feature"]);
+        git_in(repo, &["branch", "-D", "feature"]);
+        git_in(repo, &["fetch", "-q", "origin"]);
+    }
+
+    /// A repository with no remote has no `origin/<default>` at all, so a start
+    /// point built from that name is a fatal invalid reference.
+    #[test]
+    fn a_local_only_repository_starts_a_new_branch_from_its_local_default() {
+        let (_tmp, repo) = init_temp_repo();
+        // Take HEAD off the default branch, so starting from HEAD instead of
+        // the resolved default would be visible.
+        git_in(&repo, &["checkout", "-q", "-b", "side"]);
+        commit_in(&repo, "side.txt");
+
+        let target_parent = tempfile::tempdir().expect("create target parent");
+        let target = target_parent.path().join("wt-feature");
+
+        create_worktree(&repo, "feature", &target, true).expect("create from a local default");
+
+        assert_eq!(
+            git_out(&target, &["symbolic-ref", "--short", "HEAD"]),
+            "feature"
+        );
+        assert_eq!(
+            git_out(&target, &["rev-parse", "HEAD"]),
+            git_out(&repo, &["rev-parse", "main"]),
+            "the new branch starts from the local default branch"
+        );
+    }
+
+    /// Same fallback for the pre-fetched entry point the daemon uses.
+    #[test]
+    fn a_pre_resolved_start_point_falls_back_to_the_local_branch() {
+        let (_tmp, repo) = init_temp_repo();
+        git_in(&repo, &["checkout", "-q", "-b", "side"]);
+        commit_in(&repo, "side.txt");
+
+        let target_parent = tempfile::tempdir().expect("create target parent");
+        let target = target_parent.path().join("wt-feature");
+
+        create_worktree_with_start_point(&repo, "feature", &target, Some("main"))
+            .expect("create from a local start point");
+
+        assert_eq!(
+            git_out(&target, &["symbolic-ref", "--short", "HEAD"]),
+            "feature"
+        );
+        assert_eq!(
+            git_out(&target, &["rev-parse", "HEAD"]),
+            git_out(&repo, &["rev-parse", "main"])
+        );
+    }
+
+    /// Handing `origin/feature` to `git worktree add` detaches HEAD; the pick
+    /// has to become a local branch tracking it.
+    #[test]
+    fn a_remote_only_branch_becomes_an_attached_local_tracking_branch() {
+        let (_tmp, repo, _remote) = repo_with_origin();
+        push_and_forget_feature(&repo);
+
+        let target_parent = tempfile::tempdir().expect("create target parent");
+        let target = target_parent.path().join("wt-feature");
+
+        create_worktree(&repo, "origin/feature", &target, false)
+            .expect("create from a remote-only branch");
+
+        assert_eq!(
+            git_out(&target, &["symbolic-ref", "--short", "HEAD"]),
+            "feature",
+            "the checkout must be attached to a local branch, not detached"
+        );
+        assert_eq!(
+            git_out(&target, &["rev-parse", "--abbrev-ref", "@{upstream}"]),
+            "origin/feature"
+        );
+    }
+
+    /// Collision policy: a local branch of the derived name already exists, so
+    /// the checkout attaches to it rather than inventing a second name or
+    /// moving the branch onto the remote tip.
+    #[test]
+    fn a_remote_pick_whose_local_name_exists_checks_out_that_local_branch() {
+        let (_tmp, repo, _remote) = repo_with_origin();
+        push_and_forget_feature(&repo);
+        commit_in(&repo, "later.txt");
+        git_in(&repo, &["branch", "-f", "feature", "main"]);
+
+        let target_parent = tempfile::tempdir().expect("create target parent");
+        let target = target_parent.path().join("wt-feature");
+
+        create_worktree(&repo, "origin/feature", &target, false)
+            .expect("create from a colliding remote pick");
+
+        assert_eq!(
+            git_out(&target, &["symbolic-ref", "--short", "HEAD"]),
+            "feature"
+        );
+        assert_eq!(
+            git_out(&target, &["rev-parse", "HEAD"]),
+            git_out(&repo, &["rev-parse", "feature"]),
+            "the existing local branch wins over the remote tip"
+        );
+        assert_ne!(
+            git_out(&target, &["rev-parse", "HEAD"]),
+            git_out(&repo, &["rev-parse", "origin/feature"])
         );
     }
 }

--- a/crates/okena-terminal/src/input.rs
+++ b/crates/okena-terminal/src/input.rs
@@ -50,16 +50,17 @@ pub fn key_to_bytes(
 
     let mods = &event.modifiers;
 
-    // Handle Ctrl+key combinations for letters (produces control characters)
-    if mods.control && !mods.shift && !mods.alt && !mods.platform {
-        let key = event.key.as_str();
-        if let Some(c) = key.chars().next()
-            && key.len() == 1
-            && c.is_ascii_alphabetic()
-        {
-            let ctrl_char = (c.to_ascii_lowercase() as u8) - b'a' + 1;
-            return Some(vec![ctrl_char]);
+    // Handle Ctrl+key combinations (produces control characters).
+    // Ctrl+Alt keeps the meta ESC prefix in front of the control character.
+    if mods.control
+        && !mods.platform
+        && !delivered_as_text(event)
+        && let Some(byte) = control_byte(&event.key)
+    {
+        if mods.alt {
+            return Some(vec![0x1b, byte]);
         }
+        return Some(vec![byte]);
     }
 
     // Handle Tab with modifiers
@@ -143,10 +144,9 @@ pub fn key_to_bytes(
         _ => {}
     }
 
-    // If the platform provides `key_char`, the UI framework will also deliver it via the
-    // text-input (InputHandler) path. To avoid double-sending characters, let the InputHandler
-    // handle all text-producing keystrokes.
-    if event.key_char.is_some() {
+    // The platform key drives app shortcuts, never PTY input, and text-producing
+    // keystrokes are delivered again through the InputHandler path.
+    if mods.platform || delivered_as_text(event) {
         return None;
     }
 
@@ -166,33 +166,128 @@ pub fn key_to_bytes(
             }
             return Some(b"\x1b[F".to_vec());
         }
-        "pageup" => return Some(b"\x1b[5~".to_vec()),
-        "pagedown" => return Some(b"\x1b[6~".to_vec()),
-        "delete" => return Some(b"\x1b[3~".to_vec()),
-        "f1" => return Some(b"\x1bOP".to_vec()),
-        "f2" => return Some(b"\x1bOQ".to_vec()),
-        "f3" => return Some(b"\x1bOR".to_vec()),
-        "f4" => return Some(b"\x1bOS".to_vec()),
-        "f5" => return Some(b"\x1b[15~".to_vec()),
-        "f6" => return Some(b"\x1b[17~".to_vec()),
-        "f7" => return Some(b"\x1b[18~".to_vec()),
-        "f8" => return Some(b"\x1b[19~".to_vec()),
-        "f9" => return Some(b"\x1b[20~".to_vec()),
-        "f10" => return Some(b"\x1b[21~".to_vec()),
-        "f11" => return Some(b"\x1b[23~".to_vec()),
-        "f12" => return Some(b"\x1b[24~".to_vec()),
         _ => {}
+    }
+
+    if let Some(code) = tilde_key_code(&event.key) {
+        if modifier_code > 1 {
+            return Some(format!("\x1b[{};{}~", code, modifier_code).into_bytes());
+        }
+        return Some(format!("\x1b[{}~", code).into_bytes());
+    }
+
+    if let Some(final_byte) = ss3_function_key(&event.key) {
+        if modifier_code > 1 {
+            return Some(format!("\x1b[1;{}{}", modifier_code, final_byte).into_bytes());
+        }
+        return Some(format!("\x1bO{}", final_byte).into_bytes());
+    }
+
+    // Legacy meta: ESC prefix in front of the character the key sends on its own.
+    if mods.alt
+        && let Some(c) = meta_char(event)
+    {
+        return Some(format!("\x1b{}", c).into_bytes());
     }
 
     // Single character keys as fallback
     let key = event.key.as_str();
-    if key.len() == 1 {
+    if !mods.control && !mods.alt && key.len() == 1 {
         log::info!("Using key string: {:?}", key);
         return Some(key.as_bytes().to_vec());
     }
 
     log::warn!("No input generated for key: {:?}", event.key);
     None
+}
+
+/// True when the UI framework also commits this keystroke through the text-input
+/// (InputHandler) path, where encoding it here as well would double-send it.
+fn delivered_as_text(event: &KeyEvent) -> bool {
+    let mods = &event.modifiers;
+    let Some(text) = event.key_char.as_deref() else {
+        return false;
+    };
+    if text.is_empty() || text.chars().any(char::is_control) {
+        return false;
+    }
+    match (mods.control, mods.alt) {
+        (false, false) => true,
+        // Windows AltGr composes a character out of Ctrl+Alt and commits it via WM_CHAR.
+        (true, true) => true,
+        // macOS Option composes one (Option+B is `∫`) and commits it via the IME.
+        (false, true) => cfg!(target_os = "macos"),
+        (true, false) => false,
+    }
+}
+
+/// The control character a Ctrl-modified key produces in the legacy encoding.
+fn control_byte(key: &str) -> Option<u8> {
+    if key == "space" {
+        return Some(0x00);
+    }
+    let &[byte] = key.as_bytes() else {
+        return None;
+    };
+    Some(match byte {
+        b'a'..=b'z' | b'A'..=b'Z' => byte.to_ascii_lowercase() - b'a' + 1,
+        b' ' | b'@' => 0x00,
+        b'[' => 0x1b,
+        b'\\' => 0x1c,
+        b']' => 0x1d,
+        b'^' => 0x1e,
+        b'_' | b'/' => 0x1f,
+        b'?' => 0x7f,
+        _ => return None,
+    })
+}
+
+/// Parameter of the xterm `CSI n ~` keys, which take `CSI n ; mod ~` when modified.
+fn tilde_key_code(key: &str) -> Option<u32> {
+    Some(match key {
+        "insert" => 2,
+        "delete" => 3,
+        "pageup" => 5,
+        "pagedown" => 6,
+        "f5" => 15,
+        "f6" => 17,
+        "f7" => 18,
+        "f8" => 19,
+        "f9" => 20,
+        "f10" => 21,
+        "f11" => 23,
+        "f12" => 24,
+        _ => return None,
+    })
+}
+
+/// Final byte of F1-F4, which are SS3 when unmodified and `CSI 1 ; mod X` otherwise.
+fn ss3_function_key(key: &str) -> Option<char> {
+    Some(match key {
+        "f1" => 'P',
+        "f2" => 'Q',
+        "f3" => 'R',
+        "f4" => 'S',
+        _ => return None,
+    })
+}
+
+/// The character an Alt-modified key sends after the meta ESC prefix. Reads `key`,
+/// not `key_char`, so a layout's Alt composition never leaks into the sequence.
+fn meta_char(event: &KeyEvent) -> Option<char> {
+    if event.key == "space" {
+        return Some(' ');
+    }
+    let mut chars = event.key.chars();
+    let c = chars.next()?;
+    if chars.next().is_some() || c.is_control() {
+        return None;
+    }
+    Some(if event.modifiers.shift {
+        c.to_ascii_uppercase()
+    } else {
+        c
+    })
 }
 
 /// Encode a key as a `CSI u` sequence: `CSI code u` when unmodified, or
@@ -279,10 +374,25 @@ mod tests {
         }
     }
 
+    fn alt() -> KeyModifiers {
+        KeyModifiers {
+            alt: true,
+            ..Default::default()
+        }
+    }
+
     fn on() -> KittyKeyboardFlags {
         KittyKeyboardFlags {
             disambiguate_escape_codes: true,
         }
+    }
+
+    fn off() -> KittyKeyboardFlags {
+        KittyKeyboardFlags::default()
+    }
+
+    fn legacy(key: &str, key_char: Option<&str>, mods: KeyModifiers) -> Option<Vec<u8>> {
+        key_to_bytes(&ev(key, key_char, mods), false, off())
     }
 
     #[test]
@@ -371,6 +481,171 @@ mod tests {
         assert_eq!(
             key_to_bytes(&ev("up", None, KeyModifiers::default()), false, on()),
             Some(b"\x1b[A".to_vec())
+        );
+    }
+
+    #[test]
+    fn alt_printable_gets_the_meta_escape_prefix() {
+        assert_eq!(legacy("b", None, alt()), Some(b"\x1bb".to_vec()));
+        assert_eq!(legacy("f", None, alt()), Some(b"\x1bf".to_vec()));
+        assert_eq!(legacy("space", None, alt()), Some(b"\x1b ".to_vec()));
+        assert_eq!(
+            legacy(
+                "b",
+                None,
+                KeyModifiers {
+                    alt: true,
+                    shift: true,
+                    ..Default::default()
+                }
+            ),
+            Some(b"\x1bB".to_vec())
+        );
+    }
+
+    #[test]
+    fn ctrl_alt_printable_prefixes_the_control_character() {
+        assert_eq!(
+            legacy(
+                "b",
+                None,
+                KeyModifiers {
+                    control: true,
+                    alt: true,
+                    ..Default::default()
+                }
+            ),
+            Some(vec![0x1b, 0x02])
+        );
+    }
+
+    /// Windows AltGr arrives as Ctrl+Alt and commits its character via WM_CHAR.
+    #[test]
+    fn altgr_composition_is_left_to_the_text_path() {
+        assert_eq!(
+            legacy(
+                "q",
+                Some("@"),
+                KeyModifiers {
+                    control: true,
+                    alt: true,
+                    ..Default::default()
+                }
+            ),
+            None
+        );
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn alt_printable_is_encoded_even_when_the_platform_reports_a_char() {
+        assert_eq!(legacy("b", Some("b"), alt()), Some(b"\x1bb".to_vec()));
+    }
+
+    /// macOS Option composes a character and commits it through the IME.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_option_composition_is_left_to_the_text_path() {
+        assert_eq!(legacy("b", Some("\u{222b}"), alt()), None);
+    }
+
+    #[test]
+    fn ctrl_space_is_nul() {
+        assert_eq!(legacy("space", None, ctrl()), Some(vec![0x00]));
+    }
+
+    #[test]
+    fn ctrl_punctuation_maps_to_control_characters() {
+        assert_eq!(legacy("[", None, ctrl()), Some(vec![0x1b]));
+        assert_eq!(legacy("\\", None, ctrl()), Some(vec![0x1c]));
+        assert_eq!(legacy("]", None, ctrl()), Some(vec![0x1d]));
+        assert_eq!(legacy("^", None, ctrl()), Some(vec![0x1e]));
+        assert_eq!(legacy("_", None, ctrl()), Some(vec![0x1f]));
+        assert_eq!(legacy("/", None, ctrl()), Some(vec![0x1f]));
+        assert_eq!(legacy("?", None, ctrl()), Some(vec![0x7f]));
+    }
+
+    #[test]
+    fn ctrl_shift_letter_still_maps_to_its_control_character() {
+        assert_eq!(
+            legacy(
+                "a",
+                None,
+                KeyModifiers {
+                    control: true,
+                    shift: true,
+                    ..Default::default()
+                }
+            ),
+            Some(vec![0x01])
+        );
+    }
+
+    #[test]
+    fn tilde_keys_carry_their_modifier_parameter() {
+        assert_eq!(legacy("pageup", None, shift()), Some(b"\x1b[5;2~".to_vec()));
+        assert_eq!(legacy("delete", None, ctrl()), Some(b"\x1b[3;5~".to_vec()));
+        assert_eq!(legacy("pagedown", None, alt()), Some(b"\x1b[6;3~".to_vec()));
+        assert_eq!(
+            legacy("pageup", None, KeyModifiers::default()),
+            Some(b"\x1b[5~".to_vec())
+        );
+        assert_eq!(
+            legacy("insert", None, KeyModifiers::default()),
+            Some(b"\x1b[2~".to_vec())
+        );
+    }
+
+    #[test]
+    fn function_keys_keep_their_unmodified_encoding() {
+        assert_eq!(
+            legacy("f1", None, KeyModifiers::default()),
+            Some(b"\x1bOP".to_vec())
+        );
+        assert_eq!(
+            legacy("f4", None, KeyModifiers::default()),
+            Some(b"\x1bOS".to_vec())
+        );
+        assert_eq!(
+            legacy("f5", None, KeyModifiers::default()),
+            Some(b"\x1b[15~".to_vec())
+        );
+        assert_eq!(
+            legacy("f12", None, KeyModifiers::default()),
+            Some(b"\x1b[24~".to_vec())
+        );
+    }
+
+    #[test]
+    fn modified_function_keys_carry_their_modifier_parameter() {
+        assert_eq!(legacy("f1", None, ctrl()), Some(b"\x1b[1;5P".to_vec()));
+        assert_eq!(legacy("f4", None, shift()), Some(b"\x1b[1;2S".to_vec()));
+        assert_eq!(legacy("f5", None, shift()), Some(b"\x1b[15;2~".to_vec()));
+        assert_eq!(legacy("f12", None, alt()), Some(b"\x1b[24;3~".to_vec()));
+    }
+
+    #[test]
+    fn plain_char_is_never_double_sent() {
+        assert_eq!(legacy("a", Some("a"), KeyModifiers::default()), None);
+        assert_eq!(legacy("a", Some("A"), shift()), None);
+        assert_eq!(legacy("space", Some(" "), KeyModifiers::default()), None);
+    }
+
+    #[test]
+    fn platform_modified_keys_stay_out_of_the_pty() {
+        let platform = KeyModifiers {
+            platform: true,
+            ..Default::default()
+        };
+        assert_eq!(legacy("b", Some("b"), platform.clone()), None);
+        assert_eq!(legacy("f5", None, platform), None);
+    }
+
+    #[test]
+    fn kitty_disambiguation_still_wins_over_the_legacy_meta_prefix() {
+        assert_eq!(
+            key_to_bytes(&ev("b", None, alt()), false, on()),
+            Some(b"\x1b[98;3u".to_vec())
         );
     }
 }

--- a/crates/okena-terminal/src/terminal/ansi_snapshot.rs
+++ b/crates/okena-terminal/src/terminal/ansi_snapshot.rs
@@ -125,14 +125,13 @@ fn write_grid(term: &Term<ZedEventListener>, target: SnapshotTarget) -> Vec<u8> 
                 current = desired;
             }
 
-            // Write the character
-            let c = cell.c;
-            if c == '\0' || c == ' ' {
-                buf.push(b' ');
-            } else {
-                let mut utf8_buf = [0u8; 4];
-                let encoded = c.encode_utf8(&mut utf8_buf);
-                buf.extend_from_slice(encoded.as_bytes());
+            // Write the cell's glyph: base char, then the zero-width marks
+            // stacked on it. The marks advance no column on the replaying end.
+            let mut utf8_buf = [0u8; 4];
+            let base = if cell.c == '\0' { ' ' } else { cell.c };
+            buf.extend_from_slice(base.encode_utf8(&mut utf8_buf).as_bytes());
+            for mark in cell.zerowidth().into_iter().flatten() {
+                buf.extend_from_slice(mark.encode_utf8(&mut utf8_buf).as_bytes());
             }
 
             col_idx += 1;
@@ -353,6 +352,60 @@ mod tests {
         assert!(host.is_alt_screen(), "host left the alternate screen");
         assert!(host.is_mouse_mode(), "host lost mouse reporting");
         assert_eq!(first_row(&host), "remote output");
+    }
+
+    /// The mark of a decomposed grapheme lives beside `cell.c`, not in it.
+    fn first_row_cells(terminal: &Terminal, count: usize) -> Vec<(char, Vec<char>)> {
+        use alacritty_terminal::index::{Column, Line, Point};
+
+        terminal.with_content(|term| {
+            let grid = term.grid();
+            (0..count)
+                .map(|col| {
+                    let cell = &grid[Point::new(Line(0), Column(col))];
+                    (cell.c, cell.zerowidth().unwrap_or_default().to_vec())
+                })
+                .collect()
+        })
+    }
+
+    #[test]
+    fn a_snapshot_carries_combining_marks_and_their_columns() {
+        let source = terminal("source");
+        source.process_output("e\u{0301}x".as_bytes());
+        assert_eq!(
+            first_row_cells(&source, 2),
+            vec![('e', vec!['\u{0301}']), ('x', Vec::new())],
+            "alacritty stores the mark beside the base char"
+        );
+
+        let bytes = source.render_snapshot();
+        assert!(
+            String::from_utf8_lossy(&bytes).contains("e\u{0301}x"),
+            "the snapshot dropped the combining mark"
+        );
+
+        let mirror = terminal("mirror");
+        mirror.process_output(&bytes);
+        assert_eq!(
+            first_row_cells(&mirror, 2),
+            vec![('e', vec!['\u{0301}']), ('x', Vec::new())],
+            "the mirror lost the mark or shifted a column"
+        );
+    }
+
+    #[test]
+    fn a_snapshot_carries_a_mark_standing_over_a_blank_cell() {
+        let source = terminal("source");
+        source.process_output(" \u{0301}x".as_bytes());
+
+        let mirror = terminal("mirror");
+        mirror.process_output(&source.render_snapshot());
+
+        assert_eq!(
+            first_row_cells(&mirror, 2),
+            vec![(' ', vec!['\u{0301}']), ('x', Vec::new())]
+        );
     }
 
     #[test]

--- a/crates/okena-views-terminal/src/actions.rs
+++ b/crates/okena-views-terminal/src/actions.rs
@@ -29,6 +29,8 @@ gpui::actions!(
         CloseSearch,
         SendTab,
         SendBacktab,
+        ScrollUp,
+        ScrollDown,
         ZoomIn,
         ZoomOut,
         ResetZoom,

--- a/crates/okena-views-terminal/src/elements/terminal_element.rs
+++ b/crates/okena-views-terminal/src/elements/terminal_element.rs
@@ -1,6 +1,7 @@
 use crate::terminal_view_settings;
 use alacritty_terminal::grid::{Dimensions, Row};
 use alacritty_terminal::index::{Column, Line};
+use alacritty_terminal::term::TermMode;
 use alacritty_terminal::term::cell::{Cell, Flags};
 use alacritty_terminal::vte::ansi::{Color, NamedColor};
 use gpui::*;
@@ -40,7 +41,7 @@ mod tests {
     use super::super::terminal_rendering::BatchedTextLine;
     use super::{
         RowHasher, RowLayout, TerminalElementState, TerminalGridLayout, TerminalRenderCache,
-        TerminalRenderCacheKey, build_terminal_grid_layout, changed_cells,
+        TerminalRenderCacheKey, build_terminal_grid_layout, changed_cells, cursor_paints,
         deregister_resize_viewer, selected_columns, shared_resize_target,
     };
     use gpui::{Font, FontFeatures, FontStyle, FontWeight, TextRun, px};
@@ -130,6 +131,7 @@ mod tests {
             display_offset: 0,
             cursor_col: 0,
             cursor_visual_line: 0,
+            cursor_mode_visible: true,
             cells_scanned: 0,
         }
     }
@@ -156,9 +158,10 @@ mod tests {
                     .chars()
                     .next()
                     .map(|first| {
-                        let mut line = BatchedTextLine::new(row as i32, 0, first, style.clone());
+                        let mut line =
+                            BatchedTextLine::new(row as i32, 0, first, &[], style.clone());
                         for (offset, c) in text.chars().skip(1).enumerate() {
-                            line.append(offset as i32 + 1, c, style.clone());
+                            line.append(offset as i32 + 1, c, &[], style.clone());
                         }
                         line
                     })
@@ -177,6 +180,7 @@ mod tests {
             display_offset: 0,
             cursor_col: 0,
             cursor_visual_line: 0,
+            cursor_mode_visible: true,
             cells_scanned: texts.len() * cols,
         }
     }
@@ -459,6 +463,104 @@ mod tests {
             "the rebuilt row carries the new underline colour"
         );
     }
+
+    #[test]
+    fn a_decomposed_grapheme_is_shaped_with_its_combining_mark() {
+        let terminal = terminal_showing(10, 1, "e\u{0301}".as_bytes());
+
+        let layout = build(&terminal, None, None);
+
+        assert_eq!(layout.rows[0].text_lines[0].text, "e\u{0301}");
+        assert_eq!(
+            layout.rows[0].text_lines[0].styles[0].len,
+            "e\u{0301}".len(),
+            "the run length must cover the mark's bytes too"
+        );
+    }
+
+    #[test]
+    fn a_combining_mark_does_not_consume_a_column() {
+        let plain = terminal_showing(10, 1, b"e\x1b[1;6Hx");
+        let decomposed = terminal_showing(10, 1, "e\u{0301}\x1b[1;6Hx".as_bytes());
+
+        let plain_layout = build(&plain, None, None);
+        let plain_line = &plain_layout.rows[0].text_lines[0];
+        let layout = build(&decomposed, None, None);
+        let line = &layout.rows[0].text_lines[0];
+
+        assert_eq!(plain_line.text, "e    x");
+        assert_eq!(line.text, "e\u{0301}    x", "the gap absorbed a column");
+        assert_eq!(line.start_col, plain_line.start_col);
+        assert_eq!(
+            line.styles.iter().map(|run| run.len).sum::<usize>(),
+            line.text.len()
+        );
+    }
+
+    #[test]
+    fn adding_a_combining_mark_rebuilds_the_row() {
+        let terminal = terminal_showing(10, 2, b"e\r\nx");
+        let first = build(&terminal, None, None);
+
+        // A bare mark lands on the cell left of the cursor, so park it after `e`.
+        terminal.process_output("\x1b[1;2H\u{0301}".as_bytes());
+        let second = build(&terminal, None, Some(&first));
+
+        assert_eq!(reused_rows(&first, &second), vec![false, true]);
+        assert_eq!(second.rows[0].text_lines[0].text, "e\u{0301}");
+    }
+
+    #[test]
+    fn a_mark_over_a_blank_cell_still_paints() {
+        let terminal = terminal_showing(10, 1, " \u{0301}".as_bytes());
+
+        let layout = build(&terminal, None, None);
+
+        assert_eq!(layout.rows[0].text_lines[0].text, " \u{0301}");
+    }
+
+    #[test]
+    fn the_layout_follows_the_applications_cursor_visibility_mode() {
+        let terminal = terminal_showing(10, 3, b"hi");
+        assert!(build(&terminal, None, None).cursor_mode_visible);
+
+        terminal.process_output(b"\x1b[?25l");
+        let hidden = build(&terminal, None, None);
+        assert!(!hidden.cursor_mode_visible);
+        assert_eq!(
+            (hidden.cursor_col, hidden.cursor_visual_line),
+            (2, 0),
+            "hiding the cursor must not move it"
+        );
+
+        terminal.process_output(b"\x1b[?25h");
+        assert!(build(&terminal, None, None).cursor_mode_visible);
+    }
+
+    #[test]
+    fn an_application_hidden_cursor_is_never_painted() {
+        let mut layout = layout_of(3, 10, &["a", "b", "c"]);
+        assert!(cursor_paints(true, &layout));
+
+        layout.cursor_mode_visible = false;
+        assert!(!cursor_paints(true, &layout));
+        assert!(!cursor_paints(false, &layout));
+    }
+
+    #[test]
+    fn the_blink_phase_and_the_viewport_still_gate_a_shown_cursor() {
+        let mut layout = layout_of(3, 10, &["a", "b", "c"]);
+        assert!(layout.cursor_mode_visible);
+
+        assert!(!cursor_paints(false, &layout), "blinked off");
+        assert!(cursor_paints(true, &layout), "blinked on");
+
+        layout.cursor_visual_line = 3;
+        assert!(
+            !cursor_paints(true, &layout),
+            "scrolled out of the viewport"
+        );
+    }
 }
 
 pub(crate) fn deregister_resize_viewer(terminal_id: &str, viewer_id: u64) {
@@ -734,6 +836,9 @@ struct TerminalGridLayout {
     display_offset: i32,
     cursor_col: usize,
     cursor_visual_line: i32,
+    /// DECTCEM (`CSI ?25h` / `?25l`): the app hides its own cursor while the
+    /// pane keeps focus, so this is independent of the pane's blink state.
+    cursor_mode_visible: bool,
     /// Cells of the rows this build actually rebuilt; reused rows cost none.
     cells_scanned: usize,
 }
@@ -859,6 +964,7 @@ fn build_terminal_grid_layout(
             display_offset,
             cursor_col: cursor_point.column.0,
             cursor_visual_line: cursor_point.line.0 + display_offset,
+            cursor_mode_visible: term.mode().contains(TermMode::SHOW_CURSOR),
             cells_scanned: rebuilt_rows.saturating_mul(cols),
         };
         (content_generation, layout)
@@ -895,14 +1001,20 @@ fn selected_columns(
 }
 
 /// Everything that decides how a row paints besides the theme and fonts the cache
-/// key pins: each cell's glyph, colours, flags and underline colour, plus the
-/// selection span. Zero-width chars and hyperlinks are not painted by the grid.
+/// key pins: each cell's glyph (base char plus its zero-width marks), colours,
+/// flags and underline colour, plus the selection span. Hyperlinks are not painted.
 fn row_hash(cells: &Row<Cell>, cols: usize, selected: Option<(usize, usize)>) -> u64 {
     let mut hasher = RowHasher::default();
     selected.hash(&mut hasher);
     for col in 0..cols {
         let cell = &cells[Column(col)];
+        let marks = cell.zerowidth().unwrap_or_default();
         hasher.write_u32(u32::from(cell.c));
+        // Unconditional, so a mark can never be mistaken for the next field.
+        hasher.write_usize(marks.len());
+        for mark in marks {
+            hasher.write_u32(u32::from(*mark));
+        }
         hasher.write_u16(cell.flags.bits());
         hash_color(&cell.fg, &mut hasher);
         hash_color(&cell.bg, &mut hasher);
@@ -1036,7 +1148,11 @@ fn build_row(
         if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
             continue;
         }
-        if cell.c == ' ' && !cell.flags.intersects(Flags::UNDERLINE | Flags::STRIKEOUT) {
+        let marks = cell.zerowidth().unwrap_or_default();
+        if cell.c == ' '
+            && marks.is_empty()
+            && !cell.flags.intersects(Flags::UNDERLINE | Flags::STRIKEOUT)
+        {
             continue;
         }
 
@@ -1060,7 +1176,7 @@ fn build_row(
         };
 
         let text_style = TextRun {
-            len: cell.c.len_utf8(),
+            len: cell.c.len_utf8() + marks.iter().map(|mark| mark.len_utf8()).sum::<usize>(),
             font,
             color: fg_color,
             background_color: None,
@@ -1095,15 +1211,17 @@ fn build_row(
                 visual_line,
                 col_i32,
                 cell.c,
+                marks,
                 text_style,
             ));
         } else if let Some(line) = current_line.as_mut() {
-            line.append(col_i32, cell.c, text_style);
+            line.append(col_i32, cell.c, marks, text_style);
         } else {
             current_line = Some(BatchedTextLine::new(
                 visual_line,
                 col_i32,
                 cell.c,
+                marks,
                 text_style,
             ));
         }
@@ -1169,6 +1287,16 @@ fn changed_cells(
 /// Vertical shift the scroll-aware measurement searches. Wide enough for the
 /// usual streaming case (a few lines at a time), cheap enough to run per paint.
 const MAX_TRACKED_SCROLL: i32 = 8;
+
+/// Three independent reasons to skip the cursor: the pane's blink phase or
+/// focus (`blink_visible`), the app's own DECTCEM hide, and a cursor scrolled
+/// out of the viewport.
+fn cursor_paints(blink_visible: bool, layout: &TerminalGridLayout) -> bool {
+    blink_visible
+        && layout.cursor_mode_visible
+        && layout.cursor_visual_line >= 0
+        && layout.cursor_visual_line < layout.screen_lines() as i32
+}
 
 impl Element for TerminalElement {
     type RequestLayoutState = TerminalElementState;
@@ -1562,10 +1690,7 @@ impl Element for TerminalElement {
         });
 
         // Phase 4: Paint cursor
-        if cursor_visible
-            && layout.cursor_visual_line >= 0
-            && layout.cursor_visual_line < layout.screen_lines() as i32
-        {
+        if cursor_paints(cursor_visible, &layout) {
             let cursor_x =
                 px((f32::from(bounds.origin.x) + layout.cursor_col as f32 * cell_width_f).floor());
             let cursor_y = px((f32::from(bounds.origin.y)

--- a/crates/okena-views-terminal/src/elements/terminal_rendering.rs
+++ b/crates/okena-views-terminal/src/elements/terminal_rendering.rs
@@ -17,22 +17,23 @@ pub(crate) struct BatchedTextLine {
 }
 
 impl BatchedTextLine {
-    pub fn new(line: i32, start_col: i32, c: char, style: TextRun) -> Self {
-        let mut text = String::with_capacity(100);
-        text.push(c);
-        let mut style = style;
-        style.len = c.len_utf8();
-        Self {
+    /// `marks` are the cell's zero-width characters, stacked on `c`. They are
+    /// part of the cell's glyph, so they add bytes but never a column.
+    pub fn new(line: i32, start_col: i32, c: char, marks: &[char], style: TextRun) -> Self {
+        let mut result = Self {
             line,
             start_col,
-            text,
-            styles: vec![style],
+            text: String::with_capacity(100),
+            styles: Vec::new(),
             next_col: start_col + 1,
             shaped: OnceLock::new(),
-        }
+        };
+        result.push_cell(c, marks, style);
+        result
     }
 
-    pub fn append(&mut self, col: i32, c: char, style: TextRun) {
+    /// See [`Self::new`] for `marks`.
+    pub fn append(&mut self, col: i32, c: char, marks: &[char], style: TextRun) {
         debug_assert!(col >= self.next_col);
         if col > self.next_col {
             let gap = " ".repeat((self.next_col..col).count());
@@ -42,9 +43,21 @@ impl BatchedTextLine {
             gap_style.strikethrough = None;
             self.append_text(&gap, gap_style);
         }
-        let mut encoded = [0; 4];
-        self.append_text(c.encode_utf8(&mut encoded), style);
+        self.push_cell(c, marks, style);
         self.next_col = col + 1;
+    }
+
+    /// One cell's whole glyph as a single style run; the caller owns the column.
+    fn push_cell(&mut self, c: char, marks: &[char], style: TextRun) {
+        if marks.is_empty() {
+            let mut encoded = [0; 4];
+            self.append_text(c.encode_utf8(&mut encoded), style);
+            return;
+        }
+        let mut text = String::with_capacity((marks.len() + 1) * 4);
+        text.push(c);
+        text.extend(marks.iter().copied());
+        self.append_text(&text, style);
     }
 
     fn append_text(&mut self, text: &str, mut style: TextRun) {
@@ -114,9 +127,9 @@ mod tests {
     #[test]
     fn adjacent_cells_with_the_same_style_share_one_run() {
         let text_style = style(0x11_22_33);
-        let mut line = BatchedTextLine::new(2, 3, 'a', text_style.clone());
+        let mut line = BatchedTextLine::new(2, 3, 'a', &[], text_style.clone());
 
-        line.append(4, 'b', text_style);
+        line.append(4, 'b', &[], text_style);
 
         assert_eq!(line.line, 2);
         assert_eq!(line.start_col, 3);
@@ -129,9 +142,9 @@ mod tests {
     #[test]
     fn skipped_cells_become_spaces_without_an_extra_paint_run() {
         let text_style = style(0x11_22_33);
-        let mut line = BatchedTextLine::new(0, 1, 'a', text_style.clone());
+        let mut line = BatchedTextLine::new(0, 1, 'a', &[], text_style.clone());
 
-        line.append(4, 'b', text_style);
+        line.append(4, 'b', &[], text_style);
 
         assert_eq!(line.text, "a  b");
         assert_eq!(line.styles.len(), 1);
@@ -143,9 +156,9 @@ mod tests {
     fn style_changes_remain_separate_inside_one_line() {
         let first = style(0x11_22_33);
         let second = style(0x44_55_66);
-        let mut line = BatchedTextLine::new(0, 0, 'a', first);
+        let mut line = BatchedTextLine::new(0, 0, 'a', &[], first);
 
-        line.append(1, 'b', second);
+        line.append(1, 'b', &[], second);
 
         assert_eq!(line.text, "ab");
         assert_eq!(line.styles.len(), 2);
@@ -165,9 +178,9 @@ mod tests {
             color: None,
             thickness: px(1.0),
         });
-        let mut line = BatchedTextLine::new(0, 0, 'a', decorated.clone());
+        let mut line = BatchedTextLine::new(0, 0, 'a', &[], decorated.clone());
 
-        line.append(2, 'b', decorated);
+        line.append(2, 'b', &[], decorated);
 
         assert_eq!(line.text, "a b");
         assert_eq!(line.styles.len(), 3);
@@ -180,12 +193,40 @@ mod tests {
     #[test]
     fn a_wide_character_gap_preserves_following_column_alignment() {
         let text_style = style(0x11_22_33);
-        let mut line = BatchedTextLine::new(0, 0, '界', text_style.clone());
+        let mut line = BatchedTextLine::new(0, 0, '界', &[], text_style.clone());
 
-        line.append(2, 'x', text_style);
+        line.append(2, 'x', &[], text_style);
 
         assert_eq!(line.text, "界 x");
         assert_eq!(line.styles.iter().map(|run| run.len).sum::<usize>(), 5);
+        assert_eq!(line.next_col, 3);
+    }
+
+    #[test]
+    fn a_combining_mark_joins_its_base_run_without_taking_a_column() {
+        let text_style = style(0x11_22_33);
+        let mut line = BatchedTextLine::new(0, 0, 'e', &['\u{0301}'], text_style.clone());
+
+        line.append(1, 'x', &[], text_style);
+
+        assert_eq!(line.text, "e\u{0301}x");
+        assert_eq!(line.styles.len(), 1);
+        assert_eq!(line.styles[0].len, "e\u{0301}x".len());
+        assert_eq!(line.next_col, 2, "the mark shares its base cell's column");
+    }
+
+    #[test]
+    fn marks_on_a_gapped_cell_keep_the_run_lengths_in_bytes() {
+        let text_style = style(0x11_22_33);
+        let mut line = BatchedTextLine::new(0, 0, 'a', &[], text_style.clone());
+
+        line.append(2, 'e', &['\u{0301}', '\u{0308}'], text_style);
+
+        assert_eq!(line.text, "a e\u{0301}\u{0308}");
+        assert_eq!(
+            line.styles.iter().map(|run| run.len).sum::<usize>(),
+            line.text.len()
+        );
         assert_eq!(line.next_col, 3);
     }
 

--- a/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/content.rs
@@ -282,6 +282,26 @@ impl TerminalContent {
         });
     }
 
+    /// Keyboard page scroll behind the `ScrollUp` / `ScrollDown` actions.
+    pub fn scroll_by_page(&mut self, up: bool, cx: &mut Context<Self>) {
+        let Some(terminal) = self.terminal.clone() else {
+            return;
+        };
+        let Ok(lines) = i32::try_from(terminal.screen_lines()) else {
+            return;
+        };
+        if lines <= 0 {
+            return;
+        }
+        if up {
+            terminal.scroll_up(lines);
+        } else {
+            terminal.scroll_down(lines);
+        }
+        self.mark_scroll_activity(cx);
+        cx.notify();
+    }
+
     pub fn handle_scroll(
         &mut self,
         delta: f32,

--- a/crates/okena-views-terminal/src/layout/terminal_pane/render.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/render.rs
@@ -6,8 +6,8 @@ use crate::actions::{
     ExportTerminalBuffer, FocusDown, FocusLeft, FocusNextTerminal, FocusPrevTerminal, FocusRight,
     FocusUp, FullscreenNextTerminal, FullscreenPrevTerminal, JumpToNextFailedCommand,
     JumpToNextPrompt, JumpToPreviousFailedCommand, JumpToPreviousPrompt, MinimizeTerminal, Paste,
-    ResetZoom, Search, SearchNext, SearchPrev, SendBacktab, SendEscape, SendTab, SplitHorizontal,
-    SplitVertical, ToggleFullscreen, ToggleUnread, ZoomIn, ZoomOut,
+    ResetZoom, ScrollDown, ScrollUp, Search, SearchNext, SearchPrev, SendBacktab, SendEscape,
+    SendTab, SplitHorizontal, SplitVertical, ToggleFullscreen, ToggleUnread, ZoomIn, ZoomOut,
 };
 use crate::layout::navigation::NavigationDirection;
 use crate::terminal_view_settings;
@@ -242,6 +242,14 @@ impl<D: ActionDispatch + Send + Sync> Render for TerminalPane<D> {
                 if let Some(ref terminal) = this.terminal {
                     terminal.send_escape();
                 }
+            }))
+            .on_action(cx.listener(|this, _: &ScrollUp, _window, cx| {
+                this.content
+                    .update(cx, |content, cx| content.scroll_by_page(true, cx));
+            }))
+            .on_action(cx.listener(|this, _: &ScrollDown, _window, cx| {
+                this.content
+                    .update(cx, |content, cx| content.scroll_by_page(false, cx));
             }))
             .on_action(cx.listener(|this, _: &ZoomIn, _window, cx| {
                 let current = this

--- a/crates/okena-workspace/src/actions/worktree.rs
+++ b/crates/okena-workspace/src/actions/worktree.rs
@@ -1748,6 +1748,8 @@ mod merge_pipeline_tests {
         let repo = tmp.root.join("repo");
         std::fs::create_dir(&repo).unwrap();
         git(&["-C", path_str(&repo), "init", "-q"]);
+        git(&["-C", path_str(&repo), "config", "user.name", "Test"]);
+        git(&["-C", path_str(&repo), "config", "user.email", "test@example.com"]);
         git(&["-C", path_str(&repo), "commit", "-q", "--allow-empty", "-m", "root"]);
         git(&["-C", path_str(&repo), "branch", "feature"]);
 
@@ -1764,6 +1766,8 @@ mod merge_pipeline_tests {
         let repo = tmp.root.join("repo");
         std::fs::create_dir(&repo).unwrap();
         git(&["-C", path_str(&repo), "init", "-q"]);
+        git(&["-C", path_str(&repo), "config", "user.name", "Test"]);
+        git(&["-C", path_str(&repo), "config", "user.email", "test@example.com"]);
         git(&["-C", path_str(&repo), "commit", "-q", "--allow-empty", "-m", "root"]);
         git(&["-C", path_str(&repo), "branch", "feature"]);
         git(&["-C", path_str(&repo), "commit", "-q", "--allow-empty", "-m", "unmerged"]);

--- a/crates/okena-workspace/src/actions/worktree.rs
+++ b/crates/okena-workspace/src/actions/worktree.rs
@@ -344,16 +344,46 @@ pub fn close_worktree_merge_git(
 /// Delete a closed worktree's branch, local and remote.
 ///
 /// Only ever call this once the checkout is gone: `git branch -d` refuses a
-/// branch a worktree still holds, and the refusal is not worth surfacing — the
-/// close itself succeeded. A branch that survives is recoverable; the checkout
-/// this deletes it after is not.
-pub fn delete_closed_worktree_branch(main_repo_path: &str, branch: &str) {
+/// branch a worktree still holds. Returns what survived so the caller can tell
+/// the user the branch outlived the close they asked it to end.
+pub fn delete_closed_worktree_branch(main_repo_path: &str, branch: &str) -> Result<(), String> {
     let repo = std::path::Path::new(main_repo_path);
+    let mut survived = Vec::new();
+
     if let Err(e) = okena_git::delete_local_branch(repo, branch) {
         log::warn!("Delete local branch failed (continuing): {}", e);
+        survived.push(format!("local: {e}"));
     }
     if let Err(e) = okena_git::delete_remote_branch(repo, branch) {
         log::warn!("Delete remote branch failed (continuing): {}", e);
+        if !nothing_to_delete_on_remote(&e.to_string()) {
+            survived.push(format!("remote: {e}"));
+        }
+    }
+
+    if survived.is_empty() {
+        Ok(())
+    } else {
+        Err(survived.join("; "))
+    }
+}
+
+/// A repo without `origin`, or a branch never pushed, leaves nothing on the
+/// remote to delete. `git push --delete` still fails, but reporting it would
+/// put an error in front of every local-only worktree close.
+fn nothing_to_delete_on_remote(error: &str) -> bool {
+    error.contains("remote ref does not exist")
+        || error.contains("does not appear to be a git repository")
+}
+
+/// Warning, not error: the close itself succeeded, only the branch is left.
+pub fn surviving_branch_toast(branch: &str, error: &str) -> okena_state::Toast {
+    okena_state::Toast::warning(format!("Branch '{branch}' was not deleted")).with_detail(error)
+}
+
+fn report_surviving_branch(branch: &str, error: &str, cx: &mut impl WorkspaceCx) {
+    if let Some(monitor) = cx.hook_monitor() {
+        monitor.push_toast(surviving_branch_toast(branch, error));
     }
 }
 
@@ -1445,8 +1475,11 @@ impl Workspace {
                 global_hooks,
                 cx,
             );
-            if removed.is_ok() && delete_branch_enabled {
-                delete_closed_worktree_branch(&main_repo_path, &branch);
+            if removed.is_ok()
+                && delete_branch_enabled
+                && let Err(error) = delete_closed_worktree_branch(&main_repo_path, &branch)
+            {
+                report_surviving_branch(&branch, &error, cx);
             }
             removed
         }
@@ -1455,7 +1488,7 @@ impl Workspace {
 
 #[cfg(test)]
 mod merge_pipeline_tests {
-    use super::delete_closed_worktree_branch;
+    use super::{delete_closed_worktree_branch, surviving_branch_toast};
     use super::{
         CloseWorktreeGitOutcome, WorktreeRemovalPlan, WorktreeRemovalTarget, close_dirty_state,
         close_worktree_merge_git,
@@ -1707,6 +1740,48 @@ mod merge_pipeline_tests {
         String::from_utf8_lossy(&output.stdout).into_owned()
     }
 
+    /// `git push --delete` always fails without an `origin`. Reporting that
+    /// would put a warning on every close in a repository that has no remote.
+    #[test]
+    fn a_repository_without_a_remote_reports_a_clean_branch_cleanup() {
+        let tmp = TestRepo::new();
+        let repo = tmp.root.join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        git(&["-C", path_str(&repo), "init", "-q"]);
+        git(&["-C", path_str(&repo), "commit", "-q", "--allow-empty", "-m", "root"]);
+        git(&["-C", path_str(&repo), "branch", "feature"]);
+
+        assert_eq!(delete_closed_worktree_branch(path_str(&repo), "feature"), Ok(()));
+        assert!(!local_branches(&repo).contains("feature"));
+    }
+
+    /// A branch the close was asked to delete but could not is the one thing
+    /// worth surfacing: the checkout is gone and cannot be got back, the branch
+    /// is still there and the user has to decide what to do with it.
+    #[test]
+    fn an_unmerged_branch_survives_the_close_and_says_so() {
+        let tmp = TestRepo::new();
+        let repo = tmp.root.join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        git(&["-C", path_str(&repo), "init", "-q"]);
+        git(&["-C", path_str(&repo), "commit", "-q", "--allow-empty", "-m", "root"]);
+        git(&["-C", path_str(&repo), "branch", "feature"]);
+        git(&["-C", path_str(&repo), "commit", "-q", "--allow-empty", "-m", "unmerged"]);
+        git(&["-C", path_str(&repo), "branch", "-f", "feature", "HEAD"]);
+        git(&["-C", path_str(&repo), "reset", "-q", "--hard", "HEAD~1"]);
+
+        let outcome = delete_closed_worktree_branch(path_str(&repo), "feature");
+
+        let error = outcome.expect_err("an unmerged branch is not deleted by `branch -d`");
+        assert!(error.starts_with("local:"), "{error}");
+        assert!(local_branches(&repo).contains("feature"));
+
+        let toast = surviving_branch_toast("feature", &error);
+        assert_eq!(toast.level, okena_state::ToastLevel::Warning);
+        assert!(toast.message.contains("feature"));
+        assert_eq!(toast.detail.as_deref(), Some(error.as_str()));
+    }
+
     /// The whole reason the deletion left the merge pipeline: Git refuses to
     /// delete a branch a checkout still holds, and that refusal was only logged.
     #[test]
@@ -1738,10 +1813,14 @@ mod merge_pipeline_tests {
             "feature",
         ]);
 
-        delete_closed_worktree_branch(path_str(&main_repo), "feature");
+        let held = delete_closed_worktree_branch(path_str(&main_repo), "feature");
         assert!(
             local_branches(&main_repo).contains("feature"),
             "git cannot delete a branch its worktree still holds"
+        );
+        assert!(
+            held.is_err_and(|e| e.starts_with("local:")),
+            "and the caller has to learn the branch survived"
         );
 
         git(&[
@@ -1752,8 +1831,9 @@ mod merge_pipeline_tests {
             "--force",
             path_str(&worktree),
         ]);
-        delete_closed_worktree_branch(path_str(&main_repo), "feature");
+        let cleaned = delete_closed_worktree_branch(path_str(&main_repo), "feature");
 
+        assert_eq!(cleaned, Ok(()));
         assert!(
             !local_branches(&main_repo).contains("feature"),
             "the local branch must be gone once its checkout is"

--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,12 @@ case "$OS" in
   *) err "Unsupported OS: $OS. For Windows, use install.ps1" ;;
 esac
 
+# Only the combinations we actually publish. Without this, Linux arm64 falls
+# through and installs an x64 binary that cannot run.
+if [ "$OS" = "linux" ] && [ "$ARCH" != "x64" ]; then
+  err "No Linux $ARCH release is published yet. Build from source: https://github.com/${REPO}#building"
+fi
+
 # Get version (from argument or latest release)
 if [ -n "$1" ]; then
   VERSION="$1"
@@ -77,7 +83,7 @@ if [ "$OS" = "darwin" ]; then
   echo ""
 
 else
-  ARTIFACT="okena-linux-x64"
+  ARTIFACT="okena-linux-${ARCH}"
   DOWNLOAD_URL="https://github.com/${REPO}/releases/download/v${VERSION}/${ARTIFACT}.tar.gz"
 
   step "Downloading"


### PR DESCRIPTION
Stacks on #198. Continues the review fix-up where #202 stopped: that PR took every critical and high finding, this one takes fifteen mediums and lows that are cheap and user-visible.

## What is fixed

**Terminal**
- Legacy modifier encoding. `Alt-B`/`Alt-F` never reached readline, `~`-style keys ignored their modifier. Full encoding table for control bytes, `CSI n ; mod ~`, `CSI 1 ; mod P..S` and the ESC meta prefix. The negotiated Kitty path is untouched and a test pins that it still wins.
- Combining marks. alacritty stores zero-width characters apart from `cell.c`; the renderer, the row hash and the ANSI snapshot all read only the base, so decomposed text lost its accent and adding a mark did not even repaint the row.
- `CSI ?25l` is honoured. Applications that hide the cursor no longer get one painted.
- `Shift-PageUp`/`Shift-PageDown` reach a handler. They were bound in the `TerminalPane` context while sitting in the app-level action list, with no handler registered anywhere.

**Git**
- Quoted paths are decoded. Any file whose name holds non-ASCII arrived as octal escapes and every action keyed on that path missed. The same lines had an unreported defect: git terminates the `---`/`+++` path with a tab whenever the name holds a space, quoted or not.
- Worktree creation resolves a start ref that exists (a local-only repo got `fatal: invalid reference: origin/main`) and attaches the branch (a remote-only pick produced a detached checkout).
- A branch that outlives its close now raises a toast instead of a log line.

**Packaging and CLI**
- Releases publish `SHA256SUMS`. The updater looks for exactly that asset and silently skips verification without it, so every update installed unverified while the README advertised SHA256 verification.
- `install.sh` refuses a Linux architecture we do not ship. It accepted `aarch64`, then downloaded the x64 binary and reported success.
- Mobile CI runs the Jest suite it already defines.
- `okena -V` reports the app version.
- Exported terminal buffers no longer collide. Every local export wrote `terminal-remote:l.txt` and overwrote the previous one.
- The Claude usage poller no longer panics on a multibyte response body.
- README says edition 2024.

## Where the review was wrong

Three of the fifteen did not hold up as written, which is worth knowing before anyone works the rest of the list:

- **CORR-25 was already fixed** by 6df594e0. Implementing it would have rewritten working code.
- **CORR-117** said Alt-printable was "sent raw". On Linux it was dropped entirely — GPUI's text path only accepts modifiers that are a subset of shift.
- **COMP-23** said version reporting was broken. `--version` always worked; `main.rs` answers it before the CLI gate is reached. Only `-V` was broken.

## Deliberately not done

- macOS Option-as-Meta needs a `stop_propagation` and a user setting outside `input.rs`; encoding it alone would double-send.
- Terminal search still cannot match decomposed text. `col_at_byte` rests on one char per column, so marks cannot go in without an explicit byte-to-column map first.
- `git push origin --delete` fails whenever there is no `origin` or the branch was never pushed. Both are reported as success, or every close in a local-only repository would raise a warning.

## Verification

`cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace` 74 suites with no failures, `npm test` in `mobile/rn` 25 tests. Every fix carries tests; the worktree ones were checked against real git and confirmed non-vacuous by reverting the fix and watching them fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSZhvCKhHXrWBAqLjCfTSr