### PR TITLE
fix(terminal): composed characters, and Unicode in search and links

### DIFF
--- a/crates/okena-app-core/src/settings.rs
+++ b/crates/okena-app-core/src/settings.rs
@@ -174,6 +174,7 @@ impl SettingsState {
         terminal_double_click_selects_in_mouse_mode,
         bool
     );
+    setting_setter!(set_terminal_option_as_meta, terminal_option_as_meta, bool);
     setting_setter!(set_blame_visible, blame_visible, bool);
 
     /// Master switch for native desktop notifications (opt-in).

--- a/crates/okena-app-core/src/workspace/actions/execute/terminal.rs
+++ b/crates/okena-app-core/src/workspace/actions/execute/terminal.rs
@@ -9,8 +9,10 @@ use super::{ActionResult, ensure_terminal, find_terminal_path, spawn_uninitializ
 use crate::workspace::focus::FocusManager;
 use crate::workspace::persistence::AppSettings;
 use crate::workspace::state::Workspace;
+use alacritty_terminal::event::EventListener;
 use alacritty_terminal::grid::Dimensions;
 use alacritty_terminal::index::{Column, Line, Point};
+use alacritty_terminal::term::Term;
 use okena_core::keys::SpecialKey;
 use okena_core::types::SplitDirection;
 use okena_terminal::TerminalsRegistry;
@@ -327,30 +329,35 @@ pub(super) fn read_content(
     settings: &AppSettings,
 ) -> ActionResult {
     with_ensured_terminal(ws, &terminal_id, backend, terminals, settings, |term| {
-        let content = term.with_content(|term| {
-            let grid = term.grid();
-            let screen_lines = grid.screen_lines();
-            let cols = grid.columns();
-            let mut lines = Vec::with_capacity(screen_lines);
-
-            for row in 0..screen_lines as i32 {
-                let mut line = String::with_capacity(cols);
-                for col in 0..cols {
-                    let cell = &grid[Point::new(Line(row), Column(col))];
-                    line.push(cell.c);
-                }
-                let trimmed = line.trim_end().to_string();
-                lines.push(trimmed);
-            }
-
-            while lines.last().is_some_and(|l| l.is_empty()) {
-                lines.pop();
-            }
-
-            lines.join("\n")
-        });
+        let content = term.with_content(screen_text);
         ActionResult::Ok(Some(serde_json::json!({"content": content})))
     })
+}
+
+/// alacritty keeps a cell's zero-width marks beside `cell.c`, so the base char
+/// alone loses the accent of decomposed text.
+fn screen_text<T: EventListener>(term: &Term<T>) -> String {
+    let grid = term.grid();
+    let screen_lines = grid.screen_lines();
+    let cols = grid.columns();
+    let mut lines = Vec::with_capacity(screen_lines);
+
+    for row in 0..screen_lines as i32 {
+        let mut line = String::with_capacity(cols);
+        for col in 0..cols {
+            let cell = &grid[Point::new(Line(row), Column(col))];
+            line.push(cell.c);
+            line.extend(cell.zerowidth().into_iter().flatten());
+        }
+        let trimmed = line.trim_end().to_string();
+        lines.push(trimmed);
+    }
+
+    while lines.last().is_some_and(|l| l.is_empty()) {
+        lines.pop();
+    }
+
+    lines.join("\n")
 }
 
 pub(super) fn export_buffer(terminal_id: String, backend: &dyn TerminalBackend) -> ActionResult {
@@ -366,5 +373,37 @@ pub(super) fn export_buffer(terminal_id: String, backend: &dyn TerminalBackend) 
         None => {
             ActionResult::Err("buffer capture unavailable (requires a tmux session backend)".into())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::screen_text;
+    use alacritty_terminal::event::{Event, EventListener};
+    use alacritty_terminal::term::test::TermSize;
+    use alacritty_terminal::term::{Config, Term};
+    use alacritty_terminal::vte::ansi::Processor;
+
+    struct NoopListener;
+
+    impl EventListener for NoopListener {
+        fn send_event(&self, _event: Event) {}
+    }
+
+    fn screen(output: &str) -> String {
+        let mut term = Term::new(Config::default(), &TermSize::new(10, 3), NoopListener);
+        let mut processor: Processor = Processor::new();
+        processor.advance(&mut term, output.as_bytes());
+        screen_text(&term)
+    }
+
+    #[test]
+    fn a_screen_read_keeps_a_combining_mark_with_its_base_char() {
+        assert_eq!(screen("e\u{0301}x"), "e\u{0301}x");
+    }
+
+    #[test]
+    fn a_screen_read_keeps_a_mark_standing_over_a_blank_cell() {
+        assert_eq!(screen(" \u{0301}x"), " \u{0301}x");
     }
 }

--- a/crates/okena-app/src/views/overlays/settings_panel/render_terminal.rs
+++ b/crates/okena-app/src/views/overlays/settings_panel/render_terminal.rs
@@ -84,6 +84,14 @@ impl SettingsPanel {
                     cx,
                 ))
                 .child(self.render_toggle(
+                    "option-as-meta",
+                    "Option as Meta (macOS)",
+                    s.terminal_option_as_meta,
+                    true,
+                    |state, val, cx| state.set_terminal_option_as_meta(val, cx),
+                    cx,
+                ))
+                .child(self.render_toggle(
                     "idle-detection",
                     "Idle Detection",
                     s.idle_timeout_secs > 0,

--- a/crates/okena-mobile-ffi/src/client/terminal_holder.rs
+++ b/crates/okena-mobile-ffi/src/client/terminal_holder.rs
@@ -115,8 +115,13 @@ impl TerminalHolder {
                     flags |= 32;
                 }
 
+                // alacritty keeps the zero-width marks beside `cell.c`, so the
+                // base char alone loses the accent of decomposed text.
+                let mut character = String::from(cell.c);
+                character.extend(cell.zerowidth().into_iter().flatten());
+
                 cells.push(CellData {
-                    character: cell.c.to_string(),
+                    character,
                     fg: fg_argb,
                     bg: bg_argb,
                     flags,
@@ -280,6 +285,24 @@ mod tests {
             .map(|c| c.character.as_str())
             .collect();
         assert_eq!(text, "Hello, world!");
+    }
+
+    #[test]
+    fn combining_marks_stay_with_their_base_char() {
+        let holder = TerminalHolder::new(80, 24);
+        holder.process_output("e\u{0301}x".as_bytes());
+        let cells = holder.get_visible_cells(&DARK_THEME);
+        assert_eq!(cells[0].character, "e\u{0301}");
+        assert_eq!(cells[1].character, "x");
+    }
+
+    #[test]
+    fn a_mark_standing_over_a_blank_cell_survives() {
+        let holder = TerminalHolder::new(80, 24);
+        holder.process_output(" \u{0301}x".as_bytes());
+        let cells = holder.get_visible_cells(&DARK_THEME);
+        assert_eq!(cells[0].character, " \u{0301}");
+        assert_eq!(cells[1].character, "x");
     }
 
     #[test]

--- a/crates/okena-mobile-ffi/src/lib.rs
+++ b/crates/okena-mobile-ffi/src/lib.rs
@@ -150,8 +150,9 @@ pub fn get_visible_cells(conn_id: String, terminal_id: String) -> Vec<CellData> 
 ///   cols : u16 LE
 ///   rows : u16 LE
 /// Then cols*rows cells, row-major, 13 bytes each:
-///   codepoint : u32 LE   Unicode scalar of the cell's primary char
-///                        (0x20 / space for empty or wide-char-spacer cells)
+///   codepoint : u32 LE   Unicode scalar of the cell's base char, without its
+///                        zero-width marks — a fixed-width cell cannot carry
+///                        them (0x20 for empty or wide-char-spacer cells)
 ///   fg        : u32 LE   ARGB
 ///   bg        : u32 LE   ARGB
 ///   flags     : u8       bold(1)|italic(2)|underline(4)|strikethrough(8)|
@@ -187,7 +188,8 @@ pub fn get_visible_cells_packed(conn_id: String, terminal_id: String) -> Vec<u8>
     buf.extend_from_slice(&cols.to_le_bytes());
     buf.extend_from_slice(&rows.to_le_bytes());
     for cell in &cells {
-        // Primary scalar; empty (wide-char spacer) or space → 0x20.
+        // Base scalar only: one fixed u32 per cell has no room for the cell's
+        // zero-width marks, so decomposed text reaches the canvas unaccented.
         let codepoint: u32 = cell
             .character
             .chars()

--- a/crates/okena-terminal/src/input.rs
+++ b/crates/okena-terminal/src/input.rs
@@ -28,22 +28,25 @@ pub struct KittyKeyboardFlags {
     pub disambiguate_escape_codes: bool,
 }
 
+/// Terminal modes and user settings that change how a keystroke is encoded.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct KeyEncodeOptions {
+    /// Application cursor keys mode (DECCKM): arrows send SS3 (`\x1bOA`) instead
+    /// of CSI (`\x1b[A`). Set by applications like less, vim and htop.
+    pub app_cursor_mode: bool,
+    /// Active kitty keyboard protocol flags. With `disambiguate_escape_codes`,
+    /// the ambiguous keys (Esc, ctrl/alt+key, modified Enter/Tab/Backspace) are
+    /// reported as `CSI u` sequences before the legacy logic runs.
+    pub kitty: KittyKeyboardFlags,
+    /// macOS only: Option encodes Meta instead of composing a character. Callers
+    /// must pair it with `consumes_composed_text`.
+    pub option_as_meta: bool,
+}
+
 /// Convert a key event to terminal input bytes.
-///
-/// `app_cursor_mode`: When true, arrow keys send SS3 sequences (\x1bOA) instead of CSI (\x1b[A).
-/// This should be true when the terminal is in application cursor keys mode (DECCKM),
-/// which is used by applications like less, vim, htop, etc.
-///
-/// `kitty`: Active kitty keyboard protocol flags. When `disambiguate_escape_codes`
-/// is set, the ambiguous keys (Esc, ctrl/alt+key, modified Enter/Tab/Backspace) are
-/// reported as `CSI u` sequences before the legacy logic runs.
-pub fn key_to_bytes(
-    event: &KeyEvent,
-    app_cursor_mode: bool,
-    kitty: KittyKeyboardFlags,
-) -> Option<Vec<u8>> {
-    if kitty.disambiguate_escape_codes
-        && let Some(bytes) = kitty_disambiguate_bytes(event)
+pub fn key_to_bytes(event: &KeyEvent, options: KeyEncodeOptions) -> Option<Vec<u8>> {
+    if options.kitty.disambiguate_escape_codes
+        && let Some(bytes) = kitty_disambiguate_bytes(event, options)
     {
         return Some(bytes);
     }
@@ -54,7 +57,7 @@ pub fn key_to_bytes(
     // Ctrl+Alt keeps the meta ESC prefix in front of the control character.
     if mods.control
         && !mods.platform
-        && !delivered_as_text(event)
+        && !delivered_as_text(event, options)
         && let Some(byte) = control_byte(&event.key)
     {
         if mods.alt {
@@ -136,7 +139,7 @@ pub fn key_to_bytes(
                 return Some(format!("\x1b[1;{}{}", modifier_code, arrow_char).into_bytes());
             }
             // No modifiers: use SS3 in app cursor mode, CSI otherwise
-            if app_cursor_mode {
+            if options.app_cursor_mode {
                 return Some(format!("\x1bO{}", arrow_char).into_bytes());
             }
             return Some(format!("\x1b[{}", arrow_char).into_bytes());
@@ -146,7 +149,7 @@ pub fn key_to_bytes(
 
     // The platform key drives app shortcuts, never PTY input, and text-producing
     // keystrokes are delivered again through the InputHandler path.
-    if mods.platform || delivered_as_text(event) {
+    if mods.platform || delivered_as_text(event, options) {
         return None;
     }
 
@@ -203,22 +206,41 @@ pub fn key_to_bytes(
 
 /// True when the UI framework also commits this keystroke through the text-input
 /// (InputHandler) path, where encoding it here as well would double-send it.
-fn delivered_as_text(event: &KeyEvent) -> bool {
-    let mods = &event.modifiers;
-    let Some(text) = event.key_char.as_deref() else {
-        return false;
-    };
-    if text.is_empty() || text.chars().any(char::is_control) {
+fn delivered_as_text(event: &KeyEvent, options: KeyEncodeOptions) -> bool {
+    if !committable_text(event) {
         return false;
     }
+    let mods = &event.modifiers;
     match (mods.control, mods.alt) {
         (false, false) => true,
         // Windows AltGr composes a character out of Ctrl+Alt and commits it via WM_CHAR.
         (true, true) => true,
-        // macOS Option composes one (Option+B is `∫`) and commits it via the IME.
-        (false, true) => cfg!(target_os = "macos"),
+        // macOS Option composes one (Option+B is `∫`) and commits it via the IME,
+        // unless the user asked for Meta instead.
+        (false, true) => cfg!(target_os = "macos") && !options.option_as_meta,
         (true, false) => false,
     }
+}
+
+/// True when `key_char` carries a character the platform can commit as text.
+fn committable_text(event: &KeyEvent) -> bool {
+    event
+        .key_char
+        .as_deref()
+        .is_some_and(|text| !text.is_empty() && !text.chars().any(char::is_control))
+}
+
+/// True when the encoder claimed a keystroke macOS will *also* commit as text
+/// (Option-as-Meta). Callers must stop propagation for exactly these, or the
+/// composed character is sent on top of the meta sequence.
+pub fn consumes_composed_text(event: &KeyEvent, options: KeyEncodeOptions) -> bool {
+    let mods = &event.modifiers;
+    cfg!(target_os = "macos")
+        && options.option_as_meta
+        && mods.alt
+        && !mods.control
+        && !mods.platform
+        && committable_text(event)
 }
 
 /// The control character a Ctrl-modified key produces in the legacy encoding.
@@ -306,8 +328,9 @@ fn csi_u(code: u32, kmod: u32) -> Vec<u8> {
 /// Esc (always), modified Enter/Tab/Backspace, and ctrl/alt printable keys.
 /// Returns `None` for everything else so the caller falls through to the
 /// legacy logic, which already matches kitty for arrows/Home/End and produces
-/// text for plain keys.
-fn kitty_disambiguate_bytes(event: &KeyEvent) -> Option<Vec<u8>> {
+/// text for plain keys. A printable key the platform commits as text (AltGr,
+/// macOS Option) is declined too, so the protocol never steals a composition.
+fn kitty_disambiguate_bytes(event: &KeyEvent, options: KeyEncodeOptions) -> Option<Vec<u8>> {
     let mods = &event.modifiers;
     // Kitty modifier value: 1 + bitmask (shift=1, alt=2, ctrl=4, super=8).
     let kmod = 1
@@ -331,6 +354,7 @@ fn kitty_disambiguate_bytes(event: &KeyEvent) -> Option<Vec<u8>> {
             // ctrl/alt + a single printable char (ctrl+letter, alt+key,
             // ctrl+alt+key, shift+alt+key). Plain super+key is a higher level.
             if (mods.control || mods.alt)
+                && !delivered_as_text(event, options)
                 && key.chars().count() == 1
                 && let Some(c) = key.chars().next()
                 && !c.is_control()
@@ -381,33 +405,40 @@ mod tests {
         }
     }
 
-    fn on() -> KittyKeyboardFlags {
-        KittyKeyboardFlags {
-            disambiguate_escape_codes: true,
+    fn on() -> KeyEncodeOptions {
+        KeyEncodeOptions {
+            kitty: KittyKeyboardFlags {
+                disambiguate_escape_codes: true,
+            },
+            ..Default::default()
         }
     }
 
-    fn off() -> KittyKeyboardFlags {
-        KittyKeyboardFlags::default()
+    fn off() -> KeyEncodeOptions {
+        KeyEncodeOptions::default()
+    }
+
+    fn meta() -> KeyEncodeOptions {
+        KeyEncodeOptions {
+            option_as_meta: true,
+            ..Default::default()
+        }
     }
 
     fn legacy(key: &str, key_char: Option<&str>, mods: KeyModifiers) -> Option<Vec<u8>> {
-        key_to_bytes(&ev(key, key_char, mods), false, off())
+        key_to_bytes(&ev(key, key_char, mods), off())
     }
 
     #[test]
     fn flag_off_keeps_legacy_bytes() {
-        let off = KittyKeyboardFlags::default();
+        let off = KeyEncodeOptions::default();
+        assert_eq!(key_to_bytes(&ev("a", None, ctrl()), off), Some(vec![0x01]));
         assert_eq!(
-            key_to_bytes(&ev("a", None, ctrl()), false, off),
-            Some(vec![0x01])
-        );
-        assert_eq!(
-            key_to_bytes(&ev("tab", None, KeyModifiers::default()), false, off),
+            key_to_bytes(&ev("tab", None, KeyModifiers::default()), off),
             Some(b"\t".to_vec())
         );
         assert_eq!(
-            key_to_bytes(&ev("escape", None, KeyModifiers::default()), false, off),
+            key_to_bytes(&ev("escape", None, KeyModifiers::default()), off),
             Some(b"\x1b".to_vec())
         );
     }
@@ -415,11 +446,11 @@ mod tests {
     #[test]
     fn escape_is_disambiguated() {
         assert_eq!(
-            key_to_bytes(&ev("escape", None, KeyModifiers::default()), false, on()),
+            key_to_bytes(&ev("escape", None, KeyModifiers::default()), on()),
             Some(b"\x1b[27u".to_vec())
         );
         assert_eq!(
-            key_to_bytes(&ev("escape", None, ctrl()), false, on()),
+            key_to_bytes(&ev("escape", None, ctrl()), on()),
             Some(b"\x1b[27;5u".to_vec())
         );
     }
@@ -427,11 +458,11 @@ mod tests {
     #[test]
     fn ctrl_letters_are_disambiguated() {
         assert_eq!(
-            key_to_bytes(&ev("i", None, ctrl()), false, on()),
+            key_to_bytes(&ev("i", None, ctrl()), on()),
             Some(b"\x1b[105;5u".to_vec())
         );
         assert_eq!(
-            key_to_bytes(&ev("a", None, ctrl()), false, on()),
+            key_to_bytes(&ev("a", None, ctrl()), on()),
             Some(b"\x1b[97;5u".to_vec())
         );
     }
@@ -439,11 +470,11 @@ mod tests {
     #[test]
     fn tab_disambiguation() {
         assert_eq!(
-            key_to_bytes(&ev("tab", None, shift()), false, on()),
+            key_to_bytes(&ev("tab", None, shift()), on()),
             Some(b"\x1b[9;2u".to_vec())
         );
         assert_eq!(
-            key_to_bytes(&ev("tab", None, KeyModifiers::default()), false, on()),
+            key_to_bytes(&ev("tab", None, KeyModifiers::default()), on()),
             Some(b"\t".to_vec())
         );
     }
@@ -451,11 +482,11 @@ mod tests {
     #[test]
     fn enter_disambiguation() {
         assert_eq!(
-            key_to_bytes(&ev("enter", None, ctrl()), false, on()),
+            key_to_bytes(&ev("enter", None, ctrl()), on()),
             Some(b"\x1b[13;5u".to_vec())
         );
         assert_eq!(
-            key_to_bytes(&ev("enter", None, KeyModifiers::default()), false, on()),
+            key_to_bytes(&ev("enter", None, KeyModifiers::default()), on()),
             Some(b"\r".to_vec())
         );
     }
@@ -463,7 +494,7 @@ mod tests {
     #[test]
     fn ctrl_backspace_is_disambiguated() {
         assert_eq!(
-            key_to_bytes(&ev("backspace", None, ctrl()), false, on()),
+            key_to_bytes(&ev("backspace", None, ctrl()), on()),
             Some(b"\x1b[127;5u".to_vec())
         );
     }
@@ -471,7 +502,7 @@ mod tests {
     #[test]
     fn plain_char_falls_through_to_text() {
         assert_eq!(
-            key_to_bytes(&ev("a", Some("a"), KeyModifiers::default()), false, on()),
+            key_to_bytes(&ev("a", Some("a"), KeyModifiers::default()), on()),
             None
         );
     }
@@ -479,7 +510,7 @@ mod tests {
     #[test]
     fn plain_arrow_is_not_stolen() {
         assert_eq!(
-            key_to_bytes(&ev("up", None, KeyModifiers::default()), false, on()),
+            key_to_bytes(&ev("up", None, KeyModifiers::default()), on()),
             Some(b"\x1b[A".to_vec())
         );
     }
@@ -644,8 +675,137 @@ mod tests {
     #[test]
     fn kitty_disambiguation_still_wins_over_the_legacy_meta_prefix() {
         assert_eq!(
-            key_to_bytes(&ev("b", None, alt()), false, on()),
+            key_to_bytes(&ev("b", None, alt()), on()),
             Some(b"\x1b[98;3u".to_vec())
         );
+    }
+
+    fn ctrl_alt() -> KeyModifiers {
+        KeyModifiers {
+            control: true,
+            alt: true,
+            ..Default::default()
+        }
+    }
+
+    fn encode(
+        key: &str,
+        key_char: Option<&str>,
+        mods: KeyModifiers,
+        options: KeyEncodeOptions,
+    ) -> Option<Vec<u8>> {
+        key_to_bytes(&ev(key, key_char, mods), options)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn kitty_meta() -> KeyEncodeOptions {
+        KeyEncodeOptions {
+            option_as_meta: true,
+            ..on()
+        }
+    }
+
+    /// Windows AltGr arrives as Ctrl+Alt; the kitty path must decline it too,
+    /// or the negotiated protocol swallows every composed character.
+    #[test]
+    fn kitty_leaves_altgr_composition_to_the_text_path() {
+        assert_eq!(encode("q", Some("@"), ctrl_alt(), on()), None);
+    }
+
+    #[test]
+    fn kitty_still_disambiguates_ctrl_alt_that_composes_nothing() {
+        assert_eq!(
+            encode("q", None, ctrl_alt(), on()),
+            Some(b"\x1b[113;7u".to_vec())
+        );
+        assert_eq!(
+            encode("c", Some("\u{3}"), ctrl(), on()),
+            Some(b"\x1b[99;5u".to_vec())
+        );
+    }
+
+    /// Esc/Enter/Tab/Backspace only ever carry a control `key_char`, so the
+    /// text gate must not reach them: their kitty encodings stay unconditional.
+    #[test]
+    fn kitty_control_keys_are_not_gated_by_the_text_path() {
+        assert_eq!(
+            encode("escape", Some("\u{1b}"), KeyModifiers::default(), on()),
+            Some(b"\x1b[27u".to_vec())
+        );
+        assert_eq!(
+            encode("enter", Some("\r"), ctrl(), on()),
+            Some(b"\x1b[13;5u".to_vec())
+        );
+        assert_eq!(
+            encode("tab", Some("\t"), shift(), on()),
+            Some(b"\x1b[9;2u".to_vec())
+        );
+        assert_eq!(
+            encode("backspace", Some("\u{7f}"), ctrl(), on()),
+            Some(b"\x1b[127;5u".to_vec())
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_option_as_meta_encodes_the_composed_key() {
+        assert_eq!(
+            encode("b", Some("\u{222b}"), alt(), meta()),
+            Some(b"\x1bb".to_vec())
+        );
+        assert_eq!(
+            encode("space", Some("\u{a0}"), alt(), meta()),
+            Some(b"\x1b ".to_vec())
+        );
+        assert_eq!(
+            encode("b", Some("\u{222b}"), alt(), kitty_meta()),
+            Some(b"\x1b[98;3u".to_vec())
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_option_as_meta_marks_the_keystroke_as_consumed() {
+        assert!(consumes_composed_text(
+            &ev("b", Some("\u{222b}"), alt()),
+            meta()
+        ));
+        assert!(consumes_composed_text(
+            &ev("b", Some("\u{222b}"), alt()),
+            kitty_meta()
+        ));
+        assert!(!consumes_composed_text(
+            &ev("b", Some("\u{222b}"), alt()),
+            off()
+        ));
+    }
+
+    /// Option-as-Meta is a macOS-only escape hatch; elsewhere Alt is already
+    /// encoded and nothing else commits the keystroke.
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn option_as_meta_changes_nothing_off_macos() {
+        assert_eq!(
+            encode("b", Some("b"), alt(), off()),
+            Some(b"\x1bb".to_vec())
+        );
+        assert_eq!(
+            encode("b", Some("b"), alt(), meta()),
+            Some(b"\x1bb".to_vec())
+        );
+        assert!(!consumes_composed_text(&ev("b", Some("b"), alt()), meta()));
+    }
+
+    #[test]
+    fn nothing_else_is_reported_as_consumed_text() {
+        assert!(!consumes_composed_text(
+            &ev("a", Some("a"), KeyModifiers::default()),
+            meta()
+        ));
+        assert!(!consumes_composed_text(&ev("left", None, alt()), meta()));
+        assert!(!consumes_composed_text(
+            &ev("q", Some("@"), ctrl_alt()),
+            meta()
+        ));
     }
 }

--- a/crates/okena-terminal/src/terminal/io.rs
+++ b/crates/okena-terminal/src/terminal/io.rs
@@ -327,11 +327,13 @@ impl Terminal {
                 ..Default::default()
             },
         };
-        if let Some(bytes) = crate::input::key_to_bytes(
-            &event,
-            self.is_app_cursor_mode(),
-            self.kitty_keyboard_flags(),
-        ) {
+        let options = crate::input::KeyEncodeOptions {
+            app_cursor_mode: self.is_app_cursor_mode(),
+            kitty: self.kitty_keyboard_flags(),
+            // Esc / Tab / Shift+Tab never carry Alt, so Option-as-Meta cannot apply.
+            option_as_meta: false,
+        };
+        if let Some(bytes) = crate::input::key_to_bytes(&event, options) {
             self.send_bytes(&bytes);
         }
     }

--- a/crates/okena-terminal/src/terminal/links.rs
+++ b/crates/okena-terminal/src/terminal/links.rs
@@ -6,6 +6,7 @@ use std::hash::{DefaultHasher, Hasher};
 use std::sync::OnceLock;
 
 use super::Terminal;
+use super::search::GridText;
 use super::types::DetectedLink;
 use super::url_detect::{parse_path_line_col, trim_url_trailing};
 
@@ -17,7 +18,7 @@ use super::url_detect::{parse_path_line_col, trim_url_trailing};
 pub struct UrlScanCache {
     cols: usize,
     /// Text of every visual row as of the last scan; buffers are reused.
-    row_texts: Vec<String>,
+    rows: Vec<GridText>,
     row_wrapline: Vec<bool>,
     row_hashes: Vec<u64>,
     lines: Vec<ScannedLine>,
@@ -49,22 +50,21 @@ impl UrlScanCache {
             self.row_hashes.clear();
             self.lines.clear();
         }
-        self.row_texts.resize_with(screen_lines, String::new);
+        self.rows.resize_with(screen_lines, GridText::default);
         self.row_wrapline.resize(screen_lines, false);
 
         let mut hashes = Vec::with_capacity(screen_lines);
         let mut changed = Vec::with_capacity(screen_lines);
-        for (visual_row, text) in self.row_texts.iter_mut().enumerate() {
+        for (visual_row, text) in self.rows.iter_mut().enumerate() {
             let row = &grid[Line(visual_row as i32 - display_offset)];
-            text.clear();
-            for col in 0..cols {
-                text.push(row[Column(col)].c);
-            }
+            text.rebuild(row, cols);
             let wrapline = row[Column(cols - 1)].flags.contains(Flags::WRAPLINE);
             self.row_wrapline[visual_row] = wrapline;
 
+            // A row's columns follow from its text: a char's cell width is
+            // fixed, so equal text under an unchanged `cols` maps identically.
             let mut hasher = DefaultHasher::new();
-            hasher.write(text.as_bytes());
+            hasher.write(text.text().as_bytes());
             hasher.write_u8(u8::from(wrapline));
             let hash = hasher.finish();
             changed.push(self.row_hashes.get(visual_row) != Some(&hash));
@@ -78,7 +78,7 @@ impl UrlScanCache {
     /// `[start, last_read]` are unchanged, rescans the rest, and renumbers the
     /// wrap groups sequentially so the result matches a full scan.
     fn scan(&mut self, changed: &[bool]) -> Vec<DetectedLink> {
-        let screen_lines = self.row_texts.len();
+        let screen_lines = self.rows.len();
         let mut previous = std::mem::take(&mut self.lines).into_iter().peekable();
         let mut lines = Vec::new();
         let mut phase1 = Vec::new();
@@ -107,7 +107,7 @@ impl UrlScanCache {
                 Some(line) => line,
                 None => {
                     self.recomputed_lines += 1;
-                    scan_logical_line(&self.row_texts, &self.row_wrapline, start, end)
+                    scan_logical_line(&self.rows, &self.row_wrapline, start, end)
                 }
             };
 
@@ -262,20 +262,20 @@ fn url_char(c: char) -> bool {
 
 /// Runs the detection for the logical line at visual rows `start..=end`:
 /// the regex over the joined rows, then the TUI-wrap extension of its URLs.
-fn scan_logical_line(texts: &[String], wrapline: &[bool], start: usize, end: usize) -> ScannedLine {
+fn scan_logical_line(rows: &[GridText], wrapline: &[bool], start: usize, end: usize) -> ScannedLine {
     let regex = link_regex();
-    let screen_lines = texts.len();
+    let screen_lines = rows.len();
     let mut last_read = end;
 
     let mut combined_text = String::new();
-    // (visual_row, offset_in_combined, leading_spaces_stripped)
+    // (visual_row, offset_in_combined, bytes of leading padding stripped)
     let mut row_offsets: Vec<(usize, usize, usize)> = Vec::new();
 
     // Collect wrapped lines into one logical line
-    for (visual_row, row_text) in texts.iter().enumerate().take(end + 1).skip(start) {
+    for (visual_row, row) in rows.iter().enumerate().take(end + 1).skip(start) {
         // Trim trailing spaces — URLs/paths never end with spaces,
         // and this allows the regex to match across padded line breaks.
-        let rtrimmed = row_text.trim_end_matches(' ');
+        let rtrimmed = row.text().trim_end_matches(' ');
 
         // For continuation rows, also strip leading spaces (TUI padding)
         let (text_to_add, leading_stripped) = if combined_text.is_empty() {
@@ -334,9 +334,12 @@ fn scan_logical_line(texts: &[String], wrapline: &[bool], start: usize, end: usi
             let seg_start = match_start.max(row_start_offset);
             let seg_end = trimmed_end.min(row_end_offset);
 
-            let col_start =
-                combined_text[row_start_offset..seg_start].chars().count() + leading_stripped;
-            let len = combined_text[seg_start..seg_end].chars().count();
+            // Back to the row's own bytes: the segment was copied verbatim out
+            // of it, past the padding the join stripped.
+            let row = &rows[phys_row];
+            let byte_in_row = |offset: usize| offset - row_start_offset + leading_stripped;
+            let col_start = row.col_at_byte(byte_in_row(seg_start));
+            let len = row.col_at_byte(byte_in_row(seg_end)) - col_start;
 
             if len > 0 {
                 phase1.push(DetectedLink {
@@ -410,13 +413,13 @@ fn scan_logical_line(texts: &[String], wrapline: &[bool], start: usize, end: usi
             continue;
         }
 
-        let match_rtrimmed = texts[m_row].trim_end();
+        let match_rtrimmed = rows[m_row].text().trim_end();
 
         // A mid-token wrap runs the URL into the layout edge, so the
         // URL is the last thing on its row.  Anything after it — a
         // dash, a bracket, prose — means the row had room left and the
         // break was a word break, not a wrap.
-        if match_rtrimmed.chars().count() != m_col + m_len {
+        if rows[m_row].col_at_byte(match_rtrimmed.len()) != m_col + m_len {
             idx = next_idx;
             continue;
         }
@@ -433,7 +436,8 @@ fn scan_logical_line(texts: &[String], wrapline: &[bool], start: usize, end: usi
             }
             last_read = last_read.max(next_row);
 
-            let next_rtrimmed = texts[next_row].trim_end();
+            let next_row_text = &rows[next_row];
+            let next_rtrimmed = next_row_text.text().trim_end();
 
             // A mid-token wrap fills the row to the layout edge, so a
             // continuation can never be wider than the row it
@@ -441,13 +445,14 @@ fn scan_logical_line(texts: &[String], wrapline: &[bool], start: usize, end: usi
             // break — the URL ended on its own line.  No slack: the
             // edge is exact, and slack is what let a 3-column-longer
             // continuation through.
-            if next_rtrimmed.chars().count() > url_end_col {
+            if next_row_text.col_at_byte(next_rtrimmed.len()) > url_end_col {
                 break;
             }
 
             // Strip leading whitespace (TUI indentation).
             let content = next_rtrimmed.trim_start_matches(' ');
-            let indent = next_rtrimmed.len() - content.len();
+            let indent_bytes = next_rtrimmed.len() - content.len();
+            let indent = next_row_text.col_at_byte(indent_bytes);
 
             if content.is_empty() {
                 break;
@@ -488,15 +493,18 @@ fn scan_logical_line(texts: &[String], wrapline: &[bool], start: usize, end: usi
                 break;
             }
 
-            // Take URL-compatible chars as extension.
-            let ext_char_len = content.chars().take_while(|c| url_char(*c)).count();
-            if ext_char_len == 0 {
+            // Take URL-compatible cells as extension; a cell's zero-width
+            // marks ride along with the base char they stand on.
+            let mut ext_byte_len = 0;
+            for (offset, c) in content.char_indices() {
+                if next_row_text.starts_cell(indent_bytes + offset) && !url_char(c) {
+                    break;
+                }
+                ext_byte_len = offset + c.len_utf8();
+            }
+            if ext_byte_len == 0 {
                 break;
             }
-            let ext_byte_len = content
-                .char_indices()
-                .nth(ext_char_len)
-                .map_or(content.len(), |(b, _)| b);
             let ext_raw = &content[..ext_byte_len];
 
             // Trim the FULL combined URL, not just the fragment,
@@ -542,13 +550,14 @@ fn scan_logical_line(texts: &[String], wrapline: &[bool], start: usize, end: usi
 
             // Commit extension.
             let ext_trimmed_len = ext_trimmed.len();
-            let ext_trimmed_chars = ext_trimmed.chars().count();
+            let ext_trimmed_cols =
+                next_row_text.col_at_byte(indent_bytes + ext_trimmed_len) - indent;
             extended_url.push_str(ext_trimmed);
 
             phase2.push(DetectedLink {
                 line: next_row as i32,
                 col: indent,
-                len: ext_trimmed_chars,
+                len: ext_trimmed_cols,
                 text: String::new(), // updated below
                 file_line: None,
                 file_col: None,
@@ -568,7 +577,7 @@ fn scan_logical_line(texts: &[String], wrapline: &[bool], start: usize, end: usi
                 break;
             }
 
-            url_end_col = indent + ext_char_len;
+            url_end_col = next_row_text.col_at_byte(indent_bytes + ext_byte_len);
             current_row = next_row;
         }
 
@@ -776,6 +785,44 @@ mod tests {
                 cell_height: 16.0,
             }),
         }
+    }
+
+    fn detected(text: &str, cols: u16) -> Vec<super::DetectedLink> {
+        let terminal = Terminal::new(
+            "links".into(),
+            TerminalSize {
+                cols,
+                rows: 3,
+                cell_width: 8.0,
+                cell_height: 16.0,
+            },
+            Arc::new(NullTransport),
+            "/tmp".into(),
+        );
+        terminal.process_output(text.as_bytes());
+        terminal.detect_urls()
+    }
+
+    #[test]
+    fn a_url_carrying_a_combining_mark_keeps_it_and_its_columns() {
+        let links = detected("see https://example.com/cafe\u{0301}x rest", 60);
+
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].text, "https://example.com/cafe\u{0301}x");
+        assert_eq!(
+            (links[0].col, links[0].len),
+            (4, 25),
+            "the mark rides on its base cell and takes no column"
+        );
+    }
+
+    #[test]
+    fn a_wide_char_before_a_path_shifts_it_by_both_of_its_columns() {
+        let links = detected("\u{65e5}\u{672c} /usr/bin/x", 40);
+
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].text, "/usr/bin/x");
+        assert_eq!((links[0].col, links[0].len), (5, 10));
     }
 
     #[test]

--- a/crates/okena-terminal/src/terminal/search.rs
+++ b/crates/okena-terminal/src/terminal/search.rs
@@ -1,12 +1,79 @@
-use alacritty_terminal::grid::Dimensions;
-use alacritty_terminal::index::{Column, Line, Point};
+use alacritty_terminal::grid::{Dimensions, Row};
+use alacritty_terminal::index::{Column, Line};
+use alacritty_terminal::term::cell::{Cell, Flags};
 use regex::Regex;
 
 use super::Terminal;
 
+/// A grid row as searchable text, carrying the column every byte of it sits in.
+/// A cell contributes its base char then its zero-width marks, and a wide char's
+/// spacer contributes nothing — so a byte offset out of a regex or a substring
+/// search converts back to the exact column the match starts and ends at.
+#[derive(Default)]
+pub(super) struct GridText {
+    text: String,
+    /// One entry per byte of `text`; anything at or past its end is `width`.
+    col_by_byte: Vec<usize>,
+    width: usize,
+}
+
+impl GridText {
+    /// Refills from `row`, reusing the buffers.
+    pub(super) fn rebuild(&mut self, row: &Row<Cell>, cols: usize) {
+        self.text.clear();
+        self.col_by_byte.clear();
+        self.width = cols;
+        for col in 0..cols {
+            let cell = &row[Column(col)];
+            // The spacer's column belongs to the wide char standing over it.
+            if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                continue;
+            }
+            self.text.push(cell.c);
+            for mark in cell.zerowidth().unwrap_or_default() {
+                self.text.push(*mark);
+            }
+            self.col_by_byte.resize(self.text.len(), col);
+        }
+    }
+
+    pub(super) fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// The column of the cell `byte` belongs to. The end of the text answers
+    /// with the row width, so `col_at_byte(end) - col_at_byte(start)` is the
+    /// column span of `start..end` whatever those bytes hold.
+    pub(super) fn col_at_byte(&self, byte: usize) -> usize {
+        self.col_by_byte.get(byte).copied().unwrap_or(self.width)
+    }
+
+    /// Whether `byte` opens a cell — false inside a char and for its marks.
+    pub(super) fn starts_cell(&self, byte: usize) -> bool {
+        match byte.checked_sub(1) {
+            None => !self.text.is_empty(),
+            Some(previous) => self.col_by_byte.get(byte) != self.col_by_byte.get(previous),
+        }
+    }
+
+    /// Refills from `source` lowercased char by char, each keeping its column.
+    /// Lowercasing the built string instead would move byte offsets off their
+    /// columns, because a lowercased char need not keep its byte length.
+    pub(super) fn lowercase_from(&mut self, source: &GridText) {
+        self.text.clear();
+        self.col_by_byte.clear();
+        self.width = source.width;
+        for (byte, c) in source.text.char_indices() {
+            let col = source.col_at_byte(byte);
+            self.text.extend(c.to_lowercase());
+            self.col_by_byte.resize(self.text.len(), col);
+        }
+    }
+}
+
 impl Terminal {
     /// Search the terminal grid for occurrences of a query string
-    /// Returns a list of (line, col, length) for each match
+    /// Returns a list of (line, col, column span) for each match
     /// Supports case-sensitive and regex search, and searches through scrollback buffer
     pub fn search_grid(
         &self,
@@ -33,6 +100,14 @@ impl Terminal {
             None
         };
 
+        // Char by char, the rule `GridText::lowercase_from` uses on the screen:
+        // `str::to_lowercase` would also apply Greek final-sigma context.
+        let needle: String = if case_sensitive {
+            query.to_string()
+        } else {
+            query.chars().flat_map(char::to_lowercase).collect()
+        };
+
         let mut matches = Vec::new();
 
         self.with_content(|term| {
@@ -40,70 +115,131 @@ impl Terminal {
             let screen_lines = grid.screen_lines() as i32;
             let history_size = grid.history_size() as i32;
             let cols = grid.columns();
-            let _display_offset = grid.display_offset() as i32;
+
+            let mut row_text = GridText::default();
+            let mut lowered = GridText::default();
 
             // Search from top of history to bottom of screen
             // Line numbers: negative = history, 0..screen_lines = visible
-            // We iterate from -(history_size) to (screen_lines - 1)
-            for row in (-history_size)..screen_lines {
-                // Calculate the actual line index for grid access
-                // The grid uses Line() which handles the offset automatically
-                let line = row;
-
-                // Build the line text
-                let mut line_text = String::with_capacity(cols);
-                for col in 0..cols {
-                    let cell_point = Point::new(Line(line), Column(col));
-                    let cell = &grid[cell_point];
-                    line_text.push(cell.c);
-                }
-
-                // Build byte-to-column mapping for converting byte offsets to grid columns.
-                // Each char in line_text corresponds to exactly one grid column.
-                let total_chars = line_text.chars().count();
-
-                // Convert a byte offset to a column index
-                let col_at_byte = |byte_offset: usize| -> usize {
-                    line_text
-                        .char_indices()
-                        .enumerate()
-                        .find(|(_, (b, _))| *b == byte_offset)
-                        .map(|(col, _)| col)
-                        .unwrap_or(total_chars)
-                };
+            for line in (-history_size)..screen_lines {
+                row_text.rebuild(&grid[Line(line)], cols);
 
                 if let Some(ref regex) = regex {
-                    // Regex search
-                    for mat in regex.find_iter(&line_text) {
-                        let col = col_at_byte(mat.start());
-                        let end_col = col_at_byte(mat.end());
+                    for mat in regex.find_iter(row_text.text()) {
+                        let col = row_text.col_at_byte(mat.start());
                         // Store absolute grid line (not display-relative)
-                        matches.push((line, col, end_col - col));
+                        matches.push((line, col, row_text.col_at_byte(mat.end()) - col));
                     }
                 } else {
-                    // Plain text search
-                    let (search_text, query_text) = if case_sensitive {
-                        (line_text.clone(), query.to_string())
+                    let haystack = if case_sensitive {
+                        &row_text
                     } else {
-                        (line_text.to_lowercase(), query.to_lowercase())
+                        lowered.lowercase_from(&row_text);
+                        &lowered
                     };
 
-                    let query_char_len = query.chars().count();
-                    let mut search_start = 0;
-                    while let Some(pos) = search_text[search_start..].find(&query_text) {
-                        let byte_pos = search_start + pos;
-                        let col = col_at_byte(byte_pos);
-                        // Store absolute grid line (not display-relative)
-                        matches.push((line, col, query_char_len));
-                        search_start = byte_pos + query_text.len();
-                        if search_start >= search_text.len() {
-                            break;
-                        }
+                    let mut from = 0;
+                    while let Some(offset) = haystack.text()[from..].find(&needle) {
+                        let start = from + offset;
+                        let end = start + needle.len();
+                        let col = haystack.col_at_byte(start);
+                        matches.push((line, col, haystack.col_at_byte(end) - col));
+                        from = end;
                     }
                 }
             }
         });
 
         matches
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Terminal;
+    use super::super::tests::NullTransport;
+    use super::super::types::TerminalSize;
+    use std::sync::Arc;
+
+    fn terminal_showing(text: &str) -> Terminal {
+        let terminal = Terminal::new(
+            "search".into(),
+            TerminalSize {
+                cols: 20,
+                rows: 3,
+                cell_width: 8.0,
+                cell_height: 16.0,
+            },
+            Arc::new(NullTransport),
+            "/tmp".into(),
+        );
+        terminal.process_output(text.as_bytes());
+        terminal
+    }
+
+    #[test]
+    fn plain_ascii_search_reports_every_occurrence_and_its_columns() {
+        let terminal = terminal_showing("ab cab\r\nxx ab");
+
+        assert_eq!(
+            terminal.search_grid("ab", true, false),
+            vec![(0, 0, 2), (0, 4, 2), (1, 3, 2)]
+        );
+        assert_eq!(terminal.search_grid("AB", true, false), Vec::new());
+        assert_eq!(
+            terminal.search_grid("AB", false, false),
+            vec![(0, 0, 2), (0, 4, 2), (1, 3, 2)]
+        );
+        assert_eq!(terminal.search_grid("c.b", true, true), vec![(0, 3, 3)]);
+    }
+
+    #[test]
+    fn a_decomposed_grapheme_is_found_at_the_column_it_paints_on() {
+        let terminal = terminal_showing("abe\u{0301}f");
+
+        assert_eq!(terminal.search_grid("e\u{0301}", true, false), vec![(0, 2, 1)]);
+        assert_eq!(
+            terminal.search_grid("e\u{0301}f", true, false),
+            vec![(0, 2, 2)],
+            "the mark must not consume a column of its own"
+        );
+        assert_eq!(
+            terminal.search_grid("f", true, false),
+            vec![(0, 3, 1)],
+            "the cell after the mark keeps its column"
+        );
+    }
+
+    #[test]
+    fn a_wide_char_owns_both_of_its_columns() {
+        let terminal = terminal_showing("\u{65e5}\u{672c}x");
+
+        assert_eq!(
+            terminal.search_grid("\u{672c}", true, false),
+            vec![(0, 2, 2)],
+            "a wide char starts at its own column and spans two"
+        );
+        assert_eq!(
+            terminal.search_grid("\u{65e5}\u{672c}", true, false),
+            vec![(0, 0, 4)],
+            "the spacer cell must not break the two wide chars apart"
+        );
+        assert_eq!(terminal.search_grid("x", true, false), vec![(0, 4, 1)]);
+    }
+
+    #[test]
+    fn a_case_insensitive_match_keeps_its_column_when_lowercasing_grows_the_text() {
+        // 'İ' lowercases to two chars, so a lowercased line's byte offsets no
+        // longer land on the original's char boundaries.
+        let terminal = terminal_showing("\u{0130}x");
+
+        assert_eq!(terminal.search_grid("X", false, false), vec![(0, 1, 1)]);
+    }
+
+    #[test]
+    fn a_match_in_the_scrollback_reports_a_negative_line() {
+        let terminal = terminal_showing("needle\r\n\r\n\r\n\r\nlast");
+
+        assert_eq!(terminal.search_grid("needle", true, false), vec![(-2, 0, 6)]);
     }
 }

--- a/crates/okena-terminal/src/terminal/tests/kitty.rs
+++ b/crates/okena-terminal/src/terminal/tests/kitty.rs
@@ -9,8 +9,15 @@
 use super::super::Terminal;
 use super::super::types::TerminalSize;
 use super::{CapturingTransport, NullTransport};
-use crate::input::{KeyEvent, KeyModifiers, key_to_bytes};
+use crate::input::{KeyEncodeOptions, KeyEvent, KeyModifiers, key_to_bytes};
 use std::sync::Arc;
+
+fn encode_options(t: &Terminal) -> KeyEncodeOptions {
+    KeyEncodeOptions {
+        kitty: t.kitty_keyboard_flags(),
+        ..Default::default()
+    }
+}
 
 fn term() -> Terminal {
     Terminal::new(
@@ -55,14 +62,14 @@ fn escape_encodes_as_csi_u_only_after_push() {
 
     // Before the app enables the protocol: legacy bare ESC.
     assert_eq!(
-        key_to_bytes(&esc, false, t.kitty_keyboard_flags()),
+        key_to_bytes(&esc, encode_options(&t)),
         Some(b"\x1b".to_vec())
     );
 
     // After `CSI > 1 u`: the encoder reads the live flag and emits `CSI 27 u`.
     t.process_output(b"\x1b[>1u");
     assert_eq!(
-        key_to_bytes(&esc, false, t.kitty_keyboard_flags()),
+        key_to_bytes(&esc, encode_options(&t)),
         Some(b"\x1b[27u".to_vec())
     );
 }

--- a/crates/okena-tui/src/main.rs
+++ b/crates/okena-tui/src/main.rs
@@ -19,7 +19,7 @@ use crossterm::{
     terminal::{self, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use okena_core::api::{ApiLayoutNode, ApiProject, StateResponse};
-use okena_terminal::input::{KeyEvent, KeyModifiers, key_to_bytes};
+use okena_terminal::input::{KeyEncodeOptions, KeyEvent, KeyModifiers, key_to_bytes};
 use okena_terminal::terminal::{Terminal, TerminalSize, TerminalTransport};
 use okena_transport::client::{
     ConnectionEvent, ConnectionHandler, ConnectionStatus, LocalEndpoint,
@@ -618,8 +618,12 @@ fn key_bytes(terminal: &Terminal, key: CrosstermKeyEvent) -> Option<Vec<u8>> {
 
     key_to_bytes(
         &event,
-        terminal.is_app_cursor_mode(),
-        terminal.kitty_keyboard_flags(),
+        KeyEncodeOptions {
+            app_cursor_mode: terminal.is_app_cursor_mode(),
+            kitty: terminal.kitty_keyboard_flags(),
+            // crossterm never reports a composed character, so Meta is already the encoding.
+            option_as_meta: false,
+        },
     )
 }
 

--- a/crates/okena-views-terminal/src/layout/terminal_pane/navigation.rs
+++ b/crates/okena-views-terminal/src/layout/terminal_pane/navigation.rs
@@ -3,7 +3,9 @@
 use crate::ActionDispatch;
 use crate::layout::navigation::{NavigationDirection, PaneBounds, get_pane_map};
 use gpui::*;
-use okena_terminal::input::{KeyEvent, KeyModifiers, key_to_bytes};
+use okena_terminal::input::{
+    KeyEncodeOptions, KeyEvent, KeyModifiers, consumes_composed_text, key_to_bytes,
+};
 use okena_workspace::state::LayoutNode;
 
 use super::TerminalPane;
@@ -223,8 +225,11 @@ impl<D: ActionDispatch + Send + Sync> TerminalPane<D> {
                 return;
             }
 
-            let app_cursor_mode = terminal.is_app_cursor_mode();
-            let kitty = terminal.kitty_keyboard_flags();
+            let options = KeyEncodeOptions {
+                app_cursor_mode: terminal.is_app_cursor_mode(),
+                kitty: terminal.kitty_keyboard_flags(),
+                option_as_meta: crate::terminal_view_settings(cx).option_as_meta,
+            };
             let key_event = KeyEvent {
                 key: event.keystroke.key.clone(),
                 key_char: event.keystroke.key_char.clone(),
@@ -235,8 +240,13 @@ impl<D: ActionDispatch + Send + Sync> TerminalPane<D> {
                     platform: event.keystroke.modifiers.platform,
                 },
             };
-            if let Some(input) = key_to_bytes(&key_event, app_cursor_mode, kitty) {
+            if let Some(input) = key_to_bytes(&key_event, options) {
                 terminal.send_bytes(&input);
+                // GPUI keeps forwarding to the input context, which would commit
+                // the character macOS composed on top of the meta sequence.
+                if consumes_composed_text(&key_event, options) {
+                    cx.stop_propagation();
+                }
             }
         }
     }

--- a/crates/okena-views-terminal/src/lib.rs
+++ b/crates/okena-views-terminal/src/lib.rs
@@ -141,6 +141,10 @@ pub struct TerminalViewSettings {
     /// here instead of reaching a mouse-reporting app.
     #[serde(default)]
     pub double_click_selects_in_mouse_mode: bool,
+    /// macOS only: Option+key sends the Meta escape prefix instead of the
+    /// character the layout composes.
+    #[serde(default)]
+    pub option_as_meta: bool,
 }
 
 pub(crate) fn default_true() -> bool {
@@ -171,6 +175,7 @@ pub fn terminal_view_settings(cx: &gpui::App) -> TerminalViewSettings {
             right_click_opens_menu: true,
             drag_selects_in_mouse_mode: false,
             double_click_selects_in_mouse_mode: false,
+            option_as_meta: false,
         })
 }
 

--- a/crates/okena-views-terminal/src/overlays/detached_terminal.rs
+++ b/crates/okena-views-terminal/src/overlays/detached_terminal.rs
@@ -102,9 +102,9 @@ impl DetachedTerminalView {
         }
     }
 
-    fn handle_key(&mut self, event: &KeyDownEvent, _cx: &mut Context<Self>) {
+    fn handle_key(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) {
         // Forward keys to terminal
-        handle_terminal_key_input(&self.terminal, event);
+        handle_terminal_key_input(&self.terminal, event, cx);
     }
 
     fn handle_reattach(&mut self, cx: &mut Context<Self>) {

--- a/crates/okena-views-terminal/src/overlays/terminal_overlay_utils.rs
+++ b/crates/okena-views-terminal/src/overlays/terminal_overlay_utils.rs
@@ -9,19 +9,17 @@
 use crate::layout::terminal_pane::TerminalContent;
 use gpui::*;
 use okena_terminal::TerminalsRegistry;
-use okena_terminal::input::{KeyEvent, KeyModifiers, KittyKeyboardFlags, key_to_bytes};
+use okena_terminal::input::{
+    KeyEncodeOptions, KeyEvent, KeyModifiers, consumes_composed_text, key_to_bytes,
+};
 use okena_terminal::terminal::{Terminal, TerminalSize, TerminalTransport};
 use okena_workspace::request_broker::RequestBroker;
 use okena_workspace::state::Workspace;
 use std::sync::Arc;
 
-/// Convert a GPUI key event to terminal input bytes.
-fn gpui_key_to_bytes(
-    event: &KeyDownEvent,
-    app_cursor_mode: bool,
-    kitty: KittyKeyboardFlags,
-) -> Option<Vec<u8>> {
-    let key_event = KeyEvent {
+/// Convert a GPUI key event to the encoder's framework-agnostic representation.
+fn to_key_event(event: &KeyDownEvent) -> KeyEvent {
+    KeyEvent {
         key: event.keystroke.key.clone(),
         key_char: event.keystroke.key_char.clone(),
         modifiers: KeyModifiers {
@@ -30,8 +28,7 @@ fn gpui_key_to_bytes(
             alt: event.keystroke.modifiers.alt,
             platform: event.keystroke.modifiers.platform,
         },
-    };
-    key_to_bytes(&key_event, app_cursor_mode, kitty)
+    }
 }
 
 /// Default terminal size for overlay terminals.
@@ -101,15 +98,27 @@ pub fn create_terminal_content<V: 'static>(
 ///
 /// Converts the key event to terminal bytes and sends them to the terminal.
 /// Returns true if input was sent.
-pub fn handle_terminal_key_input(terminal: &Terminal, event: &KeyDownEvent) -> bool {
-    let app_cursor_mode = terminal.is_app_cursor_mode();
-    let kitty = terminal.kitty_keyboard_flags();
-    if let Some(input) = gpui_key_to_bytes(event, app_cursor_mode, kitty) {
-        terminal.send_bytes(&input);
-        true
-    } else {
-        false
+pub fn handle_terminal_key_input<V: 'static>(
+    terminal: &Terminal,
+    event: &KeyDownEvent,
+    cx: &mut Context<V>,
+) -> bool {
+    let options = KeyEncodeOptions {
+        app_cursor_mode: terminal.is_app_cursor_mode(),
+        kitty: terminal.kitty_keyboard_flags(),
+        option_as_meta: crate::terminal_view_settings(cx).option_as_meta,
+    };
+    let key_event = to_key_event(event);
+    let Some(input) = key_to_bytes(&key_event, options) else {
+        return false;
+    };
+    terminal.send_bytes(&input);
+    // GPUI keeps forwarding to the input context, which would commit the
+    // character macOS composed on top of the meta sequence.
+    if consumes_composed_text(&key_event, options) {
+        cx.stop_propagation();
     }
+    true
 }
 
 /// Handle pending focus for a terminal view.

--- a/crates/okena-workspace/src/settings.rs
+++ b/crates/okena-workspace/src/settings.rs
@@ -413,6 +413,13 @@ pub struct AppSettings {
     #[serde(default)]
     pub terminal_double_click_selects_in_mouse_mode: bool,
 
+    /// macOS only: when true, Option+key sends the Meta escape prefix instead of
+    /// composing a character (Option+B is `∫`). Ignored elsewhere, where Alt
+    /// already encodes Meta.
+    /// Default: false (matches Terminal.app / iTerm2).
+    #[serde(default)]
+    pub terminal_option_as_meta: bool,
+
     /// File finder filter preferences. The "Go to File" dialog reads these
     /// when opened and writes them back when the user toggles a filter, so
     /// the last-used state is also the default for future opens.
@@ -489,6 +496,7 @@ impl Default for AppSettings {
             terminal_right_click_opens_menu: true,
             terminal_drag_selects_in_mouse_mode: false,
             terminal_double_click_selects_in_mouse_mode: false,
+            terminal_option_as_meta: false,
             file_finder: FileFinderSettings::default(),
             header_density: HeaderDensity::default(),
             notifications: NotificationSettings::default(),
@@ -1052,6 +1060,15 @@ mod tests {
         let loaded: AppSettings =
             serde_json::from_str(r#"{"auto_hide_single_terminal_header":true}"#).unwrap();
         assert!(loaded.auto_hide_single_terminal_header);
+    }
+
+    #[test]
+    fn option_as_meta_is_opt_in() {
+        assert!(!AppSettings::default().terminal_option_as_meta);
+
+        let loaded: AppSettings =
+            serde_json::from_str(r#"{"terminal_option_as_meta":true}"#).unwrap();
+        assert!(loaded.terminal_option_as_meta);
     }
 
     #[test]

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -98,6 +98,7 @@ If the file contains invalid JSON, Okena recovers as many fields as possible and
 | `show_shell_selector` | bool | `false` | Show shell picker in the terminal header |
 | `auto_hide_single_terminal_header` | bool | `false` | Hide the 28px terminal header for standalone terminals. Its actions remain available from the owning project's focused-terminal menu. Multi-tab headers remain visible. |
 | `idle_timeout_secs` | int | `0` | Seconds before a terminal is considered idle (0 = disabled) |
+| `terminal_option_as_meta` | bool | `false` | macOS only: Option+key sends the Meta escape prefix (`ESC` + character) instead of composing a character (Option+B is `∫`). No effect on Linux/Windows, where Alt already encodes Meta. |
 
 #### Session Backend
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -556,6 +556,7 @@ fn main() {
                             double_click_selects_in_mouse_mode: s
                                 .settings
                                 .terminal_double_click_selects_in_mouse_mode,
+                            option_as_meta: s.settings.terminal_option_as_meta,
                         }).ok()
                     }
                     "git" => {
@@ -596,6 +597,7 @@ fn main() {
                                 state.settings.terminal_right_click_opens_menu = tvs.right_click_opens_menu;
                                 state.settings.terminal_drag_selects_in_mouse_mode = tvs.drag_selects_in_mouse_mode;
                                 state.settings.terminal_double_click_selects_in_mouse_mode = tvs.double_click_selects_in_mouse_mode;
+                                state.settings.terminal_option_as_meta = tvs.option_as_meta;
                                 state.save_and_notify(cx);
                             });
                         }

--- a/src/smoke_tests.rs
+++ b/src/smoke_tests.rs
@@ -66,6 +66,7 @@ mod tests {
                                 double_click_selects_in_mouse_mode: s
                                     .settings
                                     .terminal_double_click_selects_in_mouse_mode,
+                                option_as_meta: s.settings.terminal_option_as_meta,
                             })
                             .ok()
                         }


### PR DESCRIPTION
Stacks on #204. Clears the four findings that PR opened but did not fix — all four were discovered while fixing the review's list, not by the review itself.

## What is fixed

**Composed characters are no longer stolen.** `kitty_disambiguate_bytes` had a catch-all arm for any ctrl-or-alt plus a printable character. Windows delivers AltGr as Ctrl+Alt, so on a Czech or German layout `AltGr+Q` emitted `CSI 113;7u` instead of `@` whenever an app negotiated the kitty protocol. The legacy path already encodes this rule in `delivered_as_text`; the kitty arm now calls the same function instead of carrying a second copy.

The other kitty arms are deliberately left ungated. `delivered_as_text` needs a non-empty `key_char` with no control characters, and Esc/Enter/Tab/Backspace report either `None` or the control character they are — so the gate could never fire there, and none of them is a composition target on any layout. A test pins it.

**macOS Option as Meta.** Previously impossible: encoding it would double-send, because the composed character (`Option+B` → `∫`) is committed by the input context after our handler runs. It is now a setting, off by default like Terminal.app and iTerm2, and when on, `handle_key` stops propagation for exactly those keystrokes — never blanket.

**Search and link columns are mapped, not counted.** Both built their haystack by pushing `cell.c` once per column and recovered the column by counting characters. That identity is why #204 left combining marks out of them — adding the marks would have shifted every highlight onto the wrong cell. An explicit byte-to-column map replaces the counting, and three defects the same identity was already causing fall out with it:

- **Wide characters never matched at all.** `日本` was flattened to `日 本 ` because the spacer cell became a literal space. The spacer is now skipped and the base owns both its columns.
- A match boundary inside a multi-byte character fell back to the end of the line.
- Case-insensitive search fed offsets from a lowercased haystack to a map built over the original, so any character whose lowercase changes byte length (`İ` → `i̇`) put the highlight in the wrong place.

Highlight width was always consumed as a column count while plain search returned a character count. Now one thing.

**CLI and mobile cell readers keep their marks.** A decomposed accent vanished from `okena` screen reads and from the mobile client.

## Not done, and why

- **The packed mobile encoder still drops marks.** It is a fixed 13 bytes per cell with a bare `u32` codepoint and no length prefix, and that is the path React Native actually renders. Carrying marks needs a wire-format change, so the truncation is documented rather than changed. The renderer itself draws concatenated text, not per-glyph, so marks would render correctly once they reach it.
- **Unicode normalisation.** Searching a precomposed `é` against decomposed screen text still misses. Folding the haystack breaks the byte-to-column map by construction and needs a second map plus a new dependency; it belongs on top of this change, not inside it.

## Verification

`cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace` green across three full runs. Every new non-ASCII assertion was checked against the parent commit and fails there.

macOS logic is unit-tested by compiling its branches on Linux (27 tests). **What a macOS user still has to confirm** is the load-bearing assumption: that stopping propagation actually prevents the input context from committing the composed character. If it does not, turning the setting on yields both `\x1bb` and `∫`. The setting is off by default, so nobody is exposed without opting in.

One unrelated flake was seen once during a loaded run — `okena-ext-updater`'s `successful_validation_keeps_the_new_binary`, which spawns a probe under a 10s timeout. It did not reproduce in three further full-workspace runs or five targeted ones, and nothing here touches that crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSZhvCKhHXrWBAqLjCfTSr